### PR TITLE
Increase KIM test coverage and remove code duplication

### DIFF
--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -36,6 +36,7 @@ set(KIM_util util/findIndex.f90
             util/plag_coeff.f90
             util/constants_mod.f90
             util/IO_collection.f90
+            util/gauss_quadrature_m.f90
 )
 
 #set(KIM_kernels kernels/integrands.f90

--- a/KIM/src/background_equilibrium/profile_input_m.f90
+++ b/KIM/src/background_equilibrium/profile_input_m.f90
@@ -15,6 +15,8 @@ module profile_input_m
     private
 
     public :: prepare_profiles
+    ! I/O-free seams exercised by KIM/tests/test_profile_input*.f90
+    public :: classify_coordinate_type, calculate_derivative, compute_er_force_balance
 
     ! Coordinate detection threshold
     real(dp), parameter :: COORD_THRESHOLD = 2.0_dp
@@ -91,15 +93,28 @@ contains
         close(iunit)
 
         ! Determine coordinate type
-        if (max_r > COORD_THRESHOLD) then
-            detected_type = 'r_eff'
+        detected_type = classify_coordinate_type(max_r)
+        if (trim(detected_type) == 'r_eff') then
             write(*,*) 'Auto-detected coordinate type: r_eff (max_r = ', max_r, ' cm)'
         else
-            detected_type = 'sqrt_psiN'
             write(*,*) 'Auto-detected coordinate type: sqrt_psiN (max_r = ', max_r, ')'
         end if
 
     end subroutine detect_coordinate_type
+
+    function classify_coordinate_type(max_r) result(detected_type)
+        !> Pure coordinate-type decision: max_r above COORD_THRESHOLD => 'r_eff',
+        !> otherwise 'sqrt_psiN'. Shared by detect_coordinate_type and the tests.
+        real(dp), intent(in) :: max_r
+        character(20) :: detected_type
+
+        if (max_r > COORD_THRESHOLD) then
+            detected_type = 'r_eff'
+        else
+            detected_type = 'sqrt_psiN'
+        end if
+
+    end function classify_coordinate_type
 
     subroutine run_preprocessing()
         !> Run profile_preprocessor for sqrt_psiN -> r_eff transformation
@@ -316,7 +331,6 @@ contains
         implicit none
 
         real(dp), allocatable :: r(:), n(:), Ti(:), Vz(:), q(:), Er(:)
-        real(dp), allocatable :: dn_dr(:), dTi_dr(:)
         integer :: npts, i, iunit
         character(256) :: filename
         logical :: vz_exists
@@ -337,32 +351,9 @@ contains
             Vz = 0.0_dp
         end if
 
-        ! Calculate derivatives
-        allocate(dn_dr(npts), dTi_dr(npts), Er(npts))
-        call calculate_derivative(r, n, dn_dr, npts)
-        call calculate_derivative(r, Ti, dTi_dr, npts)
-
-        ! Calculate Er from radial force balance (CGS units)
-        ! From momentum balance: E_r = (T_i/e_i*n_i)*dn_i/dr + ((1-k)/e_i)*dT_i/dr + r*B0*Vtor/(c*q*R0)
-        ! With k=0 (no poloidal rotation):
-        ! E_r = (T_i*ev)/(e*n)*dn/dr + (ev/e)*dT/dr + r*B0*Vz/(c*q*R0)
-        ! Ti is in eV, convert to erg using ev = 1.6022e-12 erg/eV
-        ! e_charge = 4.803e-10 statcoulomb (CGS)
-        ! Er in statV/cm
-        do i = 1, npts
-            if (abs(n(i)) > 1.0e-20_dp) then
-                ! Term 1: (Ti*ev)/(e*n) * dn/dr (density gradient contribution)
-                Er(i) = (Ti(i) * ev / (e_charge * n(i))) * dn_dr(i)
-                ! Term 2: (ev/e) * dTi/dr (temperature gradient contribution, k=0)
-                Er(i) = Er(i) + (ev / e_charge) * dTi_dr(i)
-                ! Term 3: (r*B0*Vz)/(c*q*R0) (toroidal rotation contribution)
-                if (abs(q(i)) > 1.0e-10_dp .and. abs(R0) > 1.0e-10_dp) then
-                    Er(i) = Er(i) + (r(i) * btor * Vz(i)) / (sol * q(i) * R0)
-                end if
-            else
-                Er(i) = 0.0_dp
-            end if
-        end do
+        ! Calculate Er from radial force balance (CGS units), k=0 (no V_pol)
+        allocate(Er(npts))
+        call compute_er_force_balance(r, n, Ti, Vz, q, btor, R0, Er)
 
         ! Write to Er_no_Vpol.dat
         filename = trim(profile_location) // '/Er_no_Vpol.dat'
@@ -382,9 +373,45 @@ contains
         end do
         close(iunit)
 
-        deallocate(r, n, Ti, Vz, q, Er, dn_dr, dTi_dr)
+        deallocate(r, n, Ti, Vz, q, Er)
 
     end subroutine calculate_er_from_force_balance
