### PR TITLE
Add pre-fortnum golden diagnostic coverage

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  PRE_FORTNUM_BASELINE: 0fb4f29622080b86c31d557584dfa5951356a2ee
+
 jobs:
   golden:
+    name: golden-record (main)
     runs-on: ubuntu-latest
     # Backstop: a hanging build or case (e.g. a non-terminating ported solver)
     # must not tie up a runner for GitHub's 6h default. Two clean ref+cur builds
@@ -42,3 +46,37 @@ jobs:
 
       - name: Run golden-record suite (ref=golden-baseline, cur=HEAD)
         run: test/golden/run_golden.sh golden-baseline ${{ github.sha }}
+
+  golden-pre-fortnum:
+    name: golden-record (pre-fortnum diagnostic)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build gfortran \
+            libopenmpi-dev openmpi-bin libhdf5-openmpi-dev libnetcdf-dev \
+            libnetcdff-dev libomp-dev libopenblas-dev liblapack-dev doxygen \
+            libgsl-dev libsuitesparse-dev libsuperlu-dev python3-dev python3-pip \
+            libmpfr-dev libgmp-dev
+          pip install numpy scipy matplotlib h5py f90nml
+
+      - name: Cache external dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            test/golden/build_ref/src/build/external-install
+            test/golden/build_cur/src/build/external-install
+          key: golden-ext-${{ runner.os }}-${{ hashFiles('cmake/Fetch*.cmake') }}
+          restore-keys: golden-ext-${{ runner.os }}-
+
+      - name: Run golden-record suite (ref=pre-fortnum, cur=HEAD)
+        continue-on-error: true
+        run: test/golden/run_golden.sh "$PRE_FORTNUM_BASELINE" ${{ github.sha }}

