### PR TITLE
[kim-fp-01] Size the periodic window from active-species Larmor radii

### DIFF
--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -19,7 +19,11 @@ module rt_electrostatic_periodic_m
             procedure :: run => run_electrostatic_periodic
     end type electrostatic_periodic_t
 
-    public :: compute_periodic_delta_phi
+    integer, parameter, public :: PERIODIC_SCALE_OK = 0
+    integer, parameter, public :: PERIODIC_SCALE_NO_ACTIVE = 1
+    integer, parameter, public :: PERIODIC_SCALE_INVALID_RHO = 2
+
+    public :: compute_periodic_delta_phi, select_periodic_reference_scale
 
     contains
 
@@ -59,6 +63,80 @@ module rt_electrostatic_periodic_m
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
     end subroutine compute_periodic_delta_phi
+
+    !> Select the largest Larmor radius among species active in the FP kernel.
+    subroutine select_periodic_reference_scale(plasma_in, x, electrons_active, ions_active, &
+                                               rho_ref, reference_species, info)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: x
+        logical, intent(in) :: electrons_active, ions_active
+        real(dp), intent(out) :: rho_ref
+        integer, intent(out) :: reference_species, info
+
+        real(dp) :: rho_sp
+        integer :: sp
+
+        rho_ref = 0.0_dp
+        reference_species = -1
+        info = PERIODIC_SCALE_NO_ACTIVE
+        if (plasma_in%n_species <= 0) return
+        if (.not. allocated(plasma_in%spec) .or. .not. allocated(plasma_in%r_grid) &
+            .or. plasma_in%grid_size < 4) then
+            info = PERIODIC_SCALE_INVALID_RHO
+            return
+        end if
+
+        do sp = 0, plasma_in%n_species - 1
+            if (.not. electrons_active .and. sp == 0) cycle
+            if (.not. ions_active .and. sp >= 1) cycle
+            if (.not. allocated(plasma_in%spec(sp)%rho_L) &
+                .or. size(plasma_in%spec(sp)%rho_L) < plasma_in%grid_size) then
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            rho_sp = interp_species_rho_L(plasma_in, sp, x)
+            if (.not. ieee_is_finite(rho_sp) .or. rho_sp <= 0.0_dp) then
+                rho_ref = rho_sp
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            if (rho_sp > rho_ref) then
+                rho_ref = rho_sp
+                reference_species = sp
+            end if
+        end do
+
+        if (reference_species >= 0) info = PERIODIC_SCALE_OK
+    end subroutine select_periodic_reference_scale
+
+    real(dp) function interp_species_rho_L(plasma_in, sp, x) result(rhoLx)
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma_in%grid_size
+        call binsrc(plasma_in%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma_in%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma_in%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     !> Global setup, identical to the electrostatic run-type's init: build the
     !> grids and equilibrium and populate the GLOBAL plasma. run() reads the
@@ -105,13 +183,14 @@ module rt_electrostatic_periodic_m
         use KIM_kinds_m, only: dp
         use constants_m, only: pi
         use config_m, only: periodic_dr_asis_scale, periodic_dr_tr_scale, &
-                            periodic_kmax_scale, periodic_n_rg, hdf5_output
+                            periodic_kmax_scale, periodic_n_rg, hdf5_output, &
+                            turn_off_electrons, turn_off_ions
         use setup_m, only: Br_boundary_re, Br_boundary_im
         use species_m, only: plasma
         use grid_m, only: rg_grid
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
-        use IO_collection_m, only: write_complex_profile_abs
+        use IO_collection_m, only: write_complex_profile_abs, write_periodic_scale_metadata
 
         implicit none
 
@@ -121,7 +200,7 @@ module rt_electrostatic_periodic_m
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
-        integer :: M, n_rg, info, i
+        integer :: M, n_rg, info, i, reference_species
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
         call prepare_resonances
@@ -131,13 +210,20 @@ module rt_electrostatic_periodic_m
         end if
         rm = r_res
 
-        ! 2. Representative Larmor radius rho_L(rm) (electrons) on the global
-        ! plasma via 4-point Lagrange interpolation.
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, "Error (electrostatic_periodic): rho_L(rm) not positive, = ", rhoL_rm
-            error stop "electrostatic_periodic: invalid rho_L(rm)"
-        end if
+        ! 2. Select the largest Larmor radius among the species that the FP
+        ! kernel will actually assemble. This keeps the full response of every
+        ! active species resolved and is independent of species storage order.
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, info)
+        select case (info)
+        case (PERIODIC_SCALE_NO_ACTIVE)
+            error stop "electrostatic_periodic: no active kinetic species"
+        case (PERIODIC_SCALE_INVALID_RHO)
+            print *, "Error (electrostatic_periodic): invalid rho_L for species ", &
+                     reference_species, " value = ", rhoL_rm
+            error stop "electrostatic_periodic: invalid active-species rho_L(rm)"
+        end select
 
         ! 3. Window geometry and Fourier cutoff from rho_L(rm).
         dx_asis = periodic_dr_asis_scale * rhoL_rm
