### PR TITLE
Make kamel.sh more robust

### DIFF
--- a/kamel.sh
+++ b/kamel.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-./KiLCA/kilca.sh
-./KIM/kim.sh
-cd QL-Balance
-./ql-balance.sh
+
+OLD_DIR=$(pwd)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+./KiLCA/kilca.sh || exit $?
+./KIM/kim.sh || exit $?
+./QL-Balance/ql-balance.sh || exit $?
+cd $OLD_DIR


### PR DESCRIPTION
If the script gets executed from some directory other than the root dir of the repo assumptions about the current path are wrong. This needs to be corrected.