--- a/test/golden/bin/compare.py
+++ b/test/golden/bin/compare.py
@@ -55,20 +55,6 @@ _LINEAR_PROFILE_QUANTITIES = [
 # Time steps available in LinearProfiles (0-8)
 _TIME_STEPS = range(9)
 
-# LinearProfiles time steps downstream of the resonant-surface root find
-# (find_resonance_location in KiLCA/mode/calc_mode.cpp). The f_6_2 (m=6, n=2)
-# case sits close enough to its resonant surface that any independently
-# implemented root finder lands on a different last-bit value than GSL's
-# gsl_root_fsolver_brent, and that sub-ULP difference amplifies through the
-# nonlinear balance evolution to O(1) by the late time steps. Proven with a
-# control experiment on the unmodified GSL-based code: perturbing GSL's own
-# root by the same ~1e-14 magnitude reproduces the identical failure
-# pattern, so this is a pre-existing property of this test case, not a
-# fortnum regression. See itpplasma/KAMEL#164. Steps 0-1 are unaffected and
-# stay on the strict bar.
-_RESONANCE_CHAOTIC_TIME_STEPS = frozenset(range(2, 9))
-
-
 def _build_quantities_list() -> list[QuantitySpec]:
     """Build the full list of quantities to compare."""
     quantities = [
@@ -82,25 +68,13 @@ def _build_quantities_list() -> list[QuantitySpec]:
         QuantitySpec("/init_params/r"),
     ]
 
-    # LinearProfiles for all time steps, excluding the steps proven to fall
-    # inside the resonance-chaotic regime (see itpplasma/KAMEL#164).
     for t in _TIME_STEPS:
-        if t in _RESONANCE_CHAOTIC_TIME_STEPS:
-            continue
         for q in _LINEAR_PROFILE_QUANTITIES:
             quantities.append(QuantitySpec(f"/f_6_2/LinearProfiles/{t}/{q}"))
 
-    # KinProfiles at the initial time step (unaffected). The final time step
-    # (1008) is downstream of the same resonance-chaotic evolution and is
-    # excluded for the same reason (itpplasma/KAMEL#164).
-    quantities.extend(
-        [
-            QuantitySpec("/f_6_2/KinProfiles/1000/Te"),
-            QuantitySpec("/f_6_2/KinProfiles/1000/Ti"),
-            QuantitySpec("/f_6_2/KinProfiles/1000/n"),
-            QuantitySpec("/f_6_2/KinProfiles/1000/Er"),
-        ]
-    )
+    for t in (1000, 1008):
+        for q in ("Te", "Ti", "n", "Er"):
+            quantities.append(QuantitySpec(f"/f_6_2/KinProfiles/{t}/{q}"))
 
     return quantities
 

--- a/test/golden/bin/gr_numcompare.py
+++ b/test/golden/bin/gr_numcompare.py
@@ -80,7 +80,17 @@ def rel_files(root):
 fail = 0
 checked = 0
 if os.path.isdir(A) and os.path.isdir(B):
-    common = sorted(rel_files(A) & rel_files(B))
+    files_a = rel_files(A)
+    files_b = rel_files(B)
+    for rel in sorted(files_a - files_b):
+        checked += 1
+        fail += 1
+        print(f"{rel}: MISSING(cur)")
+    for rel in sorted(files_b - files_a):
+        checked += 1
+        fail += 1
+        print(f"{rel}: MISSING(ref)")
+    common = sorted(files_a & files_b)
 else:
     common = []
 

--- a/test/golden/bin/test_compare.py
+++ b/test/golden/bin/test_compare.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Unit tests for the QL-Balance HDF5 comparator quantity list."""
+import compare
+
+
+def _paths():
+    return {spec.path for spec in compare.QUANTITIES_TO_COMPARE}
+
+
+def test_linear_profiles_include_all_time_steps():
+    paths = _paths()
+    for t in range(9):
+        for q in compare._LINEAR_PROFILE_QUANTITIES:
+            assert f"/f_6_2/LinearProfiles/{t}/{q}" in paths
+
+
+def test_kin_profiles_include_initial_and_final_time_steps():
+    paths = _paths()
+    for t in (1000, 1008):
+        for q in ("Te", "Ti", "n", "Er"):
+            assert f"/f_6_2/KinProfiles/{t}/{q}" in paths

--- a/test/golden/bin/test_gr_numcompare.py
+++ b/test/golden/bin/test_gr_numcompare.py
@@ -58,6 +58,17 @@ def test_uff_byte_divergence_flags(tmp_path):
     assert "DIFFER(bytes" in out
 
 
+def test_missing_file_flags(tmp_path):
+    _write(tmp_path / "ref" / "only-ref.dat", "1.0\n")
+    _write(tmp_path / "cur" / "common.dat", "2.0\n")
+    _write(tmp_path / "ref" / "common.dat", "2.0\n")
+
+    rc, out = _run(tmp_path / "ref", tmp_path / "cur")
+
+    assert rc == 1, out
+    assert "only-ref.dat: MISSING(cur)" in out
+
+
 def test_near_zero_noise_not_flagged(tmp_path):
     # An oscillatory field (like KIM's rho): physical elements match, but the
     # zero-crossing elements are float noise (~1e-12) that differ hugely in


### PR DESCRIPTION
Adds a non-blocking pre-fortnum golden-record diagnostic against `0fb4f29622080b86c31d557584dfa5951356a2ee`, the last mainline commit before the fortnum migration series.

The normal `golden-record (main)` job remains the strict gate. The pre-fortnum job runs the same harness and keeps its failure visible in PR logs without blocking unrelated work.

Coverage changes:
- QL-Balance compares all `f_6_2/LinearProfiles` steps `0..8` again.
- QL-Balance compares `KinProfiles/1008` again.
- The generic comparator now fails when one side produces an output file the other side lacks.

Local diagnostic result against current `main`:

```text
test/golden/run_golden.sh 0fb4f29622080b86c31d557584dfa5951356a2ee HEAD
== golden-record overall: FAIL
KIM: 109 files compared, 38 over rtol=1.0e-07
QL-Balance: 16/114 quantities passed with full quantity coverage
KiLCA: 58 files compared, 1 over rtol=1.0e-07
```

## Verification
### Test fails on main
```bash
tmp=$(mktemp -d)
git show main:test/golden/bin/compare.py > "$tmp/compare.py"
PYTHONPATH="$tmp" python3 - <<'PY'
import compare
paths = {spec.path for spec in compare.QUANTITIES_TO_COMPARE}
required = {f"/f_6_2/LinearProfiles/{t}/{q}" for t in range(9) for q in compare._LINEAR_PROFILE_QUANTITIES}
required |= {f"/f_6_2/KinProfiles/{t}/{q}" for t in (1000, 1008) for q in ("Te", "Ti", "n", "Er")}
missing = sorted(required - paths)
if missing:
    print(f"missing {len(missing)} QL-Balance golden quantities")
    print(missing[0])
    raise SystemExit(1)
print("all required QL-Balance quantities covered")
PY
```

```text
missing 81 QL-Balance golden quantities
/f_6_2/KinProfiles/1008/Er
```

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/ref" "$tmp/cur"
printf '1.0\n' > "$tmp/ref/only-ref.dat"
printf '2.0\n' > "$tmp/ref/common.dat"
printf '2.0\n' > "$tmp/cur/common.dat"
git show main:test/golden/bin/gr_numcompare.py > "$tmp/gr_numcompare.py"
python3 "$tmp/gr_numcompare.py" "$tmp/ref" "$tmp/cur" > "$tmp/out.txt" || true
cat "$tmp/out.txt"
grep -q 'only-ref.dat: MISSING(cur)' "$tmp/out.txt"
```

```text
common.dat: max_rel=0.000e+00 PASS
-- 1 files compared, 0 over rtol=1.0e-07
```

### Test passes after fix
```bash
PYTHONPATH=test/golden/bin python3 - <<'PY'
import compare
paths = {spec.path for spec in compare.QUANTITIES_TO_COMPARE}
required = {f"/f_6_2/LinearProfiles/{t}/{q}" for t in range(9) for q in compare._LINEAR_PROFILE_QUANTITIES}
required |= {f"/f_6_2/KinProfiles/{t}/{q}" for t in (1000, 1008) for q in ("Te", "Ti", "n", "Er")}
missing = sorted(required - paths)
if missing:
    print(f"missing {len(missing)} QL-Balance golden quantities")
    print(missing[0])
    raise SystemExit(1)
print("all required QL-Balance quantities covered")
PY
```

```text
all required QL-Balance quantities covered
```

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/ref" "$tmp/cur"
printf '1.0\n' > "$tmp/ref/only-ref.dat"
printf '2.0\n' > "$tmp/ref/common.dat"
printf '2.0\n' > "$tmp/cur/common.dat"
python3 test/golden/bin/gr_numcompare.py "$tmp/ref" "$tmp/cur" > "$tmp/out.txt" || true
cat "$tmp/out.txt"
grep -q 'only-ref.dat: MISSING(cur)' "$tmp/out.txt"
```

```text
only-ref.dat: MISSING(cur)
common.dat: max_rel=0.000e+00 PASS
-- 2 files compared, 1 over rtol=1.0e-07
```

```bash
uv run --no-project --with pytest --with h5py --with numpy python -m pytest test/golden/bin/test_gr_numcompare.py test/golden/bin/test_compare.py
```

```text
12 passed in 0.21s
```

```bash
git diff --check
ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/golden.yml
bash -n test/golden/run_golden.sh test/golden/bin/gr_build_all.sh test/golden/bin/gr_run_case.sh test/golden/bin/gr_dispatch.sh test/golden/bin/gr_compare.sh test/golden/bin/compare_qlbalance.sh
```

```text
yaml ok
```
