### PR TITLE
Use a faster mirror for fetching GSL

### DIFF
--- a/cmake/FetchGSL.cmake
+++ b/cmake/FetchGSL.cmake
@@ -8,7 +8,7 @@ endif()
 
 ExternalProject_Add(EXTERNAL_gsl
     PREFIX ${CMAKE_BINARY_DIR}/download
-    URL https://ftp.gnu.org/gnu/gsl/gsl-2.4.tar.gz
+    URL https://mirror.easyname.at/gnu/gsl/gsl-2.4.tar.gz
     DOWNLOAD_NAME gsl-2.4.tar.gz
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     BUILD_IN_SOURCE TRUE


### PR DESCRIPTION
### **User description**
Found by @krystophny withing #56, but this needs to be merged ASAP and is unrelated to the other changes in that PR.


___

### **PR Type**
Other


___

### **Description**
- Switch GSL download URL to faster mirror


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GNU FTP Server"] -- "replaced with" --> B["EasyName Mirror"]
  B --> C["Faster GSL Download"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FetchGSL.cmake</strong><dd><code>Switch to faster GSL mirror</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmake/FetchGSL.cmake

<ul><li>Changed GSL download URL from GNU FTP to EasyName mirror<br> <li> Maintained same GSL version (2.4) and file structure</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/67/files#diff-fe2291a230cff64fc109506e294c01cef450955f5744c75ec63d1206e661d0b6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

