### PR TITLE
test(kim): add end-to-end EM solve keystone for the solver seam

### DIFF
--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -89,3 +89,16 @@ set_target_properties(test_kim_solver PROPERTIES
 target_link_libraries(test_kim_solver KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
 add_test(NAME test_kim_solver
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver.x)
+
+# End-to-end keystone: a real electromagnetic solve through the kim_solver seam.
+add_executable(test_kim_solver_em ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver_em.f90)
+set_target_properties(test_kim_solver_em PROPERTIES
+                        OUTPUT_NAME test_kim_solver_em.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_kim_solver_em KIM_lib "${KiLCA_lib_path}" lapack cerf ddeabm slatec)
+configure_file(${CMAKE_SOURCE_DIR}/KIM/tests/test_data/KIM_config_em_small.nml
+               ${CMAKE_BINARY_DIR}/tests/KIM_config_em_small.nml COPYONLY)
+add_test(NAME test_kim_solver_em
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_em.x)
+set_tests_properties(test_kim_solver_em PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)

--- a/KIM/tests/test_data/KIM_config_em_small.nml
+++ b/KIM/tests/test_data/KIM_config_em_small.nml
@@ -1,0 +1,111 @@
+! Small electromagnetic config for the kim_solver end-to-end keystone test.
+! Same physics setup as nmls/KIM_config_electromagnetic.nml, but on a reduced
+! grid (64 vs 512) with asymptotics/output off, so a full EM solve runs in
+! seconds. Profiles are injected in-memory by the test (profile files unused).
+
+&kim_config
+    number_of_ion_species = 1
+    read_species_from_namelist = .false.
+    type_of_run = 'electromagnetic'
+    collision_model = 'FokkerPlanck'
+    artificial_debye_case = 0
+    turn_off_ions = .false.
+    turn_off_electrons = .false.
+    plasma_type = 'D'
+    rescale_density = .false.
+    number_density_rescale = 1d-6
+    ion_flr_scale_factor = 1.0
+/
+
+&wkb_dispersion
+    WKB_dispersion_mode = 'KIM'
+    WKB_dispersion_solver = 'Muller'
+    WKB_solve_for_kr_squared = .false.
+    WKB_max_tracked_branches = 4
+    WKB_branch_search_halfwidth = 1.5
+    WKB_broad_search_halfwidth = 5.0
+    WKB_broad_search_interval = 0
+    WKB_root_tolerance = 1.0d-6
+    WKB_verbose = .false.
+/
+
+&kim_io
+    profile_location = './profiles/'
+    output_path = './out_em_small/'
+    hdf5_input = .false.
+    hdf5_output = .false.
+    log_level = 1
+    data_verbosity = 0
+    calculate_asymptotics = .false.
+    h5_out_file = ''
+/
+
+&kim_setup
+    btor = -17977.413
+    r0 = 165.0
+    m_mode = -6
+    n_mode = 2
+    omega = 0.0
+    spline_base = 1
+    type_br_field = 12
+    collisions_off = .false.
+    set_profiles_constant = 0
+    bc_type = 3
+    mphi_max = 0
+    Br_boundary_re = 1.0
+    Br_boundary_im = 0.0
+/
+
+&kim_grid
+    r_min = 3.0
+    r_plas = 67.0
+
+    width_res = 0.5
+    ampl_res = 15.0
+    hrmax_scaling = 1.0
+
+    l_space_dim = 64
+    rg_space_dim = 64
+
+    grid_spacing_rg = "equidistant"
+    grid_spacing_xl = "equidistant"
+    theta_integration = "GaussLegendre"
+
+    rkf45_atol = 1.0d-9
+    rkf45_rtol = 1.0d-6
+
+    quadpack_algorithm = 'QAG'
+    quadpack_key = 6
+    quadpack_limit = 500
+    quadpack_epsabs = 1.0d-10
+    quadpack_epsrel = 1.0d-10
+    quadpack_use_u_substitution = .true.
+
+    kernel_taper_skip_threshold = 1.0d-6
+    Larmor_skip_factor = 5
+    gauss_int_nodes_Nx = 21
+    gauss_int_nodes_Nxp = 20
+    gauss_int_nodes_Ntheta = 12
+/
+
+&kim_species
+    zi = 1
+    ai = 2
+/
+
+&KIM_PROFILES
+    coord_type = 'auto'
+    input_profile_dir = './'
+    equil_file = ''
+    geqdsk_file = ''
+    n_input_file = 'n_of_psiN.dat'
+    Te_input_file = 'Te_of_psiN.dat'
+    Ti_input_file = 'Ti_of_psiN.dat'
+    Vz_input_file = 'Vz_of_psiN.dat'
+    n_file = 'n.dat'
+    Te_file = 'Te.dat'
+    Ti_file = 'Ti.dat'
+    Vz_file = 'Vz.dat'
+    Er_file = 'Er.dat'
+    q_file = 'q.dat'
+/

--- a/KIM/tests/test_kim_solver_em.f90
+++ b/KIM/tests/test_kim_solver_em.f90
@@ -1,0 +1,113 @@
+program test_kim_solver_em
+    !> End-to-end keystone test for the kim_solver_m seam: drive a real
+    !> electromagnetic solve through init -> solve(m,n) -> results on a small
+    !> bench config with in-memory profiles, and assert the run path produces
+    !> sane output (populated, finite, monotonic field grid; non-trivial Br).
+    !>
+    !> This is the deferred Phase-1 happy-path test. It exercises the EM run
+    !> path (kernel.f90, fields_mod, electromagnetic_solver -- 0% covered) and
+    !> is the safety net the QL-Balance adapter migration (Phase 2) routes
+    !> through. Assertions are structural, not a hardcoded golden value: a
+    !> tight numeric golden for a physics solve is platform-fragile.
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use KIM_kinds_m, only: dp
+    use kim_solver_m, only: kim_solver_t, kim_results_t, kim_profiles_t, KIM_OK
+
+    implicit none
+
+    integer, parameter :: npts = 40
+    integer, parameter :: m_mode = -6, n_mode = 2
+
+    type(kim_solver_t) :: kim
+    type(kim_results_t) :: res
+    type(kim_profiles_t) :: prof
+    integer :: ierr, i
+    integer(8) :: t0, t1, rate
+    real(dp) :: frac
+    logical :: all_passed
+
+    all_passed = .true.
+
+    ! In-memory profiles over the configured domain [r_min, r_plas] = [3, 67] cm,
+    ! in CGS (n in 1/cm^3, T in eV). q rises 1 -> 4, crossing the m/n = 3
+    ! resonance mid-domain so it sits away from the boundaries.
+    allocate(prof%r(npts), prof%n(npts), prof%Te(npts), &
+             prof%Ti(npts), prof%q(npts), prof%Er(npts))
+    do i = 1, npts
+        prof%r(i)  = 3.0_dp + 64.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+        frac       = (prof%r(i) - 3.0_dp) / 64.0_dp
+        prof%n(i)  = 5.0e13_dp * (1.0_dp - 0.9_dp * frac)
+        prof%Te(i) = 100.0_dp + 1900.0_dp * (1.0_dp - frac)
+        prof%Ti(i) = 0.9_dp * prof%Te(i)
+        prof%q(i)  = 1.0_dp + 3.0_dp * frac
+        prof%Er(i) = 0.0_dp
+    end do
+
+    call kim%init('KIM_config_em_small.nml', run_type='electromagnetic', &
+                  profiles=prof, stat=ierr)
+    call check('init returns KIM_OK', ierr == KIM_OK, all_passed)
+    if (ierr /= KIM_OK) call done(all_passed)
+
+    call system_clock(t0, rate)
+    call kim%solve(m=m_mode, n=n_mode, stat=ierr)
+    call system_clock(t1)
+    print '(A,F8.2,A)', ' solve wall time: ', real(t1 - t0, dp) / real(rate, dp), ' s'
+    call check('solve returns KIM_OK', ierr == KIM_OK, all_passed)
+    if (ierr /= KIM_OK) call done(all_passed)
+
+    res = kim%results()
+
+    call check('field grid populated', &
+               allocated(res%r_field) .and. size(res%r_field) > 1, all_passed)
+    if (allocated(res%r_field)) then
+        call check('field grid strictly increasing', &
+                   all(res%r_field(2:) > res%r_field(:size(res%r_field) - 1)), all_passed)
+    end if
+
+    call check('Br populated, matches field grid', &
+               allocated(res%Br) .and. allocated(res%r_field) .and. &
+               size(res%Br) == size(res%r_field), all_passed)
+    if (allocated(res%Br)) then
+        call check('Br all finite', &
+                   all(ieee_is_finite(real(res%Br))) .and. &
+                   all(ieee_is_finite(aimag(res%Br))), all_passed)
+        ! A degenerate solve would return only the boundary value everywhere;
+        ! a real interior response varies across the grid.
+        call check('Br varies across grid (non-degenerate interior)', &
+                   maxval(abs(res%Br)) > minval(abs(res%Br)), all_passed)
+        print '(A,ES12.4,A,ES12.4)', ' |Br| range: min = ', &
+            minval(abs(res%Br)), '  max = ', maxval(abs(res%Br))
+    end if
+
+    call check('results mode == requested (m,n)', &
+               res%m == m_mode .and. res%n == n_mode, all_passed)
+
+    call kim%finalize()
+    call done(all_passed)
+
+contains
+
+    subroutine check(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name
+            passed = .false.
+        end if
+    end subroutine check
+
+    subroutine done(passed)
+        logical, intent(in) :: passed
+        if (passed) then
+            print *, 'All kim_solver EM keystone checks PASSED'
+            stop 0
+        else
+            print *, 'kim_solver EM keystone checks FAILED'
+            stop 1
+        end if
+    end subroutine done
+
+end program test_kim_solver_em


### PR DESCRIPTION
## Summary
Delivers the **happy-path end-to-end test deferred in Phase 1** (#154): drives a real electromagnetic solve through the `kim_solver_t` seam — `init → solve(m,n) → results` — on a small bench config with in-memory profiles, asserting the run path produces sane output.

This is the **safety net the Phase 2 adapter migration routes through**, and it adds coverage to the EM run path (`kernel`, `fields_mod`, `electromagnetic_solver` — previously 0%).

### Design notes
- **In-memory profiles** (`set_profiles_from_arrays`, CGS units) bypass file I/O — the test is self-contained, no fixture `.dat` files.
- **Small grid** (64 vs the 512-point production config) → the full Fokker-Planck EM solve runs in **~1 s**.
- **Structural assertions, not a numeric golden**: solve completes; field grid populated/monotonic; `Br` populated, finite, and varies across the grid (non-degenerate interior); results carry the requested mode. A tight numeric golden for a physics solve is platform-fragile — `test_rhs_balance` already fails macOS-vs-Linux for exactly that reason.

### Files
- `KIM/tests/test_kim_solver_em.f90` — the test
- `KIM/tests/test_data/KIM_config_em_small.nml` — small EM config (copied to the test working dir at configure time)
- `KIM/tests/CMakeLists.txt` — target + test wiring

## Test plan
- [x] `ctest -R test_kim_solver_em` passes (~1 s); the solve genuinely executes (kernels + ZGESV), `|Br|` spans [0, 1] across the grid.
- [x] Full `ctest` 22/23 — only the pre-existing, unrelated `test_rhs_balance` fails.

## Follow-up found
While building this I noticed the shipped `KIM/nmls/KIM_config_electromagnetic.nml` is **stale** — its `&kim_io` block still lists `fdebug`/`fstatus`/`fdiagnostics`, which the current `read_config.f90` rejects (would `error stop` on read). Out of scope here; worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)