+
+    subroutine compute_er_force_balance(r, n, Ti, Vz, q, btor_in, R0_in, Er)
+        !> Radial force-balance E_r (k=0, no poloidal rotation), CGS units (statV/cm):
+        !>   E_r = (T_i*ev)/(e*n) * dn/dr + (ev/e) * dT_i/dr + r*B0*Vz/(c*q*R0)
+        !> Ti in eV (ev converts to erg); e_charge in statcoulomb.
+        !> I/O-free; shared by calculate_er_from_force_balance and the tests.
+        real(dp), intent(in) :: r(:), n(:), Ti(:), Vz(:), q(:)
+        real(dp), intent(in) :: btor_in, R0_in
+        real(dp), intent(out) :: Er(:)
+
+        real(dp), allocatable :: dn_dr(:), dTi_dr(:)
+        integer :: npts, i
+
+        npts = size(r)
+        allocate(dn_dr(npts), dTi_dr(npts))
+        call calculate_derivative(r, n, dn_dr, npts)
+        call calculate_derivative(r, Ti, dTi_dr, npts)
+
+        do i = 1, npts
+            if (abs(n(i)) > 1.0e-20_dp) then
+                ! Term 1: (Ti*ev)/(e*n) * dn/dr (density gradient contribution)
+                Er(i) = (Ti(i) * ev / (e_charge * n(i))) * dn_dr(i)
+                ! Term 2: (ev/e) * dTi/dr (temperature gradient contribution, k=0)
+                Er(i) = Er(i) + (ev / e_charge) * dTi_dr(i)
+                ! Term 3: (r*B0*Vz)/(c*q*R0) (toroidal rotation contribution)
+                if (abs(q(i)) > 1.0e-10_dp .and. abs(R0_in) > 1.0e-10_dp) then
+                    Er(i) = Er(i) + (r(i) * btor_in * Vz(i)) / (sol * q(i) * R0_in)
+                end if
+            else
+                Er(i) = 0.0_dp
+            end if
+        end do
+
+        deallocate(dn_dr, dTi_dr)
+
+    end subroutine compute_er_force_balance
 
     subroutine read_profile_data(filename, r, data, npts)
         !> Read two-column profile data file

--- a/KIM/src/kernels/integrals.f90
+++ b/KIM/src/kernels/integrals.f90
@@ -3,6 +3,7 @@ module integrals_gauss_m
     ! uses gauss legendre quadrature for integration
 
     use KIM_kinds_m, only: dp
+    use gauss_quadrature_m, only: compute_nodes_weights, calc_xbar
 
     implicit none
 
@@ -59,7 +60,7 @@ module integrals_gauss_m
 
     subroutine gauss_integrate_F1(int_F1, result, gauss_conf)
 
-        use integrands_gauss_m, only: gauss_int_F1_rho_phi_t, calc_xbar
+        use integrands_gauss_m, only: gauss_int_F1_rho_phi_t
         use constants_m, only: pi
         use config_m, only: output_path
 
@@ -108,7 +109,7 @@ module integrals_gauss_m
 
     subroutine gauss_integrate_F2(int_F2, result, gauss_conf)
 
-        use integrands_gauss_m, only: gauss_int_F2_rho_phi_t, calc_xbar
+        use integrands_gauss_m, only: gauss_int_F2_rho_phi_t
         use constants_m, only: pi
 
         implicit none
@@ -156,7 +157,7 @@ module integrals_gauss_m
 
     subroutine gauss_integrate_F3(int_F3, result, gauss_conf)
 
-        use integrands_gauss_m, only: gauss_int_F3_rho_phi_t, calc_xbar
+        use integrands_gauss_m, only: gauss_int_F3_rho_phi_t
         use constants_m, only: pi
 
         implicit none
@@ -202,49 +203,5 @@ module integrals_gauss_m
         end do
 
     end subroutine
-
-    subroutine compute_nodes_weights(n, x, w)
-
-        implicit none
-
-        integer, intent(in) :: n
-        real(dp), intent(out) :: x(n), w(n)
-
-        integer :: i, j, m
-        real(dp) :: z, z1, p1, p2, p3, pp
-        real(dp), parameter :: EPS = 1.0d-14
-
-        m = (n + 1) / 2  ! number of roots to compute (use symmetry)
-
-        do i = 1, m
-            ! Initial guess (Chebyshev-Gauss nodes)
-            z = cos(3.14159265358979d0 * (i - 0.25d0) / (n + 0.5d0))
-
-            do
-                p1 = 1.0d0
-                p2 = 0.0d0
-                ! Evaluate Legendre polynomial using recurrence
-                do j = 1, n
-                    p3 = p2
-                    p2 = p1
-                    p1 = ((2.0d0 * j - 1.0d0) * z * p2 - (j - 1.0d0) * p3) / j
-                end do
-
-                ! Derivative of P_n
-                pp = n * (z * p1 - p2) / (z*z - 1.0d0)
-
-                z1 = z
-                z = z1 - p1 / pp  ! Newton-Raphson step
-
-                if (abs(z - z1) < EPS) exit
-            end do
-
-            x(i) = -z
-            x(n + 1 - i) = z
-            w(i) = 2.0d0 / ((1.0d0 - z*z) * pp * pp)
-            w(n + 1 - i) = w(i)
-        end do
-
-    end subroutine compute_nodes_weights
 
 end module integrals_gauss_m

--- a/KIM/src/kernels/integrals_adaptive.f90
+++ b/KIM/src/kernels/integrals_adaptive.f90
@@ -5,6 +5,7 @@ module integrals_rkf45_m
     use KIM_kinds_m, only: dp
     use constants_m, only: pi
     use integrands_rkf45_m, only: rkf45_integrand_context_t
+    use gauss_quadrature_m, only: compute_nodes_weights
 
     implicit none
 
@@ -451,49 +452,5 @@ module integrals_rkf45_m
         jac = 2.0d0 / max(sqrt(1.0d0 - uu*uu), 1.0d-300)
         val = rkf45_integrand_F3(theta, context) * jac
     end function
-
-    subroutine compute_nodes_weights(n, x, w)
-
-        implicit none
-
-        integer, intent(in) :: n
-        real(dp), intent(out) :: x(n), w(n)
-
-        integer :: i, j, m
-        real(dp) :: z, z1, p1, p2, p3, pp
-        real(dp), parameter :: EPS = 1.0d-14
-
-        m = (n + 1) / 2  ! number of roots to compute (use symmetry)
-
-        do i = 1, m
-            ! Initial guess (Chebyshev-Gauss nodes)
-            z = cos(3.14159265358979d0 * (i - 0.25d0) / (n + 0.5d0))
-
-            do
-                p1 = 1.0d0
-                p2 = 0.0d0
-                ! Evaluate Legendre polynomial using recurrence
-                do j = 1, n
-                    p3 = p2
-                    p2 = p1
-                    p1 = ((2.0d0 * j - 1.0d0) * z * p2 - (j - 1.0d0) * p3) / j
-                end do
-
-                ! Derivative of P_n
-                pp = n * (z * p1 - p2) / (z*z - 1.0d0)
-
-                z1 = z
-                z = z1 - p1 / pp  ! Newton-Raphson step
-
-                if (abs(z - z1) < EPS) exit
-            end do
-
-            x(i) = -z
-            x(n + 1 - i) = z
-            w(i) = 2.0d0 / ((1.0d0 - z*z) * pp * pp)
-            w(n + 1 - i) = w(i)
-        end do
-
-    end subroutine compute_nodes_weights
 
 end module integrals_rkf45_m

