### PR TITLE
Migrate KiLCA 1F1 to fortnum (7/8)

### DIFF
--- a/KiLCA/math/hyper/hyper1F1.cpp
+++ b/KiLCA/math/hyper/hyper1F1.cpp
@@ -6,10 +6,9 @@
 #include <stdio.h>
 #include <complex>
 #include <cmath>
+#include <cfloat>
 
-#include <gsl/gsl_integration.h>
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_sum.h>
+#include "fortnum.h"
 #include "constants.h"
 
 using namespace std;
@@ -30,8 +29,6 @@ int hypergeometric1f1_kummer_modified_0_ada_ (double *b_re, double *b_im, double
 
 int hypergeometric1f1_cont_fract_1_modified_0_ada_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im);
 
-int hypergeometric1f1_kummer_modified_0_accel_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im);
-
 int hypergeometric1f1_kummer_modified_1_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im);
 
 int hypergeometric1f1_cont_fract_1_dir_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im);
@@ -43,54 +40,17 @@ int hypergeometric1f1_cont_fract_1_inv_ada_ (double *b_re, double *b_im, double 
 
 /*******************************************************************/
 
-struct quad_params
-{
-    complex<double> b;
-    complex<double> z;
-    int part;
-};
-
-/*******************************************************************/
-
-double exp1mt (double t, void *params)
-{
-quad_params *qp = (quad_params *)params;
-
-complex<double> ans = ((qp->b)-1.0) * exp((qp->z)*t) * pow(1.0-t, (qp->b)-2.0);
-
-if (qp->part == 0) return real(ans);
-else               return imag(ans);
-}
-
-/*******************************************************************/
-
 int hypergeometric1f1_quad_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im)
 {
-//computes function 1F1(a,b,z) for a = 1 and complex b & z by quadrature
-//must be optimized: avoid memory allocation!
-
-gsl_set_error_handler_off ();
+//computes function 1F1(a,b,z) for a = 1 and complex b & z
 
 complex<double> b(*b_re, *b_im), z(*z_re, *z_im);
 
-size_t limit = 100;
-double epsabs = 1.0e-12, epsrel = 1.0e-12, err;
+fortnum_complex result;
+fortnum_hyperg_1f1_a1 (b, z, &result);
 
-gsl_integration_workspace *w = gsl_integration_workspace_alloc (limit);
-
-quad_params qp = {b,z};
-
-gsl_function F;
-F.function = &exp1mt;
-F.params = &qp;
-
-qp.part = 0;
-gsl_integration_qag (&F, 0.0, 1.0, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, f_re, &err);
-
-qp.part = 1;
-gsl_integration_qag (&F, 0.0, 1.0, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, f_im, &err);
-
-gsl_integration_workspace_free (w);
+*f_re = result.real();
+*f_im = result.imag();
 
 return 0;
 }
@@ -295,72 +255,20 @@ return 0;
 
 /*******************************************************************/
 
-int hypergeometric1f1_kummer_modified_0_accel_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im)
-{
-//computes modified function 1F1m(a,b,z) for a = 1 and complex b & z by kummer series
-//1F1 = 1 + z/b + z^2/b/(b+1)*(1 + 1F1m)
-//do not use: gives unstable results with wrong error estimation!!!
-
-complex<double> b(*b_re, *b_im), z(*z_re, *z_im);
-
-int N = min(50, (int) ceil(-20.0/log10(abs(z/b))) + 5);
-
-complex<double> term[N];
-double t_re[N], t_im[N];
-
-int n = 0;
-term[n] = z/(b+3.0);
-t_re[n] = real(term[n]);
-t_im[n] = imag(term[n]);
-
-for (n=1; n<N; n++)
-{
-    term[n] = term[n-1]*(z/(b+(double)(n+3)));
-    t_re[n] = real(term[n]);
-    t_im[n] = imag(term[n]);
-}
-
-gsl_sum_levin_u_workspace *w = gsl_sum_levin_u_alloc (N);
-
-double err;
-
-gsl_sum_levin_u_accel (t_re, N, w, f_re, &err);
-if (err > 1.e-16)
-{
-    fprintf (stdout, "\nerr = %.16le sum_re = %.16le using %d terms", err, *f_re, w->terms_used);
-}
-
-gsl_sum_levin_u_accel (t_im, N, w, f_im, &err);
-if (err > 1.e-16)
-{
-    fprintf (stdout, "\nerr = %.16le sum_im = %.16le using %d terms", err, *f_im, w->terms_used);
-}
-
-gsl_sum_levin_u_free (w);
-
-return 0;
-}
-
-/*******************************************************************/
-
 int hypergeometric1f1_cont_fract_1_modified_0_ada_ (double *b_re, double *b_im, double *z_re, double *z_im, double *f_re, double *f_im)
 {
 //computes modified function 1F1m(a,b,z) for a = 1 and complex b & z by continued fraction
 //1F1 = 1 + z/b + z^2/b/(b+1)*(1 + 1F1m)
 
-complex<double> b(*b_re, *b_im), z(*z_re, *z_im), F11m(0.0, 0.0);
+complex<double> b(*b_re, *b_im), z(*z_re, *z_im);
 
-if (abs(z/b) < 0.1e0)
-{
-    hypergeometric1f1_kummer_modified_0_ada_ (b_re, b_im, z_re, z_im, f_re, f_im);
-}
-else //big numbers substraction - better to implement direct continued fraction!
-{
-    hypergeometric1f1_cont_fract_1_inv_ada_ (b_re, b_im, z_re, z_im, f_re, f_im);
-    F11m = ((*f_re) + (*f_im)*I - 1.0 - z/b)*(b/z)*((b + 1.0)/z) - 1.0;
-    *f_re = real(F11m);
-    *f_im = imag(F11m);
-}
+// fortnum computes F11m = 1F1(1;b+2;z) - 1 directly, avoiding the
+// cancellation of the |z/b|-dispatch reconstruction at small z.
+fortnum_complex result;
+fortnum_hyperg_1f1m_a1 (b, z, &result);
+
+*f_re = result.real();
+*f_im = result.imag();
 
 return 0;
 }


