### PR TITLE
Fix force structs

### DIFF
--- a/QL-Balance/src/base/rhs_balance_m.f90
+++ b/QL-Balance/src/base/rhs_balance_m.f90
@@ -53,14 +53,17 @@ module rhs_balance_m
     ! Derived types
     !---------------------------------------------------------------------------
 
+    !> Thermodynamic forces for a single species
+    type :: species_forces_t
+        real(dp) :: A1 = 0.0_dp
+        real(dp) :: A1_noE = 0.0_dp  ! E0r set to zero
+        real(dp) :: A2 = 0.0_dp
+    end type species_forces_t
+
     !> Thermodynamic forces at a single radial point
     type :: thermodynamic_forces_t
-        real(dp) :: A_noE_1e = 0.0_dp  !< Electron force without E-field
-        real(dp) :: A_noE_2e = 0.0_dp  !< Electron temperature gradient force
-        real(dp) :: A_noE_1i = 0.0_dp  !< Ion force without E-field
-        real(dp) :: A_noE_2i = 0.0_dp  !< Ion temperature gradient force
-        real(dp) :: A_1e = 0.0_dp  !< Electron force with E-field
-        real(dp) :: A_1i = 0.0_dp  !< Ion force with E-field
+        type(species_forces_t) :: e  !< Electron forces
+        type(species_forces_t) :: i  !< Ion forces
     end type thermodynamic_forces_t
 
     !> Particle and heat fluxes for a single species