--- a/KIM/src/kernels/integrals_adaptive.f90
+++ b/KIM/src/kernels/integrals_adaptive.f90
@@ -73,7 +73,7 @@ module integrals_rkf45_m
         real(dp), intent(out) :: result
 
         if (trim(theta_integration_method) == "QUADPACK") then
-            call quadpack_integrate_F1_wrapper(result, rkf45_conf, context)
+            call quadpack_integrate_wrapper(1, result, rkf45_conf, context)
         else
             call rkf45_integrate_F1(result, rkf45_conf, context)
         end if
@@ -88,7 +88,7 @@ module integrals_rkf45_m
         real(dp), intent(out) :: result
 
         if (trim(theta_integration_method) == "QUADPACK") then
-            call quadpack_integrate_F2_wrapper(result, rkf45_conf, context)
+            call quadpack_integrate_wrapper(2, result, rkf45_conf, context)
         else
             call rkf45_integrate_F2(result, rkf45_conf, context)
         end if
@@ -103,7 +103,7 @@ module integrals_rkf45_m
         real(dp), intent(out) :: result
 
         if (trim(theta_integration_method) == "QUADPACK") then
-            call quadpack_integrate_F3_wrapper(result, rkf45_conf, context)
+            call quadpack_integrate_wrapper(3, result, rkf45_conf, context)
         else
             call rkf45_integrate_F3(result, rkf45_conf, context)
         end if
@@ -264,14 +264,18 @@ module integrals_rkf45_m
 
     end subroutine
 
-    ! QUADPACK wrapper functions
-    subroutine quadpack_integrate_F1_wrapper(result, rkf45_conf, context)
+    ! QUADPACK wrapper: integrates the theta direction with QUADPACK for the
+    ! requested integrand (which = 1, 2 or 3). The three variants differed only
+    ! in which quadpack_integrate_F* they called and the final scale factor.
+    subroutine quadpack_integrate_wrapper(which, result, rkf45_conf, context)
         use integrands_rkf45_m, only: rkf45_integrand_context_t
         use constants_m, only: pi
-        use quadpack_integration_m, only: quadpack_integrate_F1, init_quadpack_module
+        use quadpack_integration_m, only: quadpack_integrate_F1, quadpack_integrate_F2, &
+                                          quadpack_integrate_F3, init_quadpack_module
         use grid_m, only: quadpack_epsabs, quadpack_epsrel, quadpack_use_u_substitution
 
         implicit none
+        integer, intent(in) :: which
         type(rkf45_integrand_context_t), intent(inout) :: context
         type(rkf45_config_t), intent(in) :: rkf45_conf
         real(dp), intent(out) :: result
@@ -300,8 +304,17 @@ module integrals_rkf45_m
                 context%x = 0.5d0 * ((context%xlp1 - context%xlm1) * rkf45_conf%x_x(k) + context%xlp1 + context%xlm1)
 
                 quadpack_res = 0.0d0
-                call quadpack_integrate_F1(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
-                                          theta_0_local, theta_max_local, quadpack_use_u_substitution)
+                select case (which)
+                case (1)
+                    call quadpack_integrate_F1(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
+                                              theta_0_local, theta_max_local, quadpack_use_u_substitution)
+                case (2)
+                    call quadpack_integrate_F2(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
+                                              theta_0_local, theta_max_local, quadpack_use_u_substitution)
+                case (3)
+                    call quadpack_integrate_F3(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
+                                              theta_0_local, theta_max_local, quadpack_use_u_substitution)
+                end select
 
                 result = result + rkf45_conf%w_xp(j) * rkf45_conf%w_x(k) * quadpack_res
             end do
@@ -310,103 +323,15 @@ module integrals_rkf45_m
 
         result = result * exp(-context%ks**2.0d0 * context%rhoT**2.0d0) * norm_factor
 
-    end subroutine quadpack_integrate_F1_wrapper
+        ! F2/F3 carry an additional -pi/(c*rhoT^4) factor
+        select case (which)
+        case (2)
+            result = result * (-pi) / (4.0d0 * context%rhoT**4.0d0)
+        case (3)
+            result = result * (-pi) / (2.0d0 * context%rhoT**4.0d0)
+        end select
 
