### PR TITLE
Fix torque integration formula

### DIFF
--- a/QL-Balance/src/base/toroidal_torque.f90
+++ b/QL-Balance/src/base/toroidal_torque.f90
@@ -1,6 +1,6 @@
 subroutine calculate_total_toroidal_torque(time_index)
     use iso_fortran_env, only: dp => real64
-    use baseparam_mod, only: pi
+    use baseparam_mod, only: pi, rtor ! rtor is the major radius
     use grid_mod, only: T_EM_phi_e, T_EM_phi_i, T_tot_phi_e, T_tot_phi_i
     use integration, only: simpson_nonequi
     use wave_code_data, only: r
@@ -18,8 +18,8 @@ subroutine calculate_total_toroidal_torque(time_index)
     call simpson_nonequi(T_tot_phi_e(time_index), r(1:n), r(1:n) * T_EM_phi_e(1:n))
     call simpson_nonequi(T_tot_phi_i(time_index), r(1:n), r(1:n) * T_EM_phi_i(1:n))
 
-    T_tot_phi_e(time_index) = T_tot_phi_e(time_index) * 2.0_dp * pi
-    T_tot_phi_i(time_index) = T_tot_phi_i(time_index) * 2.0_dp * pi
+    T_tot_phi_e(time_index) = T_tot_phi_e(time_index) * 2.0_dp * pi**2 * rtor
+    T_tot_phi_i(time_index) = T_tot_phi_i(time_index) * 2.0_dp * pi**2 * rtor
 
 end subroutine calculate_total_toroidal_torque
 


### PR DESCRIPTION
### **User description**
S dr in KAMEL's cylinder should be dr rπ * 2πR_0 = 2π^2R_0 dr r


___

### **PR Type**
Bug fix


___

### **Description**
- Fix torque integration formula for toroidal geometry

- Correct surface element calculation in cylindrical coordinates

- Add major radius factor to torque computation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import major radius"] --> B["Calculate torque integrals"]
  B --> C["Apply corrected formula"]
  C --> D["Multiply by 2π²R₀"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toroidal_torque.f90</strong><dd><code>Correct toroidal torque integration formula</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

QL-Balance/src/base/toroidal_torque.f90

<ul><li>Import <code>rtor</code> (major radius) parameter from <code>baseparam_mod</code><br> <li> Update torque calculation formula from <code>2π</code> to <code>2π²rtor</code><br> <li> Apply correction to both electron and ion torque components</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/63/files#diff-28062e51e811bfa28529b5e9d1077f46263a40d0eefb6b2c22c7fd6b372aa5cd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