@@ -270,10 +273,10 @@ contains
                 ! - stale forces_nl (from pre-loop's last ipoi=npoib)
                 ! - current diffusion coefficients and density (ipoi)
                 ! This matches the original code's behavior
-                gamma_ql_e_nl = -(dqle11(ipoi) * forces_nl%A_1e + dqle12(ipoi) * &
-                                  forces_nl%A_noE_2e) * params_b(1, ipoi)
-                gamma_ql_i_nl = -(dqli11(ipoi) * forces_nl%A_1i + dqli12(ipoi) * &
-                                  forces_nl%A_noE_2i) * params_b(1, ipoi) / Z_i
+                gamma_ql_e_nl = -(dqle11(ipoi) * forces_nl%e%A1 + dqle12(ipoi) * &
+                                  forces_nl%e%A2) * params_b(1, ipoi)
+                gamma_ql_i_nl = -(dqli11(ipoi) * forces_nl%i%A1 + dqli12(ipoi) * &
+                                  forces_nl%i%A2) * params_b(1, ipoi) / Z_i
 
                 ! Compute source terms (using nonlinear ql fluxes for T_EM_phi)
                 call compute_internal_sources(ipoi, gamma_e_lin, gamma_i_lin, gamma_ql_e_lin, &
@@ -773,12 +776,12 @@ contains
         real(dp), intent(in) :: Ercov_val, Z_i_val
         type(thermodynamic_forces_t), intent(out) :: forces
 
-        forces%A_noE_1e = ddr_n / n_b - 1.5_dp * ddr_Te / Te_b
-        forces%A_noE_2e = ddr_Te / Te_b
-        forces%A_noE_1i = ddr_n / n_b - 1.5_dp * ddr_Ti / Ti_b
-        forces%A_noE_2i = ddr_Ti / Ti_b
-        forces%A_1e = forces%A_noE_1e + Ercov_val * e_charge / Te_b
-        forces%A_1i = forces%A_noE_1i - Ercov_val * e_charge * Z_i_val / Ti_b
+        forces%e%A1_noE = ddr_n / n_b - 1.5_dp * ddr_Te / Te_b
+        forces%e%A2 = ddr_Te / Te_b
+        forces%i%A1_noE = ddr_n / n_b - 1.5_dp * ddr_Ti / Ti_b
+        forces%i%A2 = ddr_Ti / Ti_b
+        forces%e%A1 = forces%e%A1_noE + Ercov_val * e_charge / Te_b
+        forces%i%A1 = forces%i%A1_noE - Ercov_val * e_charge * Z_i_val / Ti_b
     end subroutine compute_thermodynamic_forces
 
     pure subroutine compute_particle_fluxes(forces, n_b, Z_i_val, D11_a_e, D12_a_e, D11_ql_e, &
@@ -799,13 +802,13 @@ contains
         type(transport_fluxes_t), intent(out) :: fluxes
 
         ! Electron particle fluxes
-        fluxes%e%gamma_a = -(D11_a_e * forces%A_noE_1e + D12_a_e * forces%A_noE_2e) * n_b
-        fluxes%e%gamma_ql = -(D11_ql_e * forces%A_1e + D12_ql_e * forces%A_noE_2e) * n_b
+        fluxes%e%gamma_a = -(D11_a_e * forces%e%A1_noE + D12_a_e * forces%e%A2) * n_b
+        fluxes%e%gamma_ql = -(D11_ql_e * forces%e%A1 + D12_ql_e * forces%e%A2) * n_b
         fluxes%e%gamma = fluxes%e%gamma_a + fluxes%e%gamma_ql
 
         ! Ion particle fluxes
-        fluxes%i%gamma_a = -(D11_a_i * forces%A_noE_1i + D12_a_i * forces%A_noE_2i) * n_b / Z_i_val
-        fluxes%i%gamma_ql = -(D11_ql_i * forces%A_1i + D12_ql_i * forces%A_noE_2i) * n_b / Z_i_val
+        fluxes%i%gamma_a = -(D11_a_i * forces%i%A1_noE + D12_a_i * forces%i%A2) * n_b / Z_i_val
+        fluxes%i%gamma_ql = -(D11_ql_i * forces%i%A1 + D12_ql_i * forces%i%A2) * n_b / Z_i_val
         fluxes%i%gamma = fluxes%i%gamma_a + fluxes%i%gamma_ql
     end subroutine compute_particle_fluxes
 
@@ -830,9 +833,9 @@ contains
         real(dp), intent(in) :: D12_a_i, D21_ql_i, D22_i
         real(dp), intent(out) :: Q_e, Q_i
 
-        Q_e = -(D12_a_e * forces%A_noE_1e + D21_ql_e * forces%A_1e + D22_e * forces%A_noE_2e) &
+        Q_e = -(D12_a_e * forces%e%A1_noE + D21_ql_e * forces%e%A1 + D22_e * forces%e%A2) &
               * n_b * Te_b
-        Q_i = -(D12_a_i * forces%A_noE_1i + D21_ql_i * forces%A_1i + D22_i * forces%A_noE_2i) * &
+        Q_i = -(D12_a_i * forces%i%A1_noE + D21_ql_i * forces%i%A1 + D22_i * forces%i%A2) * &
               n_b / Z_i_val * Ti_b
     end subroutine compute_heat_fluxes
 

--- a/QL-Balance/src/test/test_rhs_balance.f90
+++ b/QL-Balance/src/test/test_rhs_balance.f90
@@ -123,12 +123,12 @@ contains
             forces)
 
         ! Verify results
-        call assert_equal(forces%A_noE_1e, expected_A_noE_1e, "A_noE_1e")
-        call assert_equal(forces%A_noE_2e, expected_A_noE_2e, "A_noE_2e")
-        call assert_equal(forces%A_noE_1i, expected_A_noE_1i, "A_noE_1i")
-        call assert_equal(forces%A_noE_2i, expected_A_noE_2i, "A_noE_2i")
-        call assert_equal(forces%A_1e, expected_A_1e, "A_1e")
-        call assert_equal(forces%A_1i, expected_A_1i, "A_1i")
+        call assert_equal(forces%e%A1_noE, expected_A_noE_1e, "A_noE_1e")
+        call assert_equal(forces%e%A2, expected_A_noE_2e, "A_noE_2e")
+        call assert_equal(forces%i%A1_noE, expected_A_noE_1i, "A_noE_1i")
+        call assert_equal(forces%i%A2, expected_A_noE_2i, "A_noE_2i")
+        call assert_equal(forces%e%A1, expected_A_1e, "A_1e")
+        call assert_equal(forces%i%A1, expected_A_1i, "A_1i")
 
         ! Test case 2: Zero electric field
         Ercov_val = 0.0_dp
@@ -141,8 +141,8 @@ contains
             Ercov_val, Z_i_val, &
             forces)
 
-        call assert_equal(forces%A_1e, expected_A_1e, "A_1e (E=0)")
-        call assert_equal(forces%A_1i, expected_A_1i, "A_1i (E=0)")
+        call assert_equal(forces%e%A1, expected_A_1e, "A_1e (E=0)")
+        call assert_equal(forces%i%A1, expected_A_1i, "A_1i (E=0)")
 
         print *, "  PASSED: ", test_name
 
@@ -174,12 +174,12 @@ contains
         Z_i_val = 1.0_dp
 
         ! Thermodynamic forces (arbitrary test values)
-        forces%A_noE_1e = -0.05_dp
-        forces%A_noE_2e = 0.1_dp
-        forces%A_noE_1i = -0.04_dp
-        forces%A_noE_2i = 0.1_dp
-        forces%A_1e = -0.03_dp
-        forces%A_1i = -0.06_dp
+        forces%e%A1_noE = -0.05_dp
+        forces%e%A2 = 0.1_dp
+        forces%i%A1_noE = -0.04_dp
+        forces%i%A2 = 0.1_dp
+        forces%e%A1 = -0.03_dp
+        forces%i%A1 = -0.06_dp
 
         ! Diffusion coefficients (individual values)
         D11_a_e = 1.0e4_dp;  D12_a_e = 0.5e4_dp
@@ -188,12 +188,12 @@ contains
         D11_ql_i = 1.5e4_dp; D12_ql_i = 0.8e4_dp
 
         ! Expected values (analytical calculation)
-        expected_gamma_a_e = -(D11_a_e*forces%A_noE_1e + D12_a_e*forces%A_noE_2e) * n_b
-        expected_gamma_ql_e = -(D11_ql_e*forces%A_1e + D12_ql_e*forces%A_noE_2e) * n_b
+        expected_gamma_a_e = -(D11_a_e*forces%e%A1_noE + D12_a_e*forces%e%A2) * n_b
+        expected_gamma_ql_e = -(D11_ql_e*forces%e%A1 + D12_ql_e*forces%e%A2) * n_b
         expected_gamma_e = expected_gamma_a_e + expected_gamma_ql_e
 
-        expected_gamma_a_i = -(D11_a_i*forces%A_noE_1i + D12_a_i*forces%A_noE_2i) * n_b / Z_i_val
-        expected_gamma_ql_i = -(D11_ql_i*forces%A_1i + D12_ql_i*forces%A_noE_2i) * n_b / Z_i_val
+        expected_gamma_a_i = -(D11_a_i*forces%i%A1_noE + D12_a_i*forces%i%A2) * n_b / Z_i_val
+        expected_gamma_ql_i = -(D11_ql_i*forces%i%A1 + D12_ql_i*forces%i%A2) * n_b / Z_i_val
         expected_gamma_i = expected_gamma_a_i + expected_gamma_ql_i
 
         ! Call the function under test
@@ -245,12 +245,12 @@ contains
         Z_i_val = 1.0_dp
 
         ! Thermodynamic forces
-        forces%A_noE_1e = -0.05_dp
-        forces%A_noE_2e = 0.1_dp
-        forces%A_noE_1i = -0.04_dp
-        forces%A_noE_2i = 0.1_dp
-        forces%A_1e = -0.03_dp
-        forces%A_1i = -0.06_dp
+        forces%e%A1_noE = -0.05_dp
+        forces%e%A2 = 0.1_dp
+        forces%i%A1_noE = -0.04_dp
+        forces%i%A2 = 0.1_dp
+        forces%e%A1 = -0.03_dp
+        forces%i%A1 = -0.06_dp
 
         ! Diffusion coefficients (individual values)
         D12_a_e = 0.5e4_dp;  D22_a_e = 1.5e4_dp
@@ -264,8 +264,8 @@ contains
         D22_i = D22_a_i + D22_nc + D22_ql_i
 
         ! Expected values: Q = -(D12_a*A_noE_1 + D21_ql*A_1 + D22*A_noE_2) * n * T
-        expected_Q_e = -(D12_a_e*forces%A_noE_1e + D21_ql_e*forces%A_1e + D22_e*forces%A_noE_2e) * n_b * Te_b
-        expected_Q_i = -(D12_a_i*forces%A_noE_1i + D21_ql_i*forces%A_1i + D22_i*forces%A_noE_2i) * n_b / Z_i_val * Ti_b
+        expected_Q_e = -(D12_a_e*forces%e%A1_noE + D21_ql_e*forces%e%A1 + D22_e*forces%e%A2) * n_b * Te_b
+        expected_Q_i = -(D12_a_i*forces%i%A1_noE + D21_ql_i*forces%i%A1 + D22_i*forces%i%A2) * n_b / Z_i_val * Ti_b
 
         ! Call the function under test
         call compute_heat_fluxes(forces, n_b, Te_b, Ti_b, Z_i_val, &


### PR DESCRIPTION
The access pattern and naming of `thermodynamic_forces_t` was way off. This PR fixes this and makes it consistent with the naming of `transport_fluxes_t`. Depends on #98.