-    subroutine quadpack_integrate_F2_wrapper(result, rkf45_conf, context)
-        use integrands_rkf45_m, only: rkf45_integrand_context_t
-        use constants_m, only: pi
-        use quadpack_integration_m, only: quadpack_integrate_F2, init_quadpack_module
-        use grid_m, only: quadpack_epsabs, quadpack_epsrel, quadpack_use_u_substitution
-
-        implicit none
-        type(rkf45_integrand_context_t), intent(inout) :: context
-        type(rkf45_config_t), intent(in) :: rkf45_conf
-        real(dp), intent(out) :: result
-        real(dp) :: norm_factor
-        real(dp) :: theta_0_local, theta_max_local, theta_eps, delta, denom
-        real(dp) :: quadpack_res
-        integer :: j, k
-
-        ! Initialize QUADPACK module if needed
-        call init_quadpack_module()
-
-        result = 0.0d0
-        norm_factor = (context%xlp1 - context%xlm1) * (context%xlpp1 - context%xlpm1) / 4.0d0
-
-        ! Endpoint exclusion
-        delta = abs(context%x - context%xp)
-        denom = max(abs(context%rhoT), 1.0d-300)
-        theta_eps = max(theta_cutoff_min, min(0.2d0, delta / (sqrt(2.0d0*theta_M) * denom)))
-        theta_0_local = theta_eps
-        theta_max_local = pi - theta_eps
-
-        !$omp parallel do collapse(2) private(j, k, quadpack_res) firstprivate(context) reduction(+:result)
-        do j = 1, rkf45_conf%Nxp
-            do k = 1, rkf45_conf%Nx
-                context%xp = 0.5d0 * ((context%xlpp1 - context%xlpm1) * rkf45_conf%x_xp(j) + context%xlpp1 + context%xlpm1)
-                context%x = 0.5d0 * ((context%xlp1 - context%xlm1) * rkf45_conf%x_x(k) + context%xlp1 + context%xlm1)
-
-                quadpack_res = 0.0d0
-                call quadpack_integrate_F2(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
-                                          theta_0_local, theta_max_local, quadpack_use_u_substitution)
-
-                result = result + rkf45_conf%w_xp(j) * rkf45_conf%w_x(k) * quadpack_res
-            end do
-        end do
-        !$omp end parallel do
-
-        result = result * exp(-context%ks**2.0d0 * context%rhoT**2.0d0) * norm_factor &
-                * (-pi) / (4.0d0 * context%rhoT**4.0d0)
-
-    end subroutine quadpack_integrate_F2_wrapper
-
-    subroutine quadpack_integrate_F3_wrapper(result, rkf45_conf, context)
-        use integrands_rkf45_m, only: rkf45_integrand_context_t
-        use constants_m, only: pi
-        use quadpack_integration_m, only: quadpack_integrate_F3, init_quadpack_module
-        use grid_m, only: quadpack_epsabs, quadpack_epsrel, quadpack_use_u_substitution
-
-        implicit none
-        type(rkf45_integrand_context_t), intent(inout) :: context
-        type(rkf45_config_t), intent(in) :: rkf45_conf
-        real(dp), intent(out) :: result
-        real(dp) :: norm_factor
-        real(dp) :: theta_0_local, theta_max_local, theta_eps, delta, denom
-        real(dp) :: quadpack_res
-        integer :: j, k
-
-        ! Initialize QUADPACK module if needed
-        call init_quadpack_module()
-
-        result = 0.0d0
-        norm_factor = (context%xlp1 - context%xlm1) * (context%xlpp1 - context%xlpm1) / 4.0d0
-
-        ! Endpoint exclusion
-        delta = abs(context%x - context%xp)
-        denom = max(abs(context%rhoT), 1.0d-300)
-        theta_eps = max(theta_cutoff_min, min(0.2d0, delta / (sqrt(2.0d0*theta_M) * denom)))
-        theta_0_local = theta_eps
-        theta_max_local = pi - theta_eps
-
-        !$omp parallel do collapse(2) private(j, k, quadpack_res) firstprivate(context) reduction(+:result)
-        do j = 1, rkf45_conf%Nxp
-            do k = 1, rkf45_conf%Nx
-                context%xp = 0.5d0 * ((context%xlpp1 - context%xlpm1) * rkf45_conf%x_xp(j) + context%xlpp1 + context%xlpm1)
-                context%x = 0.5d0 * ((context%xlp1 - context%xlm1) * rkf45_conf%x_x(k) + context%xlp1 + context%xlm1)
-
-                quadpack_res = 0.0d0
-                call quadpack_integrate_F3(quadpack_res, quadpack_epsabs, quadpack_epsrel, context, &
-                                          theta_0_local, theta_max_local, quadpack_use_u_substitution)
-
-                result = result + rkf45_conf%w_xp(j) * rkf45_conf%w_x(k) * quadpack_res
-            end do
-        end do
-        !$omp end parallel do
-
-        result = result * exp(-context%ks**2.0d0 * context%rhoT**2.0d0) * norm_factor &
-                * (-pi) / (2.0d0 * context%rhoT**4.0d0)
-
-    end subroutine quadpack_integrate_F3_wrapper
+    end subroutine quadpack_integrate_wrapper
 
     ! Mapped integrands: u = sin(theta/2), theta = 2*asin(u)
     ! Include Jacobian dtheta/du = 2/sqrt(1-u^2)

--- a/KIM/src/kernels/integrands.f90
+++ b/KIM/src/kernels/integrands.f90
@@ -256,15 +256,4 @@ module integrands_gauss_m
 
     end subroutine
 
-    function calc_xbar(x,xp) result(xbar)
-
-        implicit none
-
-        real(dp), intent(in) :: x, xp
-        real(dp) :: xbar
-
-        xbar = 0.5d0 * (xp + x)
-
-    end function
-
 end module integrands_gauss_m

--- a/KIM/src/kernels/integrands_adaptive.f90
+++ b/KIM/src/kernels/integrands_adaptive.f90
@@ -2,6 +2,7 @@
 module integrands_rkf45_m
 
     use KIM_kinds_m, only: dp
+    use gauss_quadrature_m, only: calc_xbar
 
     implicit none
 
@@ -168,17 +169,6 @@ module integrands_rkf45_m
 
     end function
 
-
-    function calc_xbar(x,xp) result(xbar)
-
-        implicit none
-
-        real(dp), intent(in) :: x, xp
-        real(dp) :: xbar
-
-        xbar = 0.5d0 * (xp + x)
-
-    end function
 
     function Jrg1(a, b, j)
 

