### PR TITLE
Migrate KiLCA/QL-Balance quadrature to fortnum (3/8)

### DIFF
--- a/KiLCA/CMakeLists.txt
+++ b/KiLCA/CMakeLists.txt
@@ -111,7 +111,7 @@ set (kilca_eigparam_main progs/main_eig_param.cpp)
 set (libs_root_path ${CMAKE_BINARY_DIR}/external-install)
 set (gsl_include_path ${libs_root_path}/gsl/include)
 
-set(EXTERNAL_LIBS slatec lapack blas SUNDIALS::cvode SUNDIALS::nvecserial gsl gslcblas)
+set(EXTERNAL_LIBS slatec lapack blas SUNDIALS::cvode SUNDIALS::nvecserial fortnum gsl gslcblas)
 
 # configure a header file to pass some of the CMake settings to the source code
 configure_file(
@@ -122,6 +122,8 @@ configure_file(
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories ("${gsl_include_path}")
+# fortnum C ABI header (fortnum.h); the Fortran fortnum target is linked above.
+include_directories ("${fortnum_SOURCE_DIR}/include")
 include_directories ("${PROJECT_BINARY_DIR}")
 include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/antenna")
 include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/background")
@@ -283,6 +285,7 @@ target_include_directories(kilca_lib PUBLIC
     # External dependencies
     ${sundials_include_path}
     ${gsl_include_path}
+    ${fortnum_SOURCE_DIR}/include
 )
 
 add_executable (kilca_normal_exe ${kilca_normal_main})

--- a/KiLCA/flre/conductivity/tests/calc_I_array_drift.cpp
+++ b/KiLCA/flre/conductivity/tests/calc_I_array_drift.cpp
@@ -5,8 +5,7 @@
 #include <complex>
 #include <cmath>
 
-#include <gsl/gsl_integration.h>
-#include <gsl/gsl_errno.h>
+#include "fortnum.h"
 
 #include "constants.h"
 
@@ -95,8 +94,6 @@ int calc_imnl_quad_ (int * m_max, int * n_max, int * l_max,
                      double * x4_re, double * x4_im,
                      double * Imnl)
 {
-gsl_set_error_handler_off();
-
 complex<double> x1(*x1_re, *x1_im);
 complex<double> x2(*x2_re, *x2_im);
 complex<double> x3(*x3_re, *x3_im);
@@ -117,14 +114,7 @@ x4 = x4 / ep2a;
 
 quad_params qp = {x1, x2, x3, x4, 0, gamma, 0, 0, 0};
 
-size_t limit = 1024;
 double epsabs = 1.0e-14, epsrel = 1.0e-14, err;
-
-gsl_integration_workspace * w = gsl_integration_workspace_alloc(limit);
-
-gsl_function F;
-F.function = &subint;
-F.params = &qp;
 
 double x = 0.0;
 double y = 0.0;
@@ -154,13 +144,11 @@ for(int l = 0; l <= *l_max; ++l)
     {
         double I_re;
         qp.part = 0;
-        //gsl_integration_qagiu(&F, 0.0e0, epsabs, epsrel, limit, w, &I_re, &err);
-        gsl_integration_qag(&F, t1, t2, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, &I_re, &err);
+        fortnum_integrate_qag(&subint, t1, t2, epsabs, epsrel, 21, &I_re, &err, &qp);
 
         double I_im;
         qp.part = 1;
-        //gsl_integration_qagiu(&F, 0.0e0, epsabs, epsrel, limit, w, &I_im, &err);
-        gsl_integration_qag(&F, t1, t2, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, &I_im, &err);
+        fortnum_integrate_qag(&subint, t1, t2, epsabs, epsrel, 21, &I_im, &err, &qp);
 
         InT = (I_re + I_im * I) / pow(ep2a, 0.5e0*(3 + m + n));
 
@@ -171,8 +159,6 @@ for(int l = 0; l <= *l_max; ++l)
         t2 += step;
     }
 }
-
-gsl_integration_workspace_free(w);
 
 return 0;
 }

--- a/KiLCA/math/fourier/four_transf.cpp
+++ b/KiLCA/math/fourier/four_transf.cpp
@@ -9,9 +9,7 @@
 #include "spline.h"
 #include "constants.h"
 
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_integration.h>
+#include "fortnum.h"
 
 /*-----------------------------------------------------------------*/
 
@@ -72,13 +70,7 @@ spline_alloc_ (N, 1, dimx, x, C, &sid);
 
 spline_calc_ (sid, yt, 0, 1, NULL, &ierr);
 
-gsl_integration_workspace *W = gsl_integration_workspace_alloc (1000);
-
 struct quad_func_params P = {0, 0, sid, pi/delta, x0};
-
-gsl_function F;
-F.function = &func;
-F.params = &P;
 
 double re, im, err_re, err_im;
 
@@ -87,10 +79,10 @@ for (k=-M; k<=M; k++)
     P.k = k;
 
     P.part = 0;
-    gsl_integration_qag (&F, x0-delta, x0+delta, 1.0e-8, 1.0e-8, 1000, 3, W, &re, &err_re);
+    fortnum_integrate_qag (&func, x0-delta, x0+delta, 1.0e-8, 1.0e-8, 31, &re, &err_re, &P);
 
     P.part = 1;
-    gsl_integration_qag (&F, x0-delta, x0+delta, 1.0e-8, 1.0e-8, 1000, 3, W, &im, &err_im);
+    fortnum_integrate_qag (&func, x0-delta, x0+delta, 1.0e-8, 1.0e-8, 31, &im, &err_im, &P);
 
     //fprintf (stdout, "\nk = %d:\tresult = %lg%+lgi\terror = %lg%+lgi", k, re, im, err_re, err_im);
 
@@ -102,7 +94,6 @@ delete [] C;
 delete [] yt;
 
 spline_free_ (sid);
-gsl_integration_workspace_free (W);
 
 return 0;
 }

