### PR TITLE
Allow external libneo_ref trigger in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main, fix-ci]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      libneo_ref:
+        description: libneo branch or tag to build against
+        required: false
+        default: ''
+
+env:
+  LIBNEO_REF: ${{ inputs.libneo_ref }}
 
 jobs:
   build-and-test:


### PR DESCRIPTION
**Merge after #132 (the resolver PR).** The `LIBNEO_REF` env added here is inert until that resolver PR lands and reads it; merging this first is harmless but does nothing.

Adds a `libneo_ref` `workflow_dispatch` input mapped to `LIBNEO_REF`, so an upstream libneo release can dispatch this CI to build KAMEL against a candidate ref (branch, tag or commit). Empty on push/PR, so normal builds keep the committed default.