--- a/KIM/src/util/gauss_quadrature_m.f90
+++ b/KIM/src/util/gauss_quadrature_m.f90
@@ -1,0 +1,71 @@
+module gauss_quadrature_m
+    !> Shared Gauss-Legendre quadrature helpers for the integration paths.
+    !> Previously duplicated byte-for-byte: compute_nodes_weights in
+    !> integrals_gauss_m / integrals_rkf45_m, and calc_xbar in
+    !> integrands_gauss_m / integrands_rkf45_m.
+
+    use KIM_kinds_m, only: dp
+
+    implicit none
+    private
+
+    public :: compute_nodes_weights, calc_xbar
+
+contains
+
+    subroutine compute_nodes_weights(n, x, w)
+
+        implicit none
+
+        integer, intent(in) :: n
+        real(dp), intent(out) :: x(n), w(n)
+
+        integer :: i, j, m
+        real(dp) :: z, z1, p1, p2, p3, pp
+        real(dp), parameter :: EPS = 1.0d-14
+
+        m = (n + 1) / 2  ! number of roots to compute (use symmetry)
+
+        do i = 1, m
+            ! Initial guess (Chebyshev-Gauss nodes)
+            z = cos(3.14159265358979d0 * (i - 0.25d0) / (n + 0.5d0))
+
+            do
+                p1 = 1.0d0
+                p2 = 0.0d0
+                ! Evaluate Legendre polynomial using recurrence
+                do j = 1, n
+                    p3 = p2
+                    p2 = p1
+                    p1 = ((2.0d0 * j - 1.0d0) * z * p2 - (j - 1.0d0) * p3) / j
+                end do
+
+                ! Derivative of P_n
+                pp = n * (z * p1 - p2) / (z*z - 1.0d0)
+
+                z1 = z
+                z = z1 - p1 / pp  ! Newton-Raphson step
+
+                if (abs(z - z1) < EPS) exit
+            end do
+
+            x(i) = -z
+            x(n + 1 - i) = z
+            w(i) = 2.0d0 / ((1.0d0 - z*z) * pp * pp)
+            w(n + 1 - i) = w(i)
+        end do
+
+    end subroutine compute_nodes_weights
+
+    function calc_xbar(x, xp) result(xbar)
+
+        implicit none
+
+        real(dp), intent(in) :: x, xp
+        real(dp) :: xbar
+
+        xbar = 0.5d0 * (xp + x)
+
+    end function calc_xbar
+
+end module gauss_quadrature_m

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -32,7 +32,9 @@ add_executable(test_profile_input ${CMAKE_SOURCE_DIR}/KIM/tests/test_profile_inp
 set_target_properties(test_profile_input PROPERTIES
                         OUTPUT_NAME test_profile_input.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_profile_input KIM_lib)
+# Links the full math set: using profile_input_m pulls KIM objects whose
+# transitive deps (W2_arr) need the hypergeometric routines from KiLCA/slatec.
+target_link_libraries(test_profile_input KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
 add_test(NAME test_profile_input
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_profile_input.x)
 
@@ -40,7 +42,7 @@ add_executable(test_profile_input_integration ${CMAKE_SOURCE_DIR}/KIM/tests/test
 set_target_properties(test_profile_input_integration PROPERTIES
                         OUTPUT_NAME test_profile_input_integration.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_profile_input_integration KIM_lib)
+target_link_libraries(test_profile_input_integration KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
 add_test(NAME test_profile_input_integration
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_profile_input_integration.x)
 

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -53,3 +53,30 @@ set_target_properties(test_ampere_matrices PROPERTIES
 target_link_libraries(test_ampere_matrices KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
 add_test(NAME test_ampere_matrices
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_ampere_matrices.x)
+
+# Pure-utility unit tests (Lagrange coefficients, binary search, index lookup,
+# equidistant grid generation). Full math link set: pulling these KIM objects
+# drags transitive deps (W2_arr) needing hypergeometric routines from KiLCA/slatec.
+add_executable(test_plag_coeff ${CMAKE_SOURCE_DIR}/KIM/tests/test_plag_coeff.f90)
+set_target_properties(test_plag_coeff PROPERTIES
+                        OUTPUT_NAME test_plag_coeff.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_plag_coeff KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
+add_test(NAME test_plag_coeff
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_plag_coeff.x)
+
+add_executable(test_findIndex ${CMAKE_SOURCE_DIR}/KIM/tests/test_findIndex.f90)
+set_target_properties(test_findIndex PROPERTIES
+                        OUTPUT_NAME test_findIndex.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_findIndex KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
+add_test(NAME test_findIndex
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_findIndex.x)
+
+add_executable(test_grid_equidistant ${CMAKE_SOURCE_DIR}/KIM/tests/test_grid_equidistant.f90)
+set_target_properties(test_grid_equidistant PROPERTIES
+                        OUTPUT_NAME test_grid_equidistant.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_grid_equidistant KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
+add_test(NAME test_grid_equidistant
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_grid_equidistant.x)

--- a/KIM/tests/test_findIndex.f90
+++ b/KIM/tests/test_findIndex.f90
@@ -1,0 +1,49 @@
+program test_findIndex
+    !> Unit tests for find_index_m%findClosestIndex: returns the index of the
+    !> array element nearest a target value (used for grid/profile lookups).
+    use KIM_kinds_m, only: dp
+    use find_index_m, only: findClosestIndex
+    implicit none
+
+    logical :: all_passed
+    real(dp) :: arr(4)
+    integer :: idx
+
+    all_passed = .true.
+    arr = [1.0_dp, 5.0_dp, 10.0_dp, 20.0_dp]
+
+    call findClosestIndex(arr, 6.0_dp, idx)
+    call report('closest to 6.0 is 5.0 (idx 2)', idx == 2, all_passed)
+
+    call findClosestIndex(arr, -3.0_dp, idx)
+    call report('below range -> first element (idx 1)', idx == 1, all_passed)
+
+    call findClosestIndex(arr, 100.0_dp, idx)
+    call report('above range -> last element (idx 4)', idx == 4, all_passed)
+
+    call findClosestIndex(arr, 10.0_dp, idx)
+    call report('exact match (idx 3)', idx == 3, all_passed)
+
+    if (all_passed) then
+        print *, 'All findIndex tests PASSED'
+        stop 0
+    else
+        print *, 'Some findIndex tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    subroutine report(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name
+            passed = .false.
+        end if
+    end subroutine report
+
+end program test_findIndex

--- a/KIM/tests/test_grid_equidistant.f90
+++ b/KIM/tests/test_grid_equidistant.f90
@@ -1,0 +1,61 @@
+program test_grid_equidistant
+    !> Unit test for grid_m equidistant grid generation: uniform spacing,
+    !> first boundary at min_val, and cell centres at boundary midpoints.
+    !> Exercises grid_init_equidistant + grid_generate_equidistant, which in
+    !> turn drive binsrc and plag_coeff for the difference-operator stencils.
+    use KIM_kinds_m, only: dp
+    use grid_m, only: grid_type
+    use kim_resonances_m, only: r_res
+    implicit none
+
+    type(grid_type) :: g
+    integer :: npts, i
+    real(dp) :: h
+    logical :: all_passed, uniform
+    real(dp), parameter :: tol = 1.0e-12_dp
+
+    all_passed = .true.
+    r_res = 0.0_dp      ! deterministic: avoids reading uninitialised module state in binsrc
+
+    npts = 11
+    call g%grid_init_equidistant(npts, 1.0_dp, 6.0_dp, 'test')
+    call g%grid_generate_equidistant()
+
+    h = (6.0_dp - 1.0_dp) / 11.0_dp
+
+    call report('npts_b set to requested count', g%npts_b == 11, all_passed)
+    call report('npts_c = npts_b - 1', g%npts_c == 10, all_passed)
+    call report('first boundary == min_val', abs(g%xb(1) - 1.0_dp) < tol, all_passed)
+
+    uniform = .true.
+    do i = 2, g%npts_b
+        if (abs((g%xb(i) - g%xb(i-1)) - h) > tol) uniform = .false.
+    end do
+    call report('uniform boundary spacing h', uniform, all_passed)
+
+    call report('cell centre is boundary midpoint', &
+                abs(g%xc(1) - 0.5_dp * (g%xb(1) + g%xb(2))) < tol, all_passed)
+
+    if (all_passed) then
+        print *, 'All grid tests PASSED'
+        stop 0
+    else
+        print *, 'Some grid tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    subroutine report(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name
+            passed = .false.
+        end if
+    end subroutine report
+
+end program test_grid_equidistant

--- a/KIM/tests/test_plag_coeff.f90
+++ b/KIM/tests/test_plag_coeff.f90
@@ -1,0 +1,120 @@
+program test_plag_coeff
+    !> Unit tests for the Lagrange-coefficient and binary-search utilities in
+    !> KIM/src/util/plag_coeff.f90 (binsrc, plag_coeff). Both are external
+    !> (non-module) subroutines, called here through an implicit interface.
+    !> These routines underpin grid generation and finite-difference operators.
+    use KIM_kinds_m, only: dp
+    implicit none
+
+    logical :: all_passed
+    all_passed = .true.
+
+    call test_binsrc_interior(all_passed)
+    call test_binsrc_upper(all_passed)
+    call test_plag_partition_of_unity(all_passed)
+    call test_plag_interpolation_cubic(all_passed)
+    call test_plag_first_derivative(all_passed)
+    call test_plag_second_derivative(all_passed)
+
+    if (all_passed) then
+        print *, 'All plag_coeff tests PASSED'
+        stop 0
+    else
+        print *, 'Some plag_coeff tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    !> Test polynomial: f(x) = 2x^3 - 3x^2 + x + 5
+    !> f'(x) = 6x^2 - 6x + 1 ; f''(x) = 12x - 6
+    pure function f(x) result(y)
+        real(dp), intent(in) :: x
+        real(dp) :: y
+        y = 2.0_dp*x**3 - 3.0_dp*x**2 + x + 5.0_dp
+    end function f
+
+    subroutine test_binsrc_interior(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: p(5)
+        integer :: idx
+        p = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp, 50.0_dp]
+        call binsrc(p, 1, 5, 25.0_dp, idx)
+        call report('binsrc: 25 lies in (p2,p3] -> idx 3', idx == 3, passed)
+    end subroutine test_binsrc_interior
+
+    subroutine test_binsrc_upper(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: p(5)
+        integer :: idx
+        p = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp, 50.0_dp]
+        call binsrc(p, 1, 5, 45.0_dp, idx)
+        call report('binsrc: 45 lies in (p4,p5] -> idx 5', idx == 5, passed)
+    end subroutine test_binsrc_upper
+
+    subroutine test_plag_partition_of_unity(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: xp(4), coef(0:2, 4)
+        xp = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        call plag_coeff(4, 2, 1.5_dp, xp, coef)
+        call report('plag: value weights sum to 1', &
+                    abs(sum(coef(0, :)) - 1.0_dp) < 1.0e-12_dp, passed)
+    end subroutine test_plag_partition_of_unity
+
+    subroutine test_plag_interpolation_cubic(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: xp(4), coef(0:2, 4), interp
+        integer :: i
+        xp = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        call plag_coeff(4, 2, 1.5_dp, xp, coef)
+        interp = 0.0_dp
+        do i = 1, 4
+            interp = interp + coef(0, i) * f(xp(i))
+        end do
+        call report('plag: exact value for cubic at x=1.5', &
+                    abs(interp - f(1.5_dp)) < 1.0e-9_dp, passed)
+    end subroutine test_plag_interpolation_cubic
+
+    subroutine test_plag_first_derivative(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: xp(4), coef(0:2, 4), d1
+        integer :: i
+        xp = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        call plag_coeff(4, 2, 1.5_dp, xp, coef)
+        d1 = 0.0_dp
+        do i = 1, 4
+            d1 = d1 + coef(1, i) * f(xp(i))
+        end do
+        ! f'(1.5) = 6*2.25 - 6*1.5 + 1 = 5.5
+        call report('plag: exact 1st derivative at x=1.5', &
+                    abs(d1 - 5.5_dp) < 1.0e-9_dp, passed)
+    end subroutine test_plag_first_derivative
+
+    subroutine test_plag_second_derivative(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: xp(4), coef(0:2, 4), d2
+        integer :: i
+        xp = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        call plag_coeff(4, 2, 1.5_dp, xp, coef)
+        d2 = 0.0_dp
+        do i = 1, 4
+            d2 = d2 + coef(2, i) * f(xp(i))
+        end do
+        ! f''(1.5) = 12*1.5 - 6 = 12
+        call report('plag: exact 2nd derivative at x=1.5', &
+                    abs(d2 - 12.0_dp) < 1.0e-9_dp, passed)
+    end subroutine test_plag_second_derivative
+
+    subroutine report(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name
+            passed = .false.
+        end if
+    end subroutine report
+
+end program test_plag_coeff

--- a/KIM/tests/test_profile_input.f90
+++ b/KIM/tests/test_profile_input.f90
@@ -1,12 +1,18 @@
 program test_profile_input
+    !> Unit tests for coordinate-type detection in profile_input_m.
+    !> Exercises the production classify_coordinate_type directly (no inline copy),
+    !> so the COORD_THRESHOLD decision is guarded by this test.
     use KIM_kinds_m, only: dp
+    use profile_input_m, only: classify_coordinate_type
     implicit none
 
     logical :: all_passed
     all_passed = .true.
 
-    call test_coord_detection_reff(all_passed)
-    call test_coord_detection_psiN(all_passed)
+    call check('r_eff well above threshold', classify_coordinate_type(45.0_dp),   'r_eff',     all_passed)
+    call check('r_eff just above threshold', classify_coordinate_type(2.0001_dp), 'r_eff',     all_passed)
+    call check('sqrt_psiN below threshold',  classify_coordinate_type(0.95_dp),   'sqrt_psiN', all_passed)
+    call check('sqrt_psiN at threshold',     classify_coordinate_type(2.0_dp),    'sqrt_psiN', all_passed)
 
     if (all_passed) then
         print *, 'All tests PASSED'
@@ -18,57 +24,16 @@ program test_profile_input
 
 contains
 
-    subroutine test_coord_detection_reff(passed)
+    subroutine check(name, got, expected, passed)
+        character(*), intent(in) :: name, got, expected
         logical, intent(inout) :: passed
-        real(dp) :: test_data(5)
-        character(20) :: result
 
-        ! r_eff data: max > 2.0
-        test_data = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp, 45.0_dp]
-        call detect_from_data(test_data, 5, result)
-
-        if (trim(result) /= 'r_eff') then
-            print *, 'FAIL: test_coord_detection_reff'
-            print *, '  Expected: r_eff'
-            print *, '  Got: ', trim(result)
+        if (trim(got) == trim(expected)) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name, ' expected=', trim(expected), ' got=', trim(got)
             passed = .false.
-        else
-            print *, 'PASS: test_coord_detection_reff'
         end if
-    end subroutine
-
-    subroutine test_coord_detection_psiN(passed)
-        logical, intent(inout) :: passed
-        real(dp) :: test_data(5)
-        character(20) :: result
-
-        ! sqrt_psiN data: max <= 2.0
-        test_data = [0.1_dp, 0.3_dp, 0.5_dp, 0.7_dp, 0.95_dp]
-        call detect_from_data(test_data, 5, result)
-
-        if (trim(result) /= 'sqrt_psiN') then
-            print *, 'FAIL: test_coord_detection_psiN'
-            print *, '  Expected: sqrt_psiN'
-            print *, '  Got: ', trim(result)
-            passed = .false.
-        else
-            print *, 'PASS: test_coord_detection_psiN'
-        end if
-    end subroutine
-
-    subroutine detect_from_data(data, n, coord_type)
-        real(dp), intent(in) :: data(:)
-        integer, intent(in) :: n
-        character(20), intent(out) :: coord_type
-        real(dp) :: max_val
-        real(dp), parameter :: COORD_THRESHOLD = 2.0_dp
-
-        max_val = maxval(data(1:n))
-        if (max_val > COORD_THRESHOLD) then
-            coord_type = 'r_eff'
-        else
-            coord_type = 'sqrt_psiN'
-        end if
-    end subroutine detect_from_data
+    end subroutine check
 
 end program test_profile_input

--- a/KIM/tests/test_profile_input_integration.f90
+++ b/KIM/tests/test_profile_input_integration.f90
@@ -1,13 +1,17 @@
 program test_profile_input_integration
-    !> Integration tests for profile_input_m module
+    !> Integration tests for profile_input_m: exercise the production
+    !> calculate_derivative and compute_er_force_balance routines directly
+    !> (no inline reimplementation of the force-balance formula).
     use KIM_kinds_m, only: dp
+    use profile_input_m, only: calculate_derivative, compute_er_force_balance
     implicit none
 
     logical :: all_passed
     all_passed = .true.
 
-    call test_auto_detection_reff(all_passed)
-    call test_er_calculation_creates_file(all_passed)
+    call test_derivative_linear(all_passed)
+    call test_er_sign_decreasing(all_passed)
+    call test_er_zero_for_flat(all_passed)
 
     if (all_passed) then
         print *, 'All integration tests PASSED'
@@ -19,78 +23,64 @@ program test_profile_input_integration
 
 contains
 
-    subroutine test_auto_detection_reff(passed)
-        !> Test that auto-detection correctly identifies r_eff coordinates
-        !> when max(r) > 2.0
+    subroutine test_derivative_linear(passed)
+        !> Forward/central/backward differences are exact for a linear profile:
+        !> y = 3 r + 1  =>  dy/dr = 3 at every node.
         logical, intent(inout) :: passed
-        real(dp) :: test_data(4)
-        character(20) :: result
-        real(dp), parameter :: COORD_THRESHOLD = 2.0_dp
+        real(dp) :: r(4), y(4), dydx(4)
+        real(dp), parameter :: tol = 1.0e-10_dp
 
-        ! r_eff data from test_data/n.dat (max = 40.0)
-        test_data = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp]
-
-        ! Test threshold detection
-        if (maxval(test_data) > COORD_THRESHOLD) then
-            result = 'r_eff'
-        else
-            result = 'sqrt_psiN'
-        end if
-
-        if (trim(result) == 'r_eff') then
-            print *, 'PASS: test_auto_detection_reff'
-        else
-            print *, 'FAIL: test_auto_detection_reff'
-            print *, '  Expected: r_eff'
-            print *, '  Got: ', trim(result)
-            passed = .false.
-        end if
-    end subroutine test_auto_detection_reff
-
-    subroutine test_er_calculation_creates_file(passed)
-        !> Test that Er calculation works with valid input
-        !> Uses profile data to calculate Er from force balance
-        logical, intent(inout) :: passed
-
-        ! This test validates the Er calculation formula
-        ! Er = (Ti/n)*dn/dr + dTi/dr + (r*B0*Vz)/(c*q*R0)
-        ! With Vz=0, Er simplifies to pressure gradient terms
-
-        real(dp) :: r(4), n(4), Ti(4), dn_dr(4), dTi_dr(4)
-        real(dp) :: Er_calc
-        integer :: i
-
-        ! Test data matching test_data files
         r = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp]
-        n = [1.0e19_dp, 8.0e18_dp, 5.0e18_dp, 2.0e18_dp]
+        y = 3.0_dp * r + 1.0_dp
+        call calculate_derivative(r, y, dydx, 4)
+
+        call report('derivative exact for linear profile', &
+                    maxval(abs(dydx - 3.0_dp)) < tol, passed)
+    end subroutine test_derivative_linear
+
+    subroutine test_er_sign_decreasing(passed)
+        !> Decreasing n and Ti with Vz = 0  =>  Er < 0 at interior nodes
+        !> (both pressure-gradient terms are negative).
+        logical, intent(inout) :: passed
+        real(dp) :: r(4), n(4), Ti(4), Vz(4), q(4), Er(4)
+
+        r  = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp]
+        n  = [1.0e19_dp, 8.0e18_dp, 5.0e18_dp, 2.0e18_dp]
         Ti = [1800.0_dp, 1600.0_dp, 1000.0_dp, 500.0_dp]
+        Vz = 0.0_dp
+        q  = 1.0_dp
+        call compute_er_force_balance(r, n, Ti, Vz, q, 2.5_dp, 165.0_dp, Er)
 
-        ! Calculate derivatives (simplified for test)
-        dn_dr(1) = (n(2) - n(1)) / (r(2) - r(1))
-        dn_dr(2) = (n(3) - n(1)) / (r(3) - r(1))
-        dn_dr(3) = (n(4) - n(2)) / (r(4) - r(2))
-        dn_dr(4) = (n(4) - n(3)) / (r(4) - r(3))
+        call report('Er < 0 for decreasing profiles (interior node)', &
+                    Er(2) < 0.0_dp, passed)
+    end subroutine test_er_sign_decreasing
 
-        dTi_dr(1) = (Ti(2) - Ti(1)) / (r(2) - r(1))
-        dTi_dr(2) = (Ti(3) - Ti(1)) / (r(3) - r(1))
-        dTi_dr(3) = (Ti(4) - Ti(2)) / (r(4) - r(2))
-        dTi_dr(4) = (Ti(4) - Ti(3)) / (r(4) - r(3))
+    subroutine test_er_zero_for_flat(passed)
+        !> Constant n and Ti with Vz = 0  =>  Er = 0 everywhere.
+        logical, intent(inout) :: passed
+        real(dp) :: r(4), n(4), Ti(4), Vz(4), q(4), Er(4)
+        real(dp), parameter :: tol = 1.0e-12_dp
 
-        ! With Vz=0, Er = (Ti/n)*dn/dr + dTi/dr
-        ! Check one point (i=2)
-        i = 2
-        Er_calc = (Ti(i) / n(i)) * dn_dr(i) + dTi_dr(i)
+        r  = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp]
+        n  = 5.0e18_dp
+        Ti = 1000.0_dp
+        Vz = 0.0_dp
+        q  = 1.0_dp
+        call compute_er_force_balance(r, n, Ti, Vz, q, 2.5_dp, 165.0_dp, Er)
 
-        ! Er should be negative (decreasing profiles)
-        if (Er_calc < 0.0_dp) then
-            print *, 'PASS: test_er_calculation_creates_file'
-            print *, '  Er(r=20cm) = ', Er_calc
+        call report('Er = 0 for flat profiles', maxval(abs(Er)) < tol, passed)
+    end subroutine test_er_zero_for_flat
+
+    subroutine report(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
         else
-            print *, 'FAIL: test_er_calculation_creates_file'
-            print *, '  Expected Er < 0 (decreasing profiles)'
-            print *, '  Got: ', Er_calc
+            print *, 'FAIL: ', name
             passed = .false.
         end if
-    end subroutine test_er_calculation_creates_file
+    end subroutine report
 
 end program test_profile_input_integration


### PR DESCRIPTION
## Summary

Raises KIM first-party test coverage and removes verified code duplication, under TDD discipline (each refactor guarded by tests, committed separately).

Measured on an instrumented `gfortran --coverage` build (parsed with `gcov-15`, since gcovr 8.4 misreads GCC-15 data):

- Reached-file line coverage **10.8% → 14.7%**; covered lines **220 → 341**; files reached by a test **16 → 19**.

## Commits

- **`test(kim): cover profile_input_m via extracted seams`** — the two profile tests re-implemented production formulas inline and asserted on the copies (production `profile_input_m` was never executed). Extract three I/O-free public seams (`classify_coordinate_type`, `calculate_derivative`, `compute_er_force_balance`); production callers delegate to them; tests now drive real code.
- **`test(kim): add unit tests for pure grid utilities`** — new tests: `plag_coeff`+`binsrc` (0→100%), `findClosestIndex` (0→100%), equidistant `grid_t` generation (`grid_mod` 8%→39%).
- **`refactor(kim): dedup Gauss quadrature helpers into shared module`** — `compute_nodes_weights` and `calc_xbar` were byte-identical across two module pairs; consolidated into a new `gauss_quadrature_m` (−53 dup lines, behaviour-neutral).
- **`refactor(kim): collapse QUADPACK wrapper triplet`** — `quadpack_integrate_F1/F2/F3_wrapper` → one `quadpack_integrate_wrapper(which,…)` (−85 dup lines), guarded by `test_integration_methods`.

## Verification

- Full suite: **20/21 pass**. The only failure, `test_rhs_balance` (QL-Balance `gamma_a_e`), is a pre-existing failure unrelated to these changes (identical value before/after).
- Both refactors are behaviour-neutral and guarded by `test_integration_methods` (RKF45 + QUADPACK paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)