--- a/QL-Balance/CMakeLists.txt
+++ b/QL-Balance/CMakeLists.txt
@@ -124,6 +124,9 @@ set_source_files_properties(${base_balance_src}/kim_wave_code_adapter.f90
 # Include central slatec math sources via cache variable defined by common/math
 target_include_directories(ql-balance_lib PUBLIC ${SLATEC_INCLUDE_DIR})
 
+# fortnum C ABI header (fortnum.h) for vel_integral.cpp.
+target_include_directories(ql-balance_lib PUBLIC ${fortnum_SOURCE_DIR}/include)
+
 find_package(HDF5 REQUIRED COMPONENTS C HL Fortran Fortran_HL)
 message(" ====== HDF5 was found! ======")
 
@@ -150,6 +153,7 @@ target_link_libraries(ql-balance_lib PUBLIC
     SUNDIALS::cvode
     SUNDIALS::nvecserial
     blas
+    fortnum
     gsl
     gslcblas
     hdf5::hdf5

--- a/QL-Balance/src/base/vel_integral.cpp
+++ b/QL-Balance/src/base/vel_integral.cpp
@@ -7,9 +7,7 @@
 
 #include "constants.h"
 
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_integration.h>
+#include "fortnum.h"
 
 /*-----------------------------------------------------------------*/
 
@@ -65,13 +63,7 @@ return exp(-x*x)/(pow((P->a)*x + P->omE, 2)+(P->nu)*(P->nu))*real(field_fac)*ind
 
 void calc_velocity_integral_ (int ind, double vT, double ks, double kp, double omE, double nu, double *Es, double *Ep, double *res)
 {
-gsl_integration_workspace *W = gsl_integration_workspace_alloc (10000);
-
 struct quad_func_params P;
-
-gsl_function F;
-F.function = &func;
-F.params = &P;
 
 //set structure:
 P.ind = ind;
@@ -100,10 +92,10 @@ for (i=0; i<10000; i++)
 
 double err;
 
-gsl_integration_qagi (&F, 1.0e-6, 1.0e-6, 10000, W, res, &err);
-//gsl_integration_qag (&F, -10.0, 10.0, 1.0e-6, 1.0e-6, 10000, 3, W, res, &err);
-
-gsl_integration_workspace_free (W);
+// gsl_integration_qagi over (-inf, +inf): fortnum QAGIU with inf=2 splits at
+// the bound and sums the two semi-infinite transforms (bound ignored except
+// as the split point, matching QAGI's split at 0).
+fortnum_integrate_qagiu (&func, 0.0, 2, 1.0e-6, 1.0e-6, res, &err, &P);
 }
 
 /*-----------------------------------------------------------------*/


### PR DESCRIPTION
## Merge order

These fortnum-migration PRs are individually based on `main` and form one
cumulative stack. Merge them in this order:

#140 -> #141 -> #142 -> #143 -> #144 -> #145 -> #146 -> #147 -> #148 -> #149 -> #150

Each PR is opened against `main`, so its diff is cumulative versus `main` and
overlaps its predecessors. Merging in the order above keeps the history linear:
once a predecessor merges into `main`, the next PR's diff shrinks to just its
own increment.

## Scope

Route the C/C++ GSL adaptive-quadrature call sites onto the fortnum C ABI. The Fourier transform (`four_transf`) and the conductivity drift test (`calc_I_array_drift`) use `fortnum_integrate_qag`; the QL-Balance velocity integral (`vel_integral`) uses `fortnum_integrate_qagiu` over the doubly infinite interval. GSL workspace alloc/free and `gsl_function` wrappers are removed; integrand callbacks take fortnum's `(x, ctx)` ABI. Adds the fortnum C ABI include dir and links fortnum into `kilca_lib` and `ql-balance_lib`.

## Dependency removed

GSL `gsl_integration_qag`/`qagi` in KiLCA and QL-Balance.

## Verification

The K3 fortnum quadrature signatures compile and link against libfortnum:

```
$ g++ -std=c++14 -I.../fortnum/include probe.cpp libfortnum.a -lgfortran -o probe && ./probe
0.5   # int_0^1 x dx via fortnum_integrate_qag / qagiu
```

Stack tip builds green and `ctest` passes 18/18 (see K8). Draft: only the stack tip was built end to end.




---

### Stack reconciliation (update)

The migration stack was rebuilt as a strictly linear cumulative chain on main `428a708`:

```
k1 (+ golden CI fix) -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8 -> z1 -> z2 -> z3
```

## Status (2026-06-30, supersedes earlier DOP853/"not achievable" notes in this body)

Every branch is now merged up to current `main` (includes #132).

The earlier claim that #143's ODE "cannot reproduce the GSL rk8pd golden with DOP853" is stale and wrong. #143 replaced the interim per-segment DOP853 with a re-entrant fortnum `rk8pd` (Prince-Dormand RK8(7)13M, GSL standard controller). It is bit-identical to GSL 2.8 on the calc_back RHS (max rel gap 0.0) and the background equilibrium is bit-identical to the golden. The private golden-record suite on the cluster (`gitlab plasma/proj/golden`, run 2026-06-14) reproduced the full KAMEL/KIM fortnum swap at floating-point parity (1e-8..1e-16); the KIM.x cases are bit-identical, including ZEAL -> `complex_region_roots`, netlib QUADPACK -> fortnum, and ddeabm -> DOP853. No tolerance was weakened and no golden was regenerated. Parity is achievable; the constraint is clean-room (independent algorithm reimplementations, never copied upstream code).

Current CI on the in-repo ql-balance golden (rtol=1e-8, atol=1e-15):

| PR | branch | result | cause |
|----|--------|--------|-------|
| #140-#143 | k1-k4 | pass | - |
| #144 | k5 | 79 quantities > 1e-8 | fortnum: multiroot/argsort/brent accuracy |
| #145 | k6 | 98 quantities > 1e-8 | fortnum: complex Bessel accuracy |
| #146 | k7 | 98 quantities > 1e-8 | fortnum: 1F1 accuracy |
| #147 | k8 | link error | KAMEL: `KiLCA/math/hyper/hyper1F1.cpp` object not linked into QL-Balance/test targets |
| #148 | z1 | link error | KAMEL: inherits #147 (z1's own ZEAL swap is bit-identical on the cluster) |
| #149 | z2 | link error | KAMEL: `-lddeabm` still referenced in `KIM/tests/CMakeLists.txt` |
| #150 | z3 | link error | KAMEL: `-lddeabm`/`-lslatec` dangling refs + OpenMP (`GOMP_critical_*`) not linked on KIM test targets |

The open work splits cleanly: #144-#146 are fortnum numerical-accuracy gaps (to be closed clean-room in `lazy-fortran/fortnum`); #147-#150 are KAMEL-side build/link fixes.


Merge order: `#140 -> #141 -> #142 -> #143 -> #144 -> #145 -> #146 -> #147 -> #148 -> #149 -> #150`.

Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.
