### PR TITLE
Reject unsupported periodic collision models

### DIFF
--- a/KIM/src/fourier_periodic/rt_fourier_periodic.f90
+++ b/KIM/src/fourier_periodic/rt_fourier_periodic.f90
@@ -20,6 +20,16 @@ module rt_fourier_periodic_m
 
 contains
 
+    pure logical function periodic_collision_model_supported(model)
+
+        implicit none
+
+        character(*), intent(in) :: model
+
+        periodic_collision_model_supported = trim(model) == "Krook"
+
+    end function periodic_collision_model_supported
+
     subroutine init_fourier_periodic(this)
 
         use species_m, only: plasma, set_plasma_quantities
@@ -28,7 +38,7 @@ contains
         use grid_m, only: rg_grid
         use setup_m, only: fp_r_res, fp_dr_layer, fp_dr_transition, &
                            fp_grid_points
-        use config_m, only: rescale_density
+        use config_m, only: collision_model, rescale_density
 
         implicit none
 
@@ -36,6 +46,10 @@ contains
 
         this%run_type = "fourier_periodic"
 
+        if (.not. periodic_collision_model_supported(collision_model)) then
+            error stop "fourier_periodic: only collision_model = Krook is &
+                &implemented"
+        end if
         if (rescale_density) then
             error stop "fourier_periodic: rescale_density is not supported; &
                 &the periodized collision frequencies would rescale twice"

--- a/KIM/tests/test_fourier_periodic.f90
+++ b/KIM/tests/test_fourier_periodic.f90
@@ -10,6 +10,7 @@ program test_fourier_periodic
     use kernels_m, only: kernel_rho_phi_of_kr_krp_rg
     use fourier_periodic_m, only: periodic_k_grid, assemble_periodic_kernel, &
                                   solve_periodic_potential, periodic_field_value
+    use rt_fourier_periodic_m, only: periodic_collision_model_supported
     use kernel_test_background_m, only: setup_uniform_background, require_close
 
     implicit none
@@ -25,6 +26,13 @@ program test_fourier_periodic
     complex(dp) :: kernel_matrix(n_k, n_k), rhs(n_k), phi_modes(n_k)
     complex(dp) :: analytic, value_a, value_b
     integer :: m, mp, sp
+
+    if (.not. periodic_collision_model_supported("Krook")) then
+        error stop "fourier_periodic rejects its implemented Krook model"
+    end if
+    if (periodic_collision_model_supported("FokkerPlanck")) then
+        error stop "fourier_periodic silently accepts unimplemented FP kernels"
+    end if
 
     call setup_uniform_background()
     k_modes = periodic_k_grid(period, n_modes)


### PR DESCRIPTION
The periodic-Fourier driver currently assembles the restored Krook kernels regardless of collision_model. Reject every model except Krook until a continuum Fokker-Planck kernel is implemented, so an input cannot silently claim different collision physics.

Invariant: the supported Krook periodic assembly, Fourier convention, CGS units, grid, dense solve, and boundary behavior are unchanged.

## Verification

Failing before, using the parent binary with collision_model = FokkerPlanck:

    parent_exit=0
    Collision Model............. FokkerPlanck
    ...fourier_periodic solve finished with 257 modes.

Passing after, using the same input:

    fixed_exit=1
    ERROR STOP fourier_periodic: only collision_model = Krook is implemented

    100% tests passed, 0 tests failed out of 30
    Static: OK
    Build: OK
    Tests: OK
    Lint: OK
    All stages passed

## Relation to Markus's Fokker-Planck periodic branch

This guard closes a real semantic hole in the independent stack: a Krook kernel must not run under a Fokker-Planck label. Keep the guard until #187 verifies the FP kernel and #190 accepts the FP benchmark. #191 must replace the blanket rejection with explicit Krook/FP dispatch, not remove collision-model validation.
