### PR TITLE
feat: enhance kernel calculations in FLR2 asymptotics module

### DIFF
--- a/KIM/src/asymptotics/FLR2_asymptotics.f90
+++ b/KIM/src/asymptotics/FLR2_asymptotics.f90
@@ -158,8 +158,9 @@ module flr2_asymptotics_m
 
         type(plasma_t), intent(in) :: plasma_in
         integer :: j, sp, i
-        complex(dp), allocatable :: kernel(:)
-        complex(dp) :: kernel_temp
+        complex(dp), allocatable :: kernel_phi(:)
+        complex(dp), allocatable :: kernel_B(:)
+        complex(dp) :: kernel_phi_temp
         real(dp) :: b
         real(dp) :: ks
         real(dp) :: kr
@@ -167,17 +168,19 @@ module flr2_asymptotics_m
         character(256) :: filename
 
         complex(dp) :: besselI ! complex bessel function from bessel.f90
-        allocate(kernel(rg_grid%npts_b))
+        allocate(kernel_phi(rg_grid%npts_b))
+        allocate(kernel_B(rg_grid%npts_b))
 
         kr_arr = [1.0d0, 5.0d0, 10.0d0]
 
         do i = 1, size(kr_arr)
             kr = kr_arr(i)
             print *, "Calculating hatK_Phi for kr = ", kr
-            kernel = 0.0d0
+            kernel_phi = 0.0d0
+            kernel_B = 0.0d0
             
             do j = 1, size(rg_grid%xb)
-                kernel_temp = 0.0d0
+                kernel_phi_temp = 0.0d0
                 do sp = 0, plasma_in%n_species-1
                     if (turn_off_ions .and. sp >= 1) cycle
                     if (turn_off_electrons .and. sp == 0) cycle
@@ -188,11 +191,11 @@ module flr2_asymptotics_m
                     b = kr**2.0d0 * plasma_in%spec(sp)%rho_L(j)**2.0d0
 
                     if (artificial_debye_case <= 1) then
-                        kernel_temp = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0
+                        kernel_phi_temp = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0
                     end if
 
                     if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
-                        kernel_temp = kernel_temp + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * plasma_in%ks(j) &
+                        kernel_phi_temp = kernel_phi_temp + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * plasma_in%ks(j) &
                             / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-b) * &
                             (&
                                 plasma_in%spec(sp)%I00(j) * (&
@@ -201,18 +204,30 @@ module flr2_asymptotics_m
                                 )&
                                 + 0.5d0 * plasma_in%spec(sp)%I20(j) * plasma_in%spec(sp)%A2(j) * gsl_sf_bessel_In(0, b) &
                             )
+                        kernel_B(j) = kernel_B(j) - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
+                            / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-b) * &
+                            (&
+                                plasma_in%spec(sp)%I01(j) * (&
+                                    gsl_sf_bessel_In(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
+                                    + 0.5d0 * plasma_in%spec(sp)%A2(j) * b * gsl_sf_bessel_In(-1, b) &
+                                )&
+                                + 0.5d0 * plasma_in%spec(sp)%I21(j) * plasma_in%spec(sp)%A2(j) * gsl_sf_bessel_In(0, b) &
+                            )
                     end if
 
-                    kernel(j) = kernel(j) + kernel_temp
+                    kernel_phi(j) = kernel_phi(j) + kernel_phi_temp
                 end do
-                ! kernel = kernel * exp(com_unit * kr * rg_grid%xb(j))
             end do
 
-            kernel = 1.0d0 / (4.0d0 * pi) * kernel
-            write(filename, '(A,I5,A)') trim(output_path)//"/fields/hatK_Phi_kr", int(kr), ".dat"
-            call write_complex_profile_abs(rg_grid%xb, kernel, rg_grid%npts_b, filename)
-        end do
+            kernel_phi = kernel_phi / (4.0d0 * pi)
+            kernel_B = kernel_B / (4.0d0 * pi)
 
+            write(filename, '(A,I0,A)') trim(output_path)//"/fields/hatK_Phi_kr", int(kr), ".dat"
+            call write_complex_profile_abs(rg_grid%xb, kernel_phi, rg_grid%npts_b, filename)
+            write(filename, '(A,I0,A)') trim(output_path)//"/fields/hatK_B_kr", int(kr), ".dat"
+            call write_complex_profile_abs(rg_grid%xb, kernel_B, rg_grid%npts_b, filename)
+
+        end do
 
     end subroutine
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add magnetic field kernel (`kernel_B`) calculations alongside existing electric potential kernel

- Refactor variable names for clarity (`kernel` → `kernel_phi`, `kernel_temp` → `kernel_phi_temp`)

- Output both electric and magnetic kernel profiles to separate files

- Improve file naming format using `I0` specifier


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Electric Kernel Only"] --> B["Dual Kernel Calculation"]
  B --> C["kernel_phi: Electric Field"]
  B --> D["kernel_B: Magnetic Field"]
  C --> E["hatK_Phi_kr*.dat"]
  D --> F["hatK_B_kr*.dat"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FLR2_asymptotics.f90</strong><dd><code>Add magnetic field kernel calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

KIM/src/asymptotics/FLR2_asymptotics.f90

<ul><li>Add <code>kernel_B</code> array allocation and calculation for magnetic field <br>kernel<br> <li> Rename variables for clarity (<code>kernel</code> → <code>kernel_phi</code>, <code>kernel_temp</code> → <br><code>kernel_phi_temp</code>)<br> <li> Implement magnetic field kernel formula with velocity cubed term and <br>speed of light factor<br> <li> Output both electric and magnetic kernel profiles to separate data <br>files</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/60/files#diff-f697a7168035f710237ca97b59f8d945c6bd74102a4e88fd682c0dfb349d3b73">+28/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