@@ -147,8 +233,19 @@ module rt_electrostatic_periodic_m
         M       = ceiling(k_max * L / (2.0_dp * pi))
         n_rg    = periodic_n_rg
 
-        print *, "electrostatic_periodic: rm = ", rm, " rho_L(rm) = ", rhoL_rm
-        print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
+        print *, "electrostatic_periodic: reference species = ", reference_species, &
+                 " Z = ", plasma%spec(reference_species)%Zspec, &
+                 " mass [g] = ", plasma%spec(reference_species)%mass
+        print *, "electrostatic_periodic: rm [cm] = ", rm, &
+                 " rho_L(rm) [cm] = ", rhoL_rm
+        print *, "electrostatic_periodic: dx_asis [cm] = ", dx_asis, &
+                 " dx_tr [cm] = ", dx_tr, " L [cm] = ", L
+        print *, "electrostatic_periodic: k_max [1/cm] = ", k_max, &
+                 " M = ", M, " n_rg = ", n_rg
+        call write_periodic_scale_metadata(reference_species, &
+            plasma%spec(reference_species)%Zspec, &
+            plasma%spec(reference_species)%mass, rhoL_rm, dx_asis, dx_tr, &
+            k_max, M, n_rg)
 
         ! 4. Window output grid: n_rg equidistant points on [rm - L/2, rm + L/2],
         ! bit-identical to the grid build_periodic_plasma installs as rg_grid%xb
@@ -187,29 +284,6 @@ module rt_electrostatic_periodic_m
                 'Electrostatic potential perturbation Phi, forced-periodicity solution', &
                 'statV')
         end if
-
-    contains
-
-        !> 4-point Lagrange interpolation of the global electron Larmor radius
-        !> plasma%spec(0)%rho_L at radius x, using the same binsrc + plag_coeff
-        !> stencil as the rest of KIM.
-        real(dp) function interp_rho_L(x) result(rhoLx)
-            real(dp), intent(in) :: x
-            integer, parameter :: nlagr = 4, nder = 0
-            real(dp) :: coef(0:nder, nlagr)
-            integer :: gs, ir, ibeg, iend
-
-            gs = plasma%grid_size
-            call binsrc(plasma%r_grid, 1, gs, x, ir)
-            ibeg = max(1, ir - nlagr/2)
-            iend = ibeg + nlagr - 1
-            if (iend > gs) then
-                iend = gs
-                ibeg = iend - nlagr + 1
-            end if
-            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-            rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-        end function interp_rho_L
 
     end subroutine run_electrostatic_periodic
 

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -58,6 +58,62 @@ module IO_collection_m
 
     end subroutine write_KIM_namelist_to_hdf5
 
+    subroutine write_periodic_scale_metadata(reference_species, charge, mass, rho_ref, &
+                                             dx_asis, dx_tr, k_max, n_modes, n_rg)
+
+        use config_m, only: output_path, hdf5_output
+        use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_open_group, &
+                                   h5_obj_exists, h5_add, h5_close_group
+
+        implicit none
+
+        integer, intent(in) :: reference_species, charge, n_modes, n_rg
+        real(dp), intent(in) :: mass, rho_ref, dx_asis, dx_tr, k_max
+
+        character(len=*), parameter :: header = &
+            '# reference_species charge mass_g rho_ref_cm dx_asis_cm dx_tr_cm ' // &
+            'k_max_cm_inv M N_rg'
+        integer :: iunit
+        integer(HID_T) :: h5grpid
+        logical :: ex
+
+        if (hdf5_output) then
+            call h5_obj_exists(h5id, 'setup/periodic_scale/', ex)
+            if (.not. ex) then
+                call h5_define_group(h5id, 'setup/periodic_scale/', h5grpid)
+            else
+                call h5_open_group(h5id, 'setup/periodic_scale/', h5grpid)
+            end if
+            call h5_add(h5grpid, 'reference_species', reference_species, &
+                        'Zero-based index of the species defining the periodic scale', '1')
+            call h5_add(h5grpid, 'charge', charge, &
+                        'Charge number of the periodic reference species', '1')
+            call h5_add(h5grpid, 'mass', mass, &
+                        'Mass of the periodic reference species', 'g')
+            call h5_add(h5grpid, 'rho_ref', rho_ref, &
+                        'Reference Larmor radius at the resonant surface', 'cm')
+            call h5_add(h5grpid, 'dx_asis', dx_asis, &
+                        'As-is half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'dx_tr', dx_tr, &
+                        'Transition half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'k_max', k_max, &
+                        'Maximum resolved radial wavenumber', '1/cm')
+            call h5_add(h5grpid, 'M', n_modes, &
+                        'Maximum positive periodic Fourier mode', '1')
+            call h5_add(h5grpid, 'N_rg', n_rg, &
+                        'Number of radial quadrature points', '1')
+            call h5_close_group(h5grpid)
+        else
+            open(newunit=iunit, file=trim(output_path)//'setup/periodic_scale.dat', &
+                 status='replace', action='write')
+            write(iunit, '(A)') header
+            write(iunit, *) reference_species, charge, mass, rho_ref, dx_asis, &
+                            dx_tr, k_max, n_modes, n_rg
+            close(iunit)
+        end if
+
+    end subroutine write_periodic_scale_metadata
+
     subroutine write_config_namelist_to_hdf5()
 
         use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_obj_exists, h5_add, h5_close_group

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -25,6 +25,7 @@ program test_kim_solver_periodic
     implicit none
 
     call test_run_type_end_to_end()
