### PR TITLE
Add KIM collision-frequency scale

### DIFF
--- a/KIM/nmls/KIM_config.nml
+++ b/KIM/nmls/KIM_config.nml
@@ -12,6 +12,7 @@
     rescale_density = .false.
     number_density_rescale = 1d-6
     ion_flr_scale_factor = 1.0
+    collision_frequency_scale = 1.0
 /
 
 &wkb_dispersion

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -451,7 +451,8 @@ module species_m
 
         use constants_m, only: sol, e_charge, ev, pi, com_unit
         use setup_m, only: omega, collisions_off
-        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, ion_flr_scale_factor
+        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, &
+                            ion_flr_scale_factor, collision_frequency_scale
 
         implicit none
 
@@ -530,6 +531,10 @@ module species_m
             do i = 1, plasma_in%grid_size
                 plasma_in%spec(sp)%nu(i) = nui(sp, i)
             end do
+        end do
+
+        do sp = 0, plasma_in%n_species-1
+            plasma_in%spec(sp)%nu = plasma_in%spec(sp)%nu*collision_frequency_scale
         end do
 
         do sp =0, plasma_in%n_species-1

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -1,8 +1,6 @@
 module config_display_m
     ! Module for displaying configuration with formatted tables, colors, and status indicators
 
-    use KIM_kinds_m, only: dp
-
     implicit none
 
     private
@@ -134,6 +132,10 @@ contains
         call print_config_line('Plasma Type', trim(plasma_type), width)
         call print_config_line('Collision Model', trim(collision_model), width)
         call print_bool_line('Collisions', .not. collisions_off, width)
+        if (collision_frequency_scale /= 1.0d0) then
+            write(value_str, '(ES12.3)') collision_frequency_scale
+            call print_config_line('Collision Frequency Scale', trim(adjustl(value_str)), width)
+        end if
         write(value_str, '(I0)') artificial_debye_case
         call print_config_line('Artificial Debye Case', trim(adjustl(value_str)), width)
         call print_bool_line('Turn Off Ions', turn_off_ions, width)

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -4,7 +4,6 @@ subroutine kim_read_config
     use constants_m
     use setup_m
     use grid_m
-    use poisson_solver_m, only: solve_poisson
     use config_display_m, only: display_kim_configuration
     use logger_m, only: set_log_level
     use getIfunc_config_m, only: getIfunc_boole_energy_conservation => boole_energy_conservation
@@ -18,7 +17,7 @@ subroutine kim_read_config
     namelist /KIM_CONFIG/ number_of_ion_species, artificial_debye_case, &
                         type_of_run, collision_model, read_species_from_namelist, &
                         turn_off_ions, turn_off_electrons, plasma_type, rescale_density, &
-                        number_density_rescale, ion_flr_scale_factor, &
+                        number_density_rescale, ion_flr_scale_factor, collision_frequency_scale, &
                         boole_energy_conservation
 
     namelist /WKB_DISPERSION/ WKB_dispersion_mode, WKB_dispersion_solver, &
@@ -103,6 +102,11 @@ subroutine kim_read_config
     if (collisions_off .and. collision_model == "FokkerPlanck") then
         write(*,*) 'Error: collision_model is set to "FokkerPlanck" but collisions_off is true.'
         write(*,*) 'Please set collisions_off to false or change collision_model.'
+        stop
+    end if
+
+    if (collision_frequency_scale <= 0.0_dp) then
+        write(*,*) 'Error: collision_frequency_scale must be positive.'
         stop
     end if
 

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -50,6 +50,7 @@ module config_m
     logical :: rescale_density
     real(dp) :: number_density_rescale
     real(dp) :: ion_flr_scale_factor
+    real(dp) :: collision_frequency_scale = 1.0_dp
 
     ! KIM_PROFILES namelist variables
     character(20) :: coord_type = 'auto'           ! 'auto', 'sqrt_psiN', or 'r_eff'

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -140,6 +140,7 @@ module IO_collection_m
     subroutine write_setup_namelist_to_hdf5()
 
         use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_obj_exists, h5_add, h5_close_group
+        use config_m, only: collision_frequency_scale
         use setup_m
 
         implicit none
