### PR TITLE
Copy KiLCA run path by known length instead of strcpy (fixes buffer over-read)

### DIFF
--- a/KiLCA/interface/wave_code_interface.cpp
+++ b/KiLCA/interface/wave_code_interface.cpp
@@ -23,7 +23,7 @@ void calc_wave_code_data_ (core_data ** cdptr, char const * run_path, int * path
     //!The function computes wave fields and other quantities which migth be obtained by subsequent calls of other get_* () interface functions
     //gets path to the project
     char * path = new char[1024];
-    strcpy (path, run_path);
+    memcpy (path, run_path, *pathlength);
     path[*pathlength] = '\0'; //end of string symbol
 
     if (path[strlen(path)-1] != '/') strcat(path, "/");
@@ -46,7 +46,7 @@ void calc_wave_code_data_for_mode_ (core_data ** cdptr, char const * run_path, i
     //!The function computes wave fields and other quantities which migth be obtained by subsequent calls of other get_* () interface functions
     //gets path to the project
     char * path = new char[1024];
-    strcpy (path, run_path);
+    memcpy (path, run_path, *pathlength);
     path[*pathlength] = '\0'; //end of string symbol
     if (path[strlen(path)-1] != '/') strcat(path, "/");
 
@@ -384,7 +384,7 @@ calc_conductivity_matrices_for_mode_
 //gets path to the project
 char * path = new char[1024];
 
-strcpy (path, run_path);
+memcpy (path, run_path, *pathlength);
 
 path[*pathlength] = '\0'; //end of string symbol
 


### PR DESCRIPTION
## Problem

Three interface entry points in `KiLCA/interface/wave_code_interface.cpp` — `calc_wave_code_data_`, `calc_wave_code_data_for_mode_`, `calc_conductivity_matrices_for_mode_` — receive `run_path` from Fortran as a `character` buffer of length `*pathlength` that is **not NUL-terminated**, then copy it with `strcpy`:

```c
char * path = new char[1024];
strcpy (path, run_path);            // reads past the buffer looking for a NUL
path[*pathlength] = '\0';
```

`strcpy` reads until it finds a NUL byte, over-reading past the `*pathlength`-byte source. If no NUL appears within 1024 bytes of adjacent heap it also overflows the destination buffer.

## Fix

`*pathlength` is already passed in. Copy exactly that many bytes with `memcpy`, then NUL-terminate. For valid paths the resulting string is identical.

## Verification

Case: ql-balance golden `f_6_2`.

### Fails on main
`valgrind --tool=memcheck --track-origins=yes`:
```
Invalid read of size 1
   at strcpy
   by calc_wave_code_data_for_mode_
   by initialize_wave_code_interface_ (wave_code_data_64bit.f90:75)
 Address is 0 bytes after a block of size 68 alloc'd
   by _gfortran_string_trim (string_intrinsics_inc.c:180)
```

### Passes after fix
Same command on the fixed binary:
```
Invalid-read (strcpy): 0
```

## Notes
- Pre-existing bug on `main`, independent of the fortnum migration. Separate from the uninitialized-index fix in the sibling PR.
