### PR TITLE
Improve config file reading

### DIFF
--- a/QL-Balance/src/base/read_config.f90
+++ b/QL-Balance/src/base/read_config.f90
@@ -12,6 +12,8 @@ subroutine read_config
 
     implicit none
 
+    integer :: u, ios
+
     character(len=*), parameter :: config_file = "balance_conf.nml"
 
     !> namelist for the balance configuration input
@@ -25,9 +27,12 @@ subroutine read_config
         constant_time_step, urelax
 
     ! read the parameters from namelist file
-    open (22, file=config_file)
-    read (22, NML=BALANCENML)
-    close (22)
+    open (newunit=u, file=config_file, status="old", action="read", iostat=ios)
+    if (ios /= 0) error stop "Failed to open config file"
+    read (u, nml=BALANCENML, iostat=ios)
+    if (ios /= 0) error stop "Failed to read namelist"
+    close (u)
+
     write (*, *) ""
     write (*, *) "================================================================================="
     write (*, "(A,A)") "    Type of Run: ", type_of_run


### PR DESCRIPTION
### **User description**
Beautify printing of `balance_conf.nml` content by explicitly providing a format string. More robust opening and reading of the file.


___

### **PR Type**
Enhancement


___

### **Description**
- Improved config file reading with robust error handling

- Added explicit format strings for all output statements

- Reorganized imports and namelist declarations for clarity

- Enhanced numeric output formatting with appropriate data types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config File Reading"] --> B["Error Handling"]
  A --> C["Formatted Output"]
  B --> D["newunit parameter"]
  B --> E["iostat checks"]
  C --> F["Format strings"]
  C --> G["adjustl trimming"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>read_config.f90</strong><dd><code>Robust file I/O with formatted output statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

QL-Balance/src/base/read_config.f90

<ul><li>Reorganized use statements with improved formatting and alphabetical <br>ordering<br> <li> Added variables <code>u</code> and <code>ios</code> for robust file unit and I/O status handling<br> <li> Introduced <code>config_file</code> parameter constant for maintainability<br> <li> Replaced hardcoded file unit 22 with <code>newunit=u</code> for better Fortran <br>practices<br> <li> Added error checking with <code>iostat</code> and <code>error stop</code> for file open and read <br>operations<br> <li> Converted all <code>write(*,*)</code> statements to use explicit format strings <br>with <code>write(*,"(format)")</code><br> <li> Applied <code>adjustl()</code> function to string outputs for left-alignment<br> <li> Added appropriate format specifiers: <code>ES15.8</code> for reals, <code>I0</code> for <br>integers, <code>L0</code> for logicals<br> <li> Improved output formatting with consistent spacing and alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/81/files#diff-1d9a3982988bf2102e0911b5e66e0b823a31567442610ed04e3854d69faeb6ec">+72/-74</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