@@ -170,6 +171,8 @@ module IO_collection_m
             'Integer type of delta Br.', '1')
         call h5_add(h5grpid, 'collisions_off', collisions_off, &
             'Logical switch to turn off collisions.', 'true/false')
+        call h5_add(h5grpid, 'collision_frequency_scale', collision_frequency_scale, &
+            'Multiplier applied to calculated collision frequencies.', '1')
         call h5_add(h5grpid, 'set_profiles_constant', set_profiles_constant, &
             'Integer switch for setting (some) profiles constant.', '1')
         call h5_add(h5grpid, 'bc_type', bc_type, &

--- a/KIM/tests/test_periodized_background_feed.f90
+++ b/KIM/tests/test_periodized_background_feed.f90
@@ -11,7 +11,7 @@ program test_periodized_background_feed
     use rt_fourier_periodic_m, only: build_periodized_background
     use kernel_test_background_m, only: setup_uniform_background, n0, T0, b0
     use config_m, only: number_of_ion_species, rescale_density, &
-                        ion_flr_scale_factor
+                        ion_flr_scale_factor, collision_frequency_scale
     use setup_m, only: collisions_off, omega
 
     implicit none
@@ -26,12 +26,14 @@ program test_periodized_background_feed
     real(dp), parameter :: slope = -1.0d0/(4.0d0*67.0d0)
 
     real(dp) :: r, physical, got, centered, physical_slope, deviation
+    real(dp) :: lee, lei, expected_nue
     complex(dp) :: kernel_a, kernel_b
     integer :: i, j, sp
 
     number_of_ion_species = 1
     rescale_density = .false.
     ion_flr_scale_factor = 1.0d0
+    collision_frequency_scale = 3.0d0
     collisions_off = .false.
     omega = 0.0d0
 
@@ -48,6 +50,18 @@ program test_periodized_background_feed
     end do
 
     call build_periodized_background(r_res, dr_layer, dr_transition, n_points)
+
+    j = point_index(r_res)
+    associate (ne => plasma%spec(0)%n(j), ni => plasma%spec(1)%n(j), &
+            te => plasma%spec(0)%T(j))
+        lee = 23.5d0 - log(sqrt(ne)/te**1.25d0) &
+            - sqrt(1d-5 + (log(te) - 2.0d0)**2/16.0d0)
+        lei = 24.0d0 - log(sqrt(ne)/te)
+        expected_nue = 3.0d0*(5.8e-6*ne*lee/te**1.5d0 &
+            + 7.7d-6*ni*lei/te**1.5d0)
+    end associate
+    call require_close("collision-frequency scale reaches the background", &
+        plasma%spec(0)%nu(j), expected_nue, 1.0d-12)
 
     ! Inside the resonant layer the linear physical profile survives
     ! exactly (four-point Lagrange interpolation is exact on it).


### PR DESCRIPTION
Adds a positive `collision_frequency_scale` to KIM configuration. It multiplies calculated electron and ion collision frequencies before the Krook argument and Fokker-Planck susceptibility inputs are assembled. The default is 1, so existing collision formulas, profiles, units, and outputs are unchanged. The configured value is displayed and stored in HDF5 provenance.

The periodized-background regression uses a scale of 3 and checks the resulting electron collision frequency against the existing Coulomb-logarithm formula.

## Verification

Before: `test_periodized_background_feed` failed to compile because the configuration value did not exist.

After: the focused regression passes; the full CMake build and all 30 CTest tests pass; bare `fo` passes Static, Build, Tests, and Lint.

An initial 64-point Krook scout at omega=1e5 overflowed above scale 1. PR 183 traced that result to interpolation of the derived `z0` across `k_parallel=0`, not to the collision-frequency scale. With `z0` recomputed from interpolated primitives, scales 1 through 3 remain finite. This PR supplies a controlled sensitivity parameter; it makes no benchmark-acceptance claim.

## Relation to Markus's Fokker-Planck periodic branch

This PR provides a controlled sensitivity parameter with a default-preserving implementation. It was used to diagnose the rejected Krook benchmark and is not an FP acceptance mechanism. Keep its provenance and regression independent of the periodic-FP decision in #191.
