### PR TITLE
Link granular libneo sub-targets (decompose-neo-core)

### DIFF
--- a/QL-Balance/CMakeLists.txt
+++ b/QL-Balance/CMakeLists.txt
@@ -134,7 +134,7 @@ set(LIBNEO_BUILD_TESTING OFF CACHE BOOL "Disable libneo tests" FORCE)
 
 
 # Only fetch libneo if not already available (prevents duplicate targets)
-if(NOT TARGET LIBNEO::neo)
+if(NOT TARGET LIBNEO::polylag)
     find_or_fetch(libneo)
 endif()
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../libneo/include)
@@ -144,7 +144,7 @@ add_dependencies(ql-balance_lib sparse)
 # Link common dependencies defined in top-level Dependencies.cmake
 target_link_libraries(ql-balance_lib PUBLIC
     LIBNEO::collision_freqs
-    LIBNEO::neo
+    LIBNEO::polylag
     LIBNEO::species
     LIBNEO::transport
     SUNDIALS::cvode


### PR DESCRIPTION
Migrates KAMEL onto libneo's granular target decomposition (libneo branch dep-audit/decompose-neo-core).

## Changes

- QL-Balance: replace the LIBNEO::neo umbrella with LIBNEO::polylag, the only sub-target it consumes beyond the already-granular LIBNEO::collision_freqs, LIBNEO::species, and LIBNEO::transport. Module audit: QL-Balance uses only libneo_collisions, libneo_species, libneo_transport, and PolyLagrangeInterpolation from libneo.
- common/equil and PreProc/fourier already link the minimal LIBNEO::magfie sub-target; no change needed.

No fallback to the umbrella: every KAMEL component now links explicit granular sub-targets.

## Verification

Built against the fetched refined libneo branch:

```
cmake -S . -B build_refined -G Ninja -DCMAKE_BUILD_TYPE=Release -DLIBNEO_REF=dep-audit/decompose-neo-core
-- Using libneo branch dep-audit/decompose-neo-core from https://github.com/itpplasma/libneo.git
cmake --build build_refined -j32
[1031/1031] Linking CXX executable install/bin/ql-balance.x
```

Fast tests (golden record excluded):

```
ctest --test-dir build_refined -LE golden_record
100% tests passed, 0 tests failed out of 23
```