### PR TITLE
fix(test): remove non-existent HDF5 datasets from golden record

### DIFF
--- a/test/ql-balance/golden_record/compare.py
+++ b/test/ql-balance/golden_record/compare.py
@@ -50,8 +50,6 @@ _LINEAR_PROFILE_QUANTITIES = [
     "Br_Im",  # B_r
     "T_EM_phi_e",
     "T_EM_phi_i",  # EM torque
-    "T_EM_phi_e_source",
-    "T_EM_phi_i_source",  # EM torque source
 ]
 
 # Time steps available in LinearProfiles (0-8)


### PR DESCRIPTION
## Summary
- Removes `T_EM_phi_e_source` and `T_EM_phi_i_source` from the golden record comparison list in `compare.py`
- These datasets are never written by the Fortran code (`writeData.f90`), causing 18 test failures in CI after PR #96 was merged

## Test plan
- [ ] CI golden record tests pass (18 previously failing tests should now pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)