### PR TITLE
fix(QL-Balance): regularize Jacobian probing to fix ill-conditioning

### DIFF
--- a/QL-Balance/src/base/rhs_balance_m.f90
+++ b/QL-Balance/src/base/rhs_balance_m.f90
@@ -226,8 +226,14 @@ contains
             ibegtot = max(1, ibegtot)
             iendtot = min(neqset, iendtot)
 
-            ! Set probe
-            y_lin(iprobe) = 1.0_dp
+            ! Set probe with physically-motivated perturbation
+            ! Instead of y_lin = 1 (unphysical), use relative perturbation of actual values
+            ! This prevents extreme Jacobian entries from resonance responses
+            if (abs(y(iprobe)) > 1.0e-30_dp) then
+                y_lin(iprobe) = 1.0e-6_dp * y(iprobe)
+            else
+                y_lin(iprobe) = 1.0e-6_dp  ! Fallback for zero values
+            end if
 
             ! Copy y_lin to params_lin
             do ipoi = ibeg, iend
@@ -310,13 +316,15 @@ contains
             end do
 
             ! Store non-zero elements
+            ! Divide by perturbation size to get correct Jacobian entry:
+            ! J[i,j] = dy[i] / delta_y[j]
             do i = ibegtot, iendtot
                 if (dy(i) /= 0.0_dp) then
                     k = k + 1
                     if (isw_rhs .eq. 1) then
                         irow(k) = i
                         icol(k) = iprobe
-                        amat(k) = dy(i)
+                        amat(k) = dy(i) / y_lin(iprobe)
                     end if
                 end if
             end do


### PR DESCRIPTION
### **User description**
The numerical Jacobian was computed by setting y_lin = 1 for each parameter. This caused extreme, unphysical responses (~10^32) from KiLCA resonances because the actual parameter values are:
- density: ~10^13 cm^-3
- velocity: ~10^4 cm/s
- temperature: ~10^3 eV

Now using y_lin = epsilon * y (with epsilon = 10^-6) keeps perturbations in the physical regime. The Jacobian entry is then normalized by the perturbation size: J[i,j] = dy[i] / delta_y[j].

Results:
- polforce dropped from 10^32 to 10^18
- Vphi changes from catastrophic (-2.1e10) to physical (-4.8e3)
- Simulation now runs stably with NTV torque enabled


___

### **PR Type**
Bug fix


___

### **Description**
- Regularize Jacobian probing by using physically-motivated perturbations

- Replace hardcoded y_lin = 1 with epsilon * y (epsilon = 10^-6)

- Normalize Jacobian entries by dividing by perturbation size

- Prevents extreme unphysical responses from KiLCA resonances


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Jacobian Probing"] -->|Old: y_lin = 1| B["Extreme Values ~10^32"]
  A -->|New: y_lin = epsilon*y| C["Physical Perturbations"]
  C -->|Normalize by delta_y| D["Correct Jacobian Entries"]
  B -->|Result| E["Unstable Simulation"]
  D -->|Result| F["Stable Simulation with NTV"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rhs_balance_m.f90</strong><dd><code>Regularize Jacobian computation with physical perturbations</code></dd></summary>
<hr>

QL-Balance/src/base/rhs_balance_m.f90

<ul><li>Modified Jacobian probing to use relative perturbation y_lin = 1.0e-6 <br>* y instead of hardcoded y_lin = 1<br> <li> Added fallback for zero values to prevent division issues<br> <li> Normalized Jacobian matrix entries by dividing by perturbation size: <br>amat(k) = dy(i) / y_lin(iprobe)<br> <li> Added explanatory comments describing the physical motivation and <br>normalization approach</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/KAMEL/pull/108/files#diff-cb11d90e56742f2d45852eac80727323482f6adb4cee5cb87a0ecd3ef4f09017">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

