### PR TITLE
Don't hard-code plasma and antenna radius

### DIFF
--- a/python/KiLCA_interface/KiLCA_interface.py
+++ b/python/KiLCA_interface/KiLCA_interface.py
@@ -186,9 +186,9 @@ class KiLCA_interface:
 
         self.BLUE_PATH = inspect.getfile(KiLCA_interface)[0:-18] + self.BLUE_PATH
 
-    def set_machine(self, delta_r_antenna: float = 3.0):
+    def set_machine(self, delta_r_antenna: float = 3.0, a_minor: float = None):
         if self.machine == "AUG":
-            self.set_ASDEX()
+            self.set_ASDEX(a_minor=a_minor, delta_r_antenna=delta_r_antenna)
         elif self.machine == "MASTU":
             self.set_MASTU(delta_r_antenna=delta_r_antenna)
         elif self.machine == None:
@@ -261,32 +261,50 @@ class KiLCA_interface:
             for k in range(0, len(m))
         ]
 
-    def set_ASDEX(self, nmodes: int = 1, ra: float = 70, I0: float = 5.1e12):
+    def set_ASDEX(
+        self,
+        nmodes: int = 1,
+        ra: float = None,
+        I0: float = 5.1e12,
+        a_minor: float = None,
+        delta_r_antenna: float = 3.0,
+    ):
         """
         Description:
             Initializes the class for a standard run on ASDEX parameters.
         Input:
             nmodes ... number of modes to calculate, default=0
-            ra ... radius of the antenna
+            ra ... radius of the antenna (if None, computed from a_minor + delta_r_antenna)
             I0 ... RMP coil current value in statA, AUG: 1.7kA = 5.1e12 statA
+            a_minor ... plasma minor radius in cm (default 67.0)
+            delta_r_antenna ... distance from plasma edge to antenna (default 3.0)
         """
         self.machine = "AUG"
         # print(f'Machine setting: AUG, type: {self.run_type}')
 
-        if ra < 67:
-            raise ValueError("Radius of antenna inside plasma")
+        # Set plasma radius (default 67.0 for AUG)
+        if a_minor is None:
+            self.a_minor = 67.0
+        else:
+            self.a_minor = a_minor
+
+        self.R0 = 165.0
+
+        # Compute antenna radius if not specified
+        if ra is None:
+            ra = self.a_minor + delta_r_antenna
+
+        if ra < self.a_minor:
+            raise ValueError(f"Radius of antenna ({ra}) inside plasma ({self.a_minor})")
         if ra > 80:
             raise ValueError("Radius of antenna outside wall")
-
-        self.a_minor = 67.0
-        self.R0 = 165.0
 
         self.set_antenna(ra, nmodes, I0=I0)
         self.set_background(Rtor=self.R0, rpl=self.a_minor)
         self.background.data["Btor"] = -17563.3704
 
-        # set zones
-        r = [3.0, 67.0, 70.0, 80.0]
+        # set zones - use actual plasma radius
+        r = [3.0, self.a_minor, ra, 80.0]
         b = ["center", "interface", "antenna", "idealwall"]
         m = [self.run_type, "vacuum", "vacuum"]
         self.set_zones(r, b, m)

--- a/python/balance_interface/balance_interface.py
+++ b/python/balance_interface/balance_interface.py
@@ -193,7 +193,7 @@ class QL_Balance_interface:
         if self.debug:
             print("D: Prepare KiLCA")
         self.kil_flre = KiLCA_interface(self.shot, self.time, self.run_path, "flre", self.machine)
-        self.kil_flre.set_machine(delta_r_antenna=self.delta_r_antenna)
+        self.kil_flre.set_machine(delta_r_antenna=self.delta_r_antenna, a_minor=a_minor)
         self.kil_flre.background.data["Btor"] = Btor
 
         self.kil_flre.set_modes(self.m_mode, self.n_mode)
@@ -205,7 +205,7 @@ class QL_Balance_interface:
 
         kil_vac = KiLCA_interface(self.shot, self.time, self.run_path, "vacuum", self.machine)
         kil_vac.background.data["Btor"] = Btor
-        kil_vac.set_machine(delta_r_antenna=self.delta_r_antenna)
+        kil_vac.set_machine(delta_r_antenna=self.delta_r_antenna, a_minor=a_minor)
         kil_vac.set_modes(self.m_mode, self.n_mode)
         kil_vac.antenna.data["flab"] = [1.0, 0.0]
         kil_vac.write()


### PR DESCRIPTION
### **User description**
- Make plasma minor radius (`a_minor`) and antenna radius (`ra`) configurable in the ASDEX machine setup instead of using hard-coded values
- Update zone boundaries to use actual plasma and antenna radii dynamically
- Propagate `a_minor` parameter through `set_machine()` to `QL_Balance_interface`


___

### **PR Type**
Enhancement


___

### **Description**
- Make plasma minor radius (`a_minor`) and antenna radius (`ra`) configurable parameters instead of hard-coded values

- Compute antenna radius dynamically from plasma radius and delta_r_antenna offset

- Update zone boundaries to use actual plasma and antenna radii

- Propagate `a_minor` parameter through `set_machine()` to `QL_Balance_interface`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set_machine<br/>delta_r_antenna, a_minor"] --> B["set_ASDEX<br/>compute ra from a_minor"]
  B --> C["set_zones<br/>use actual radii"]
  D["balance_interface<br/>prepare_KiLCA"] --> A
  A --> E["antenna radius<br/>validated"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KiLCA_interface.py</strong><dd><code>Parameterize plasma and antenna radius configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/KiLCA_interface/KiLCA_interface.py

<ul><li>Added <code>a_minor</code> parameter to <code>set_machine()</code> method signature<br> <li> Modified <code>set_ASDEX()</code> to accept <code>a_minor</code> and <code>delta_r_antenna</code> parameters <br>with dynamic antenna radius computation<br> <li> Changed hard-coded plasma radius (67.0) and antenna radius (70.0) to <br>use configurable values<br> <li> Updated zone boundaries array to use <code>self.a_minor</code> and computed <code>ra</code> <br>instead of hard-coded values<br> <li> Improved error messages to include actual radius values in validation <br>checks</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/107/files#diff-f31dff008b8922f1c57e086c374fdf0d90cadbf2dd14fb1a2de225397804df5f">+29/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>balance_interface.py</strong><dd><code>Propagate a_minor parameter to KiLCA setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/balance_interface/balance_interface.py

<ul><li>Updated <code>prepare_KiLCA()</code> calls to pass <code>a_minor</code> parameter to <br><code>set_machine()</code> method<br> <li> Propagated <code>a_minor</code> from balance interface to KiLCA interface for both <br>FLRE and vacuum configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/107/files#diff-bbcbaece5bc91bdafe2aa887d27dfa4b63e9e0bf82a0be932034825b0bc29161">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