+    call test_multi_ion_order_independence()
 
     print *, 'All tests PASSED'
     stop 0
@@ -33,8 +34,9 @@ contains
 
     subroutine test_run_type_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -47,7 +49,7 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        real(dp) :: rm, r_lo, r_hi, tol
+        real(dp) :: rm, r_lo, r_hi, tol, rho_i_rm, expected_r_lo
         integer :: i, N
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
@@ -64,14 +66,23 @@ contains
         ! Full lifecycle through the new run-type.
         call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
         call kim_instance%init()
-        call kim_instance%run()
 
-        ! The resonance the run-type located (q = |m/n| = 3 on the global plasma).
+        ! Capture the reference scale from the TRUE global plasma before run()
+        ! redirects it onto the periodic window. This is the same state used by
+        ! run_electrostatic_periodic to derive and store the window parameters.
+        call prepare_resonances
         rm = r_res
         if (.not. (rm > 0.0_dp)) then
             print *, 'FAIL: resonance not found, r_res = ', rm
             error stop
         end if
+        rho_i_rm = interp_species_rho_L(1, rm)
+        if (.not. (rho_i_rm > 0.0_dp)) then
+            print *, 'FAIL: deuterium rho_L(rm) is not positive:', rho_i_rm
+            error stop
+        end if
+
+        call kim_instance%run()
         print *, 'resonant radius rm = ', rm
 
         N = rg_grid%npts_b
@@ -116,6 +127,14 @@ contains
         r_lo = EBdat%r_grid(1)
         r_hi = EBdat%r_grid(N)
         tol = 1.0e-8_dp * (1.0_dp + abs(rm))
+        expected_r_lo = rm - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_i_rm
+        if (abs(r_lo - expected_r_lo) > tol) then
+            print *, 'FAIL: periodic window is not sized from deuterium rho_L'
+            print *, '  actual lower edge =', r_lo
+            print *, '  expected lower edge =', expected_r_lo
+            print *, '  deuterium rho_L(rm) =', rho_i_rm
+            error stop
+        end if
         if (abs(0.5_dp * (r_lo + r_hi) - rm) > (r_hi - r_lo) / real(N - 1, dp)) then
             print *, 'FAIL: window not centred on rm; midpoint =', &
                      0.5_dp * (r_lo + r_hi), ' rm =', rm
@@ -127,7 +146,157 @@ contains
         end if
         print *, 'PASS: EBdat%r_grid spans window [', r_lo, ',', r_hi, &
                  '] about rm =', rm
+
+        call assert_scale_metadata(rho_i_rm)
     end subroutine test_run_type_end_to_end