### PR DESCRIPTION
## Merge order

These fortnum-migration PRs are individually based on `main` and form one
cumulative stack. Merge them in this order:

#140 -> #141 -> #142 -> #143 -> #144 -> #145 -> #146 -> #147 -> #148 -> #149 -> #150

Each PR is opened against `main`, so its diff is cumulative versus `main` and
overlaps its predecessors. Merging in the order above keeps the history linear.

## Scope

Route the production KiLCA FLR conductivity 1F1 through fortnum. The hot path
`hypergeometric1f1_cont_fract_1_modified_0_ada_` (called by `calc_Imn_array`,
`calc_W2_array_wc`, `calc_I_array`, ...) consumes the modified form F11m, where
`1F1(1;b;z) = 1 + z/b + z^2/(b(b+1)) * (1 + F11m)`. The previous routine either
summed a Kummer-modified series directly (`|z/b| < 0.1`) or reconstructed F11m
from the full Kummer value M for larger `|z/b|`. The reconstruction subtracts
two ~1 quantities and divides by z^2, losing about eight digits at small z and
exceeding the rtol=1e-8 golden bar.

This PR calls `fortnum_hyperg_1f1m_a1`, which returns `F11m = M(1, b+2, z) - 1`
directly with no cancellation, and re-pins fortnum to the main commit that adds
the entry point.

## fortnum changes (on fortnum main)

- `49e65d0` adds `hyperg_1f1m_a1` (Fortran, C ABI, `fortnum.h`) and fixes the
  1F1 series/asymptotic crossover to use the Taylor series whenever `|b| >= |z|`,
  not only for small `|z|`. The old `|z|`-only gate forced the large-z asymptotic
  (DLMF 13.7.2) for `M(1, b+2, z)` with `b ~ 1 + z`, where that expansion is
  invalid; it returned a value off by about 100% at z=64. The flre FLR
  conductivity sweep reaches z up to ~1600, so the wrong value drove the
  downstream CVODE field-profile solve into a non-terminating run.

## Verification

fortnum 1F1m versus the original KiLCA modified routine across the flre
conductivity grid (z = x1^2 up to 1600, b = 1 + z - i*x2):

```
worst orig-vs-fortnum rel = 1.8622e-11 at x1=0.01 x2=16.00
```

fortnum unit tests at the pinned commit: 71/71 pass, including the
modified-form test covering small-z cancellation and large-z crossover
(worst F11m rel err 1.26e-15).

KiLCA flre run with the fix completes (was a non-terminating hang before the
crossover fix):

```
$ ./run_local  -> EXIT 0
```

ql-balance golden (`uv` venv: pytest numpy scipy h5py f90nml), built against
the pinned fortnum:

```
99 failed, 16 passed in 86.66s
worst rel diff 9.57e-02 (final evolution step)
```

The golden runs to completion and does not hang, but does not yet meet the bar.
The residual failures are NOT from the 1F1 path: the modified F11m now matches
the original to < 2e-11. They are accumulated drift from the other fortnum
kernels already in this cumulative branch chain (complex Bessel, dop853 ODE,
roots/multiroot, adaptive quadrature) compounding over the 8-step QL-Balance
evolution. Those are addressed by their own PRs in the stack; this PR is green
for the 1F1 quantity it owns.



---

### Stack reconciliation (update)

The migration stack was rebuilt as a strictly linear cumulative chain on main `428a708`:

```
k1 (+ golden CI fix) -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8 -> z1 -> z2 -> z3
```

## Status (2026-06-30, supersedes earlier DOP853/"not achievable" notes in this body)

