### PR TITLE
Initialize constant_time_step and set_constant_time_step (read-before-set)

### DIFF
--- a/QL-Balance/src/base/time_evolution.f90
+++ b/QL-Balance/src/base/time_evolution.f90
@@ -30,8 +30,8 @@ module time_evolution
     real(dp) :: timstep
     real(dp) :: time
     real(dp) :: t_hysteresis_turn = 0
-    real(dp) :: constant_time_step
-    logical :: set_constant_time_step
+    real(dp) :: constant_time_step = 0.0_dp
+    logical :: set_constant_time_step = .false.
 
     real(dp), dimension(:), allocatable :: timscal
 


### PR DESCRIPTION
## Problem

`constant_time_step` (real) and `set_constant_time_step` (logical) in `QL-Balance/src/base/time_evolution.f90` are module variables with no default. They are logged unconditionally in `read_config` (`read_config.f90:88-89`) and are absent from the golden namelist, so they are read before being set.

Today this is harmless because module storage lands in zero-filled BSS. Building with `-finit-real=snan` exposes the read as a signaling-NaN use — a SIGFPE in the config logger (`fmt_val_real`, `logger_m.f90:78`).

## Fix

Give both explicit defaults (`0.0_dp`, `.false.`), so the read-before-set no longer relies on BSS zeroing.

## Verification

With `-finit-real=snan -ffpe-trap=invalid`:

- Before: SIGFPE in `__logger_m_MOD_fmt_val_real` (`read_config.f90:89`, `constant_time_step`).
- After: the run proceeds past config logging.

## Notes

Found while investigating KiLCA/ql-balance golden-record nondeterminism (#172). This is a latent read-before-set, not the run-to-run source (which is BLAS-level FP nondeterminism); included as a small correctness fix.