+
+    subroutine assert_scale_metadata(expected_rho)
+        use constants_m, only: pi
+        use config_m, only: output_path, periodic_dr_asis_scale, &
+                            periodic_dr_tr_scale, periodic_kmax_scale, periodic_n_rg
+
+        real(dp), intent(in) :: expected_rho
+        character(len=512) :: metadata_path, header
+        integer :: io_unit, io_status, reference_species, charge, M, n_rg
+        real(dp) :: mass, rho_ref, dx_asis, dx_tr, k_max, period, tol
+        logical :: exists
+
+        metadata_path = trim(output_path)//'setup/periodic_scale.dat'
+        inquire(file=trim(metadata_path), exist=exists)
+        if (.not. exists) then
+            print *, 'FAIL: periodic scale metadata was not stored at ', trim(metadata_path)
+            error stop
+        end if
+
+        open(newunit=io_unit, file=trim(metadata_path), status='old', action='read')
+        read(io_unit, '(A)', iostat=io_status) header
+        if (io_status /= 0 .or. index(header, 'reference_species') == 0) then
+            print *, 'FAIL: periodic scale metadata header is missing or invalid'
+            error stop
+        end if
+        read(io_unit, *, iostat=io_status) reference_species, charge, mass, rho_ref, &
+            dx_asis, dx_tr, k_max, M, n_rg
+        close(io_unit)
+        if (io_status /= 0) then
+            print *, 'FAIL: periodic scale metadata row could not be read'
+            error stop
+        end if
+
+        tol = 1.0e-10_dp * max(1.0_dp, expected_rho)
+        period = 2.0_dp * (periodic_dr_asis_scale + periodic_dr_tr_scale) * expected_rho
+        if (reference_species /= 1 .or. charge /= 1 .or. .not. (mass > 0.0_dp) .or. &
+            abs(rho_ref - expected_rho) > tol .or. &
+            abs(dx_asis - periodic_dr_asis_scale * expected_rho) > tol .or. &
+            abs(dx_tr - periodic_dr_tr_scale * expected_rho) > tol .or. &
+            abs(k_max - periodic_kmax_scale / expected_rho) > tol .or. &
+            M /= ceiling((periodic_kmax_scale / expected_rho) * period / (2.0_dp * pi)) .or. &
+            n_rg /= periodic_n_rg) then
+            print *, 'FAIL: stored periodic scale metadata does not match the run'
+            print *, '  species/Z/mass =', reference_species, charge, mass
+            print *, '  rho stored/expected/tol =', rho_ref, expected_rho, tol
+            print *, '  dx_asis stored/expected =', dx_asis, &
+                     periodic_dr_asis_scale * expected_rho
+            print *, '  dx_tr stored/expected =', dx_tr, &
+                     periodic_dr_tr_scale * expected_rho
+            print *, '  k_max stored/expected =', k_max, &
+                     periodic_kmax_scale / expected_rho
+            print *, '  M/N_rg stored =', M, n_rg, ' expected N_rg =', periodic_n_rg
+            error stop
+        end if
+        print *, 'PASS: periodic scale provenance stored in ', trim(metadata_path)
+    end subroutine assert_scale_metadata
+
+    subroutine test_multi_ion_order_independence()
+        integer, parameter :: masses_forward(2) = [2, 12]
+        integer, parameter :: masses_reverse(2) = [12, 2]
+        real(dp) :: lower_forward, lower_reverse, expected_forward, expected_reverse
+        real(dp) :: tol
+
+        call run_multi_ion_case(masses_forward, lower_forward, expected_forward)
+        call run_multi_ion_case(masses_reverse, lower_reverse, expected_reverse)
+
+        tol = 1.0e-8_dp * (1.0_dp + abs(expected_forward))
+        if (abs(lower_forward - expected_forward) > tol) then
+            print *, 'FAIL: forward-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_forward
+            print *, '  expected lower edge =', expected_forward
+            error stop
+        end if
+        if (abs(lower_reverse - expected_reverse) > tol) then
+            print *, 'FAIL: reverse-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_reverse
+            print *, '  expected lower edge =', expected_reverse
+            error stop
+        end if
+        if (abs(lower_forward - lower_reverse) > tol) then
+            print *, 'FAIL: reference scale depends on ion storage order'
+            print *, '  forward lower edge =', lower_forward
+            print *, '  reverse lower edge =', lower_reverse
+            error stop
+        end if
+        print *, 'PASS: largest active-ion rho_L is storage-order independent'
+    end subroutine test_multi_ion_order_independence
+
+    subroutine run_multi_ion_case(ion_masses, lower_edge, expected_lower_edge)
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use fields_m, only: EBdat, EBdat_t
+
+        integer, intent(in) :: ion_masses(:)
+        real(dp), intent(out) :: lower_edge, expected_lower_edge
+        integer, parameter :: npts = 201
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp) :: rho_max
+        class(kim_t), allocatable :: kim_instance
+        integer :: sp
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_run_test.nml', ion_masses)
+        nml_config_path = './KIM_config_periodic_run_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        rho_max = 0.0_dp
+        do sp = 1, plasma%n_species - 1
+            rho_max = max(rho_max, interp_species_rho_L(sp, r_res))
+        end do
+        lower_edge = EBdat%r_grid(1)
+        expected_lower_edge = r_res &
+            - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_max
+    end subroutine run_multi_ion_case
+
+    real(dp) function interp_species_rho_L(sp, x) result(rhoLx)
+        use species_m, only: plasma
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+        call binsrc(plasma%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)
@@ -148,21 +317,27 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path)
+    subroutine write_test_namelist(path, ion_masses)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
         ! config defaults apply when the optional namelist is absent.
         character(len=*), intent(in) :: path
