### PR TITLE
test(golden): floor near-zero noise in gr_numcompare (fixes rho false-fail)

### DIFF
--- a/test/golden/bin/gr_numcompare.py
+++ b/test/golden/bin/gr_numcompare.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
 # Generic numeric comparator for codes without a code-specific one.
-# Usage: gr_numcompare.py <dir_A> <dir_B> [rtol] [atol]
+# Usage: gr_numcompare.py <dir_A> <dir_B> [rtol] [atol] [near_zero_floor]
 # Recursively compares every regular file present in BOTH trees: whitespace-
 # separated numeric columns where parseable, else byte-equality. Reports max
 # relative diff per file. Exit 1 if any file diverges beyond rtol.
+#
+# near_zero_floor (default 1e-9): an element where BOTH the reference and the
+# current value are at or below this magnitude carries no physical signal and is
+# treated as equal. Oscillatory fields (e.g. KIM's charge density rho) are
+# O(1e-12) floating-point noise at their zero crossings, ~14 orders below their
+# O(1e2) physical scale; a *relative* diff there is meaningless and flips on the
+# reference build's last bits (a fortnum-vs-GSL last-bit wobble reads as tens of
+# percent). This floors only genuine near-zero noise -- the smallest physically
+# meaningful value in the current golden set is ~1e-6, far above it -- so it
+# never masks a real divergence on a physical value. Tune per code via arg 5.
 import sys, os
 
 A, B = sys.argv[1], sys.argv[2]
 rtol = float(sys.argv[3]) if len(sys.argv) > 3 else 1e-7
 atol = float(sys.argv[4]) if len(sys.argv) > 4 else 1e-12
+floor = float(sys.argv[5]) if len(sys.argv) > 5 else 1e-9
 
 SKIP = {"run.log", "exit_code.txt", "runtime_seconds.txt", "migrate.log", "prepare.log"}
 
@@ -56,13 +67,18 @@ for rel in common:
         fail += 0 if same else 1
         continue
     mx = 0.0
+    skipped = 0
     for x, y in zip(na, nb):
+        if abs(x) <= floor and abs(y) <= floor:
+            skipped += 1                       # near-zero noise: carries no signal
+            continue
         d = abs(x - y)
         s = d / (abs(y) + atol)
         mx = max(mx, 0.0 if d <= atol else s)
     checked += 1
     ok = mx <= rtol
-    print(f"{rel}: max_rel={mx:.3e} {'PASS' if ok else 'FAIL'}")
+    note = f" ({skipped} near-zero skipped)" if skipped else ""
+    print(f"{rel}: max_rel={mx:.3e} {'PASS' if ok else 'FAIL'}{note}")
     fail += 0 if ok else 1
 
 print(f"-- {checked} files compared, {fail} over rtol={rtol:.1e}")

--- a/test/golden/bin/test_gr_numcompare.py
+++ b/test/golden/bin/test_gr_numcompare.py
@@ -58,6 +58,33 @@ def test_uff_byte_divergence_flags(tmp_path):
     assert "DIFFER(bytes" in out
 
 
+def test_near_zero_noise_not_flagged(tmp_path):
+    # An oscillatory field (like KIM's rho): physical elements match, but the
+    # zero-crossing elements are float noise (~1e-12) that differ hugely in
+    # *relative* terms between two builds. Those must not fail the comparison.
+    # Element 3 diverges by 1.6e-12 > atol (1e-12) on a ~4e-12 value: 33% rel.
+    # The pre-existing atol floor does NOT catch it (d > atol); the near-zero
+    # floor must. This is the exact KIM rho / itpplasma-KAMEL#164 scenario.
+    _write(tmp_path / "ref" / "fields" / "rho.dat",
+           "9.5780e1\n3.1738e-6\n3.9e-12\n")
+    _write(tmp_path / "cur" / "fields" / "rho.dat",
+           "9.5780e1\n3.1738e-6\n5.5e-12\n")
+    rc, out = _run(tmp_path / "ref", tmp_path / "cur")
+    assert rc == 0, out
+    assert "FAIL" not in out
+    assert "near-zero skipped" in out
+
+
+def test_near_zero_floor_does_not_mask_physical_divergence(tmp_path):
+    # A value above the floor that genuinely diverges must still fail, even when
+    # the file also contains skippable near-zero noise.
+    _write(tmp_path / "ref" / "rho.dat", "9.50e1\n-6.03e-14\n")
+    _write(tmp_path / "cur" / "rho.dat", "9.60e1\n 3.04e-13\n")   # 1% on the big element
+    rc, out = _run(tmp_path / "ref", tmp_path / "cur")
+    assert rc == 1, out
+    assert "FAIL" in out
+
+
 def test_volatile_files_skipped(tmp_path):
     for root in ("ref", "cur"):
         _write(tmp_path / root / "run.log", f"started at {root}\n")


### PR DESCRIPTION
## Problem

The `golden` job fails on the fortnum-migration PRs (first seen on #140) with exactly one quantity over tolerance:

```
electromagnetic/out/m-6_n2/fields/rho.dat: max_rel=3.803e-01 FAIL
```

Every other quantity — all fields, all kernels, all of QL-Balance and KiLCA — passes, most at `0.000e+00`.

## Root cause — a comparator artifact, not a code regression

`gr_numcompare.py` judged every array element by relative diff with only a `1e-12` absolute floor. `rho` (charge density) is an oscillatory `m=6` radial profile: `max|rho| ≈ 96`, but at its **zero crossings** the values are `O(1e-12)` floating-point noise. A last-bit difference between two builds there (fortnum vs GSL — or even two GSL versions) is a negligible *absolute* diff but tens of percent *relative*.

Reproduced locally by building both baseline (GSL) and the fortnum branch, running the KIM electromagnetic case, and diffing `rho.dat` element-by-element:

| idx | ref (GSL) | cur (fortnum) | abs diff | rel diff |
|----:|----------:|--------------:|---------:|---------:|
| 5 (physical) | 3.1738e-06 | 3.1738e-06 | 6.5e-15 | 2e-09 ✓ |
| 125 (near-zero) | -6.03e-14 | 3.04e-13 | 3.6e-13 | **0.34** |
| 126 (near-zero) | 1.35e-12 | 1.92e-12 | 5.6e-13 | **0.24** |

**Max absolute diff across all 128 elements: `5.87e-13`** — ~13 digits of agreement. The physical `rho` profile is identical; only noise-level zero-crossings diverge, and only in relative terms. Whether a given zero-element trips the bar is a coin flip on the reference build's last bits — GSL-2.8 vs fortnum passes locally, CI's GSL-2.4 vs fortnum fails. That is the signature of a tolerance artifact, not a regression. Same physics as #164, on a quantity `gr_numcompare` cannot exclude.

## Fix

Skip elements where **both** the reference and current value are at or below a near-zero floor (default `1e-9`, overridable via arg 5). The floor sits 3 orders below the smallest physically meaningful value in the golden set (~`1e-6`) and 3 orders above the noise (~`1e-12`), so it floors only genuine noise and **never masks a real divergence on a physical value**.

- `rho.dat` (and the many-zero kernel files) now pass on real output with a `(N near-zero skipped)` annotation.
- Adds two unit tests: near-zero noise is skipped; a real divergence on a physical element still fails.

Refs #164. Unblocks the fortnum-migration golden gate (#140–#150).
