### PR TITLE
Seperate time step and time loop

### DIFF
--- a/QL-Balance/src/base/time_evolution.f90
+++ b/QL-Balance/src/base/time_evolution.f90
@@ -168,14 +168,12 @@ module time_evolution
     subroutine runTimeEvolution(this)
         class(TimeEvolution_t), intent(inout) :: this
 
-        integer :: iredo = 0 ! TODO: Shouldn't this be per time step and not per evolution?
-
         do time_ind = 1, Nstorage
-            call doStep(this, iredo)
+            call doStep(this)
         end do
     end subroutine runTimeEvolution
 
-    subroutine doStep(this, iredo)
+    subroutine doStep(this)
         use baseparam_mod, only: factolmax, factolred
         use control_mod, only: debug_mode
         use parallelTools, only: irank
@@ -188,7 +186,8 @@ module time_evolution
         implicit none
 
         class(TimeEvolution_t), intent(inout) :: this
-        integer, intent(inout) :: iredo
+
+        integer :: iredo
 
         call copy_kin_profs_to_yprev
         redostep = .false.
@@ -212,6 +211,7 @@ module time_evolution
             call redoTimeStep
         end if
 
+        iredo = 0
         do ! redo step loop
             iredo = iredo + 1
             params_beg = params


### PR DESCRIPTION
### **User description**
Extract the loop over time steps and the actual things done per time step. This allows for appending actions to one time step, needed for the new mode including NEO-RT calculations.
`runTimeEvolution` now only loops over the total time steps and calls `doStep` in each iteration. The big amount of lines changed results only from re-intending.

The check for a maximum of 100 redo iterations was moved to a per-time-step basis rather than a per-time-evolution basis. Please check carefully if this is intended, as I thought this was a logic error, but I could be wrong!


___

### **PR Type**
Enhancement


___

### **Description**
- Separate time loop from individual time step logic

- Extract `doStep` subroutine handling single step operations

- Move 100 redo iteration limit to per-time-step basis

- Improve debug output formatting with structured write statement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["runTimeEvolution"] -->|loops over time steps| B["doStep"]
  B -->|performs single step| C["redo loop<br/>max 100 iterations"]
  C -->|evolves plasma| D["update parameters"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>time_evolution.f90</strong><dd><code>Separate time loop from step execution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

QL-Balance/src/base/time_evolution.f90

<ul><li>Extracted <code>doStep</code> subroutine from <code>runTimeEvolution</code> to handle single <br>time step operations<br> <li> Simplified <code>runTimeEvolution</code> to only loop over time steps and call <br><code>doStep</code><br> <li> Moved 100 redo iteration check from evolution-level to per-time-step <br>basis<br> <li> Improved debug output formatting using structured write statement with <br>format specifier<br> <li> Reorganized module imports for better clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/72/files#diff-88cc0467d284b7123751fb2e161265d74226139a3f38f70a3817a4e736a2246d">+84/-76</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