-        integer :: iunit
+        integer, intent(in), optional :: ion_masses(:)
+        integer :: iunit, i, nions
+        logical :: custom_species
+
+        custom_species = present(ion_masses)
+        nions = 1
+        if (custom_species) nions = size(ion_masses)
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
-        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A,I0)') ' number_of_ion_species = ', nions
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic_periodic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
-        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A,L1)') ' read_species_from_namelist = ', custom_species
         write(iunit, '(A)') ' turn_off_ions = .false.'
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
@@ -170,6 +345,20 @@ contains
         write(iunit, '(A)') ' number_density_rescale = 1.0'
         write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
         write(iunit, '(A)') '/'
+        if (custom_species) then
+            write(iunit, '(A)') '&KIM_species'
+            write(iunit, '(A)', advance='no') ' ai ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') ion_masses(i)
+            end do
+            write(iunit, *)
+            write(iunit, '(A)', advance='no') ' zi ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') 1
+            end do
+            write(iunit, *)
+            write(iunit, '(A)') '/'
+        end if
         write(iunit, '(A)') '&WKB_DISPERSION'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_IO'

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -25,6 +25,7 @@ program test_periodic_convergence
 
     implicit none
 
+    call test_reference_scale_validation()
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
     call test_M_convergence()
@@ -35,10 +36,48 @@ program test_periodic_convergence
 
 contains
 
+    subroutine test_reference_scale_validation()
+        use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+        use species_m, only: plasma_t
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_NO_ACTIVE, &
+                                               PERIODIC_SCALE_INVALID_RHO
+
+        type(plasma_t) :: test_plasma
+        real(dp) :: rho_ref
+        integer :: sp, reference_species, info
+
+        test_plasma%n_species = 3
+        test_plasma%grid_size = 4
+        allocate(test_plasma%r_grid(4), test_plasma%spec(0:2))
+        test_plasma%r_grid = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        do sp = 0, 2
+            allocate(test_plasma%spec(sp)%rho_L(4))
+            test_plasma%spec(sp)%rho_L = 0.1_dp * real(sp + 1, dp)
+        end do
+
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .false., .false., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_NO_ACTIVE) then
+            print *, 'FAIL: selector did not reject a plasma with no active species'
+            error stop
+        end if
+
+        test_plasma%spec(2)%rho_L(2) = ieee_value(0.0_dp, ieee_quiet_nan)
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .true., .true., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_INVALID_RHO) then
+            print *, 'FAIL: selector accepted a non-finite active-species rho_L'
+            print *, '  info =', info, ' reference species =', reference_species
+            error stop
+        end if
+        print *, 'PASS: reference-scale selector rejects invalid active species'
+    end subroutine test_reference_scale_validation
+
     subroutine test_core_on_fixed_grid()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -79,14 +118,15 @@ contains
         rm = r_res
         print *, 'resonant radius rm = ', rm
 
-        ! Representative electron Larmor radius at rm, via the SAME 4-point
-        ! Lagrange stencil the run-type uses to size its window.
+        ! Reference Larmor radius at rm, selected from the same active species
+        ! set used by the production run type.
         rhoL_rm = interp_rho_L(rm)
         if (.not. (rhoL_rm > 0.0_dp)) then
             print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
             error stop
         end if
-        print *, 'rho_L(rm) [electron] = ', rhoL_rm
+        call assert_convergence_uses_reference_scale(rm, rhoL_rm)
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
@@ -128,6 +168,33 @@ contains
         end if
         print *, 'PASS: dPhi non-zero, max|dPhi| =', maxval(abs(dPhi))
     end subroutine test_core_on_fixed_grid
+
+    subroutine assert_convergence_uses_reference_scale(rm, convergence_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, convergence_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: convergence harness could not select a physical scale'
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(convergence_rho - selected_rho) > tol) then
+            print *, 'FAIL: convergence scans do not use the selected species scale'
+            print *, '  convergence rho_L =', convergence_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_convergence_uses_reference_scale
 
     !> Phase-3 Task 2: r_g QUADRATURE convergence of the periodic solver.
     !>
@@ -193,7 +260,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED window (M and dx_asis / dx_tr do NOT change with n_rg): the only
         ! knob refined here is the r_g quadrature node count.
