### PR TITLE
Patch out deprecated LAPACK routine from zeros.f90 from ZEAL

### DIFF
--- a/cmake/FetchZeal.cmake
+++ b/cmake/FetchZeal.cmake
@@ -12,4 +12,10 @@ FetchContent_Declare(zeal
 # Download & extract Zeal sources, making them available
 FetchContent_MakeAvailable(zeal)
 
+# Patch zeros.f90 to use modern ZGGEV instead of deprecated ZGEGV
+# (ZGEGV was deprecated in LAPACK 3.0 and removed from modern distributions)
+file(READ "${zeal_SOURCE_DIR}/zeros.f90" ZEROS_CONTENT)
+string(REPLACE "ZGEGV" "ZGGEV" ZEROS_CONTENT "${ZEROS_CONTENT}")
+file(WRITE "${zeal_SOURCE_DIR}/zeros.f90" "${ZEROS_CONTENT}")
+
 # Now `zeal_SOURCE_DIR` is set and sources can be compiled by subprojects


### PR DESCRIPTION
Fixes #87.

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated LAPACK routine ZGEGV with modern ZGGEV

- Patch zeros.f90 after fetching ZEAL sources

- Ensure compatibility with modern LAPACK distributions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch ZEAL sources"] -- "Read zeros.f90" --> B["Load file content"]
  B -- "Replace ZGEGV with ZGGEV" --> C["Update deprecated routine"]
  C -- "Write modified file" --> D["Save patched zeros.f90"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FetchZeal.cmake</strong><dd><code>Patch ZEAL zeros.f90 to use modern LAPACK routine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmake/FetchZeal.cmake

<ul><li>Added post-fetch patching logic to replace deprecated ZGEGV with ZGGEV<br> <li> Reads zeros.f90 file content after FetchContent_MakeAvailable<br> <li> Performs string replacement of deprecated routine name<br> <li> Writes patched content back to zeros.f90 file</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/89/files#diff-5f6b6c381ba84a6432fb2c72647c99717dd1ce06ab45c8b915a89665a01d5199">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