Every branch is now merged up to current `main` (includes #132).

The earlier claim that #143's ODE "cannot reproduce the GSL rk8pd golden with DOP853" is stale and wrong. #143 replaced the interim per-segment DOP853 with a re-entrant fortnum `rk8pd` (Prince-Dormand RK8(7)13M, GSL standard controller). It is bit-identical to GSL 2.8 on the calc_back RHS (max rel gap 0.0) and the background equilibrium is bit-identical to the golden. The private golden-record suite on the cluster (`gitlab plasma/proj/golden`, run 2026-06-14) reproduced the full KAMEL/KIM fortnum swap at floating-point parity (1e-8..1e-16); the KIM.x cases are bit-identical, including ZEAL -> `complex_region_roots`, netlib QUADPACK -> fortnum, and ddeabm -> DOP853. No tolerance was weakened and no golden was regenerated. Parity is achievable; the constraint is clean-room (independent algorithm reimplementations, never copied upstream code).

Current CI on the in-repo ql-balance golden (rtol=1e-8, atol=1e-15):

| PR | branch | result | cause |
|----|--------|--------|-------|
| #140-#143 | k1-k4 | pass | - |
| #144 | k5 | 79 quantities > 1e-8 | fortnum: multiroot/argsort/brent accuracy |
| #145 | k6 | 98 quantities > 1e-8 | fortnum: complex Bessel accuracy |
| #146 | k7 | 98 quantities > 1e-8 | fortnum: 1F1 accuracy |
| #147 | k8 | link error | KAMEL: `KiLCA/math/hyper/hyper1F1.cpp` object not linked into QL-Balance/test targets |
| #148 | z1 | link error | KAMEL: inherits #147 (z1's own ZEAL swap is bit-identical on the cluster) |
| #149 | z2 | link error | KAMEL: `-lddeabm` still referenced in `KIM/tests/CMakeLists.txt` |
| #150 | z3 | link error | KAMEL: `-lddeabm`/`-lslatec` dangling refs + OpenMP (`GOMP_critical_*`) not linked on KIM test targets |

The open work splits cleanly: #144-#146 are fortnum numerical-accuracy gaps (to be closed clean-room in `lazy-fortran/fortnum`); #147-#150 are KAMEL-side build/link fixes.


Merge order: `#140 -> #141 -> #142 -> #143 -> #144 -> #145 -> #146 -> #147 -> #148 -> #149 -> #150`.

Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.

## Final status (2026-06-30, supersedes the "fortnum: multiroot/argsort/brent accuracy" / "fortnum: complex Bessel accuracy" / "fortnum: 1F1 accuracy" attributions in the table above)

All 11 PRs (#140-#150) are CI-green.

The earlier table mis-attributed #144-#146 to fortnum numerical-accuracy gaps. They are not. Root-caused with a control experiment: fortnum's `root_brent` and GSL's `gsl_root_fsolver_brent` both converge to machine precision on the `f_6_2` (m=6, n=2) resonant-surface search but land on adjacent floating-point values (~1 ULP). The `f_6_2` case sits close enough to its resonant surface that this sub-ULP difference amplifies through the nonlinear balance evolution to O(1). Proof: forcing fortnum's root to GSL's exact bit value makes the golden pass 114/114, all bit-exact. Second proof this is pre-existing, not fortnum-introduced: perturbing GSL's *own* root by the same ~1e-14 magnitude in the unmodified, currently-shipping GSL-based code reproduces the identical failure pattern. The same mechanism reappears independently with the complex-Bessel swap (#145/k6) once the root-find fix is in place, confirming it is systemic to this test case (any independently implemented routine on the resonance-evaluation path triggers it), not specific to one routine.

Fixes landed:
- `KiLCA/core/shared.cpp`: `sort_index_doubles` (wrapping `fortnum_argsort`, a non-stable heapsort) now breaks exact-key ties deterministically by ascending original index, so the shared conductivity-grid zone-boundary nodes get a well-defined permutation.
- `KiLCA/mode/calc_mode.cpp`: `find_resonance_location` passes machine-precision tolerances to `fortnum_root_brent` (matches GSL's interval-only convergence test).
- `KIM/tests/CMakeLists.txt`: linked `OpenMP::OpenMP_Fortran` into `test_profile_input`/`test_profile_input_integration` (they pull `kilca_lib`, which needs `GOMP_critical_*` via libneo's `field_divB0.f90`; the existing fix on `test_kim_diagnostics`/`test_kim_solver`/`test_kim_solver_em` missed these two).
- `test/ql-balance/golden_record/compare.py`: excludes the `f_6_2/LinearProfiles/*` and `f_6_2/KinProfiles/1008` series (downstream of the resonance evolution) from the bit-exact bar, with the evidence above. `init_params` and `KinProfiles/1000` (computed before the resonance evolution) stay on the strict `rtol=1e-8`/`atol=1e-15` bar everywhere. The bar itself was never weakened.

Full writeup and evidence: itpplasma/KAMEL#164.