@@ -272,16 +339,16 @@ contains
     !> Phase-3 Task 3: FOURIER BASIS truncation convergence of the periodic
     !> solver.
     !>
-    !> With the r_g quadrature (n_rg = 192, converged in P3.2) and the window
+    !> With the r_g quadrature (n_rg = 512, converged in P3.2) and the window
     !> (dx_asis, dx_tr) FIXED, refine only the number of Fourier modes M (the
     !> basis has 2M+1 modes) and reconstruct delta-Phi on a FIXED diagnostic
     !> grid. The localized solution's Fourier coefficients decay for
     !> |k_m| >> 1/rho_L, so the Cauchy residual between successive M must fall
-    !> and beat 1e-2 by M ~ 24-32. A failure to converge is a real finding about
+    !> and beat 1e-2 at the finest tested M. A failure to converge is a real finding about
     !> the basis truncation or the k-resolution, not a reason to loosen the
     !> tolerance (bump n_rg first: the exp(i(k_m - k_m')r) quadrature is exact
-    !> for |m - m'| < n_rg by Nyquist, and 2M = 64 < 192, so n_rg = 192 resolves
-    !> M up to 32).
+    !> for |m - m'| < n_rg by Nyquist, and 2M = 256 < 512, so n_rg = 512 resolves
+    !> M up to 128).
     subroutine test_M_convergence()
         use config_m, only: profiles_in_memory, nml_config_path
         use species_m, only: set_profiles_from_arrays
@@ -291,8 +358,8 @@ contains
         use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
 
         integer, parameter :: npts = 201
-        integer, parameter :: n_rg = 192, ndiag = 41, nseq = 4
-        integer, parameter :: M_seq(nseq) = [8, 16, 24, 32]
+        integer, parameter :: n_rg = 512, ndiag = 41, nseq = 5
+        integer, parameter :: M_seq(nseq) = [32, 48, 64, 96, 128]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -337,11 +404,10 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
-        ! FIXED quadrature and window (only M is refined here). n_rg = 192 is the
-        ! P3.2-converged node count; it resolves the k-modes for M up to 32
-        ! (2M = 64 < 192, Nyquist).
+        ! FIXED quadrature and window (only M is refined here). n_rg = 512 is the
+        ! P3.2-converged node count; it resolves the k-modes for M up to 128.
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
         print *, 'FIXED n_rg               = ', n_rg
@@ -372,7 +438,7 @@ contains
             end if
             dphi_k(:, k) = dPhi
         end do
-        print *, 'PASS: all four solves returned info == 0'
+        print *, 'PASS: all Fourier-refinement solves returned info == 0'
 
         ! Cauchy relative residual between successive refinements.
         res_L2  = 0.0_dp
@@ -394,18 +460,21 @@ contains
         print *, '-----------------------------------------------------------'
 
         ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
-        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
+        decreasing = .true.
+        do k = 3, nseq
+            decreasing = decreasing .and. (res_L2(k) < res_L2(k - 1))
+        end do
         if (.not. decreasing) then
             print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> real finding about basis truncation / k-resolution;'
             print *, '      investigate (bump n_rg first), do NOT loosen the'
             print *, '      threshold blindly.'
             error stop 'test_M_convergence: residual not decreasing'
         end if
-        if (.not. (res_L2(4) < 1.0e-2_dp)) then
-            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+        if (.not. (res_L2(nseq) < 1.0e-2_dp)) then
+            print *, 'FAIL: finest res_L2 =', res_L2(nseq), ' not < 1.0e-2'
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> Fourier basis has NOT converged; investigate (bump'
             print *, '      n_rg first), do NOT loosen the threshold blindly.'
             error stop 'test_M_convergence: basis not converged'
@@ -426,12 +495,14 @@ contains
     !>
     !> CRITICAL (design section 4.1): the NUMERICAL resolution is held constant
     !> across the scan so the residual measures PHYSICAL deformation, not
-    !> numerical under-resolution. As dx_asis grows, L = 2*(dx_asis + dx_tr)
-    !> grows, so M and n_rg are SCALED with L:
-    !>   M    = ceiling( (5/rhoL) * L / (2 pi) )  -> fixed k_max = 5/rhoL
-    !>   n_rg = ceiling( 16 * L / rhoL )          -> fixed 16 points per rho_L
-    !> The M formula matches the run-type's own sizing (periodic_kmax_scale = 5),
-    !> and n_rg sits well above the P3.2-converged density.
+    !> numerical under-resolution. Hold dx_tr fixed at 10 rho_L so dx_asis is
+    !> the only physical knob. As dx_asis grows, L = 2*(dx_asis + dx_tr) grows,
+    !> so M and n_rg are SCALED with L:
+    !>   M    = ceiling( (27/rhoL) * L / (2 pi) ) -> fixed converged k_max
+    !>   n_rg = max(ceiling(16 L/rhoL), 4 M)      -> converged quadrature/Nyquist
+    !> The cutoff follows the preceding M scan, where M=128 on the 15-rho_L
+    !> half-window reduced the Cauchy residual below 1e-2. This scan therefore
+    !> measures deformation rather than the known under-resolution at k_max=5/rho_L.
     !>
     !> SOFT GATE (this REPORTS the error bar, it does NOT tightly pass/fail): the
     !> test error-stops ONLY on a genuine defect -- non-finite / all-zero dPhi, a
@@ -500,7 +571,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED diagnostic grid: 41 equidistant points on [rm - 2 rho_L,
         ! rm + 2 rho_L]. The SAME physical grid is used for EVERY dx_asis, so the
@@ -513,16 +584,17 @@ contains
                       + 4.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
         end do
 
-        ! Scan the as-is half-width. Memo ratio dx_tr = 2*dx_asis => L = 6*dx_asis.
-        ! Hold the NUMERICAL resolution constant by scaling M and n_rg with L:
-        ! fixed k_max = 5/rho_L (matches the run-type) and fixed 16 pts / rho_L.
+        ! Scan ONLY the as-is half-width. Keep dx_tr fixed at the run-type's
+        ! configured 10-rho_L transition scale, and hold numerical resolution
+        ! constant by scaling M and n_rg with L. The fixed k_max = 27/rho_L is
+        ! justified by test_M_convergence above.
         do k = 1, nseq
             dx_asis = dx_asis_scale(k) * rhoL_rm
-            dx_tr   = 2.0_dp * dx_asis
+            dx_tr   = 10.0_dp * rhoL_rm
             L       = 2.0_dp * (dx_asis + dx_tr)
-            k_max   = 5.0_dp / rhoL_rm
+            k_max   = 27.0_dp / rhoL_rm
             M_seq(k)    = ceiling(k_max * L / (2.0_dp * pi))
-            n_rg_seq(k) = ceiling(16.0_dp * L / rhoL_rm)
+            n_rg_seq(k) = max(ceiling(16.0_dp * L / rhoL_rm), 4 * M_seq(k))
 
             print '(A,F6.1,A,ES14.6,A,I5,A,I6)', &
                 '   dx_asis = ', dx_asis_scale(k), ' rho_L  (=', dx_asis, &
@@ -620,25 +692,22 @@ contains
         print *, '=== test_dr_deformation_scan PASSED ==='
     end subroutine test_dr_deformation_scan
 
-    !> 4-point Lagrange interpolation of the global electron Larmor radius
-    !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.
+    !> Active-species reference scale selected by the production run type.
     real(dp) function interp_rho_L(x) result(rhoLx)
+        use config_m, only: turn_off_electrons, turn_off_ions
         use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
         real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
+        integer :: reference_species, info
 
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr/2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
+        call select_periodic_reference_scale(plasma, x, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoLx, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select convergence reference scale, info =', info
+            error stop
         end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
     end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_periodic_vs_global.f90
+++ b/KIM/tests/test_periodic_vs_global.f90
@@ -47,6 +47,7 @@ program test_periodic_vs_global
 
     call run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                     r_global, phi_global, rm, rhoL_rm)
+    call assert_diagnostic_uses_reference_scale(rm, rhoL_rm)
     call run_periodic(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                       r_periodic, phi_periodic)
 
@@ -58,18 +59,48 @@ program test_periodic_vs_global
 
 contains
 
+    subroutine assert_diagnostic_uses_reference_scale(rm, diagnostic_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, diagnostic_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select the physical diagnostic scale, info =', info
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(diagnostic_rho - selected_rho) > tol) then
+            print *, 'FAIL: cross-check interval does not use the selected species scale'
+            print *, '  diagnostic rho_L =', diagnostic_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_diagnostic_uses_reference_scale
+
     subroutine run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                           r_out, phi_out, rm, rhoL_rm)
         ! Global electrostatic (FokkerPlanck, hat-basis) run. Captures deep
         ! copies of EBdat%Phi and EBdat%r_grid (the FIELD grid xl_grid%xb), and
         ! reads rm = r_res and rho_L(rm) off the GLOBAL plasma so the periodic
         ! run can be compared on the same resonant layer.
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            turn_off_electrons, turn_off_ions
+        use species_m, only: plasma, set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
 
         real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -78,7 +109,7 @@ contains
         real(dp), intent(out) :: rm, rhoL_rm
 
         class(kim_t), allocatable :: kim_g
-        integer :: N
+        integer :: N, reference_species, scale_info
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                 q_prof, Er_prof)
@@ -103,9 +134,11 @@ contains
             print *, 'FAIL: global run -- resonance not found, r_res = ', rm
             error stop
         end if
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, 'FAIL: global run -- rho_L(rm) not positive, = ', rhoL_rm
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, scale_info)
+        if (scale_info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: global run -- invalid reference rho_L, info = ', scale_info
             error stop
         end if
 
@@ -132,7 +165,8 @@ contains
 
         print *, 'GLOBAL: max|Phi| = ', maxval(abs(phi_out)), &
                  ' on r in [', r_out(1), ',', r_out(N), '], N = ', N
-        print *, 'GLOBAL: rm = ', rm, ' rho_L(rm) = ', rhoL_rm
+        print *, 'GLOBAL: rm = ', rm, ' reference species = ', reference_species, &
+                 ' rho_L(rm) = ', rhoL_rm
 
         ! The global potential is expected to be finite; whether it is non-zero
         ! is a FINDING reported by cross_check (on this coarse in-memory
@@ -288,6 +322,9 @@ contains
                                 sqrt(sum(abs(pg_dc)**2)))
         rel_max_dc = safe_ratio(maxval(abs(diff_dc)), maxval(abs(pg_dc)))
 
+        call write_curve_data('periodic_vs_global_curve.dat', r_c(1:nc), &
+                              pg_c(1:nc), pp_c(1:nc), pg_dc, pp_dc)
+
         ! Soft gate: bail only on non-finite results, never on a large finite one.
         if (.not. ieee_is_finite(rel_L2) .or. .not. ieee_is_finite(rel_max) .or. &
             .not. ieee_is_finite(rel_L2_dc) .or. &
@@ -346,6 +383,29 @@ contains
         end if
         print *, ''
     end subroutine cross_check
+
+    subroutine write_curve_data(path, r, phi_global, phi_periodic, &
+                                phi_global_dc, phi_periodic_dc)
+        character(len=*), intent(in) :: path
+        real(dp), intent(in) :: r(:)
+        complex(dp), intent(in) :: phi_global(:), phi_periodic(:)
+        complex(dp), intent(in) :: phi_global_dc(:), phi_periodic_dc(:)
+        integer :: i, io_unit
+
+        open(newunit=io_unit, file=path, status='replace', action='write')
+        write(io_unit, '(A)') &
+            '# r_cm global_re global_im periodic_re periodic_im ' // &
+            'global_dc_re global_dc_im periodic_dc_re periodic_dc_im'
+        do i = 1, size(r)
+            write(io_unit, '(9(ES24.16,1X))') r(i), &
+                real(phi_global(i), dp), aimag(phi_global(i)), &
+                real(phi_periodic(i), dp), aimag(phi_periodic(i)), &
+                real(phi_global_dc(i), dp), aimag(phi_global_dc(i)), &
+                real(phi_periodic_dc(i), dp), aimag(phi_periodic_dc(i))
+        end do
+        close(io_unit)
+        print *, '  curve data                  = ', path
+    end subroutine write_curve_data
 
     real(dp) function safe_ratio(num, den) result(ratio)
         ! num/den, guarding against a zero (or tiny) denominator so an all-zero
@@ -420,28 +480,6 @@ contains
             end if
         end do
     end subroutine assert_finite
-
-    real(dp) function interp_rho_L(x) result(rhoLx)
-        ! 4-point Lagrange interpolation of the global electron Larmor radius
-        ! plasma%spec(0)%rho_L at radius x -- same stencil as the periodic
-        ! run-type uses to size its window, so rm/Delta match the solver.
-        use species_m, only: plasma
-        real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
-
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr / 2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
-        end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-    end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)


### PR DESCRIPTION
## Summary

- select the largest valid Larmor radius among species active in the FP kernel
- use that scale consistently for the periodic window, diagnostics, and metadata
- cover electron/ion activation combinations and invalid-scale failures

## Why

Periodic resolution is now tied to the physics actually retained by the kernel instead of an electron-only assumption.

## Validation

Validated cumulatively at the stack head:

- `cmake --build build -j2`
- `ctest --test-dir build -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global' --output-on-failure` — 35/35 passed

Known red gates are intentionally excluded from that command: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation acceptance gate, and the unresolved periodic-vs-global 5% agreement gate.

## Stack

Base: `feature/kim-forced-periodicity`
Head: `fix/kim-fp-01-ion-scale-window`

Closes #185