### PR TITLE
Add parallel flow to x2 in KIM-FP

### DIFF
--- a/KIM/README.md
+++ b/KIM/README.md
@@ -24,6 +24,37 @@ The following are automatically downloaded during build:
 ## Configuration
 The code is configured with the namelist file */nmls/KIM_config.nml*.
 
+### Fokker-Planck equilibrium parallel flow
+
+`Vz_file` is the cylindrical `z` velocity (the toroidal component in KIM's
+straight-cylinder model), in cm/s. A finite file must be declared explicitly:
+
+```fortran
+&KIM_PROFILES
+  Vz_file = 'Vz.dat'
+  parallel_flow_convention = 'toroidal'
+/
+```
+
+KIM treats this as the axial component of a field-aligned ion flow and applies
+the cylindrical projection once,
+`V_parallel = Vz/h_z`, where
+`h_z = sign(B_z)/sqrt(1 + (r/(q R0))**2)`. All configured ion Maxwellians use
+that profile; electrons remain stationary. Radial force balance continues to
+use the original toroidal component, while Fokker-Planck susceptibilities use
+
+```text
+x2(s,m_phi) = -(omega_E + k_parallel V_parallel(s)
+                 + m_phi omega_c(s) - omega) / nu(s).
+```
+
+No `Vz.dat`, or an identically zero profile, preserves the historical zero-flow
+path bit-for-bit. A finite profile with no declared convention or insufficient
+radial coverage is rejected before susceptibility assembly. In-memory callers
+may pass the explicitly field-parallel `Vpar_in` argument to
+`set_profiles_from_arrays`; omission means zero flow. Poloidal neoclassical flow
+is not added by this model.
+
 ## Compilation
 To compile the code:
 ```

--- a/KIM/nmls/KIM_config.nml
+++ b/KIM/nmls/KIM_config.nml
@@ -118,6 +118,7 @@
     Te_file = 'Te.dat'
     Ti_file = 'Ti.dat'
     Vz_file = 'Vz.dat'
+    parallel_flow_convention = 'toroidal'
     Er_file = 'Er.dat'
     q_file = 'q.dat'
 /

--- a/KIM/nmls/KIM_config_electromagnetic.nml
+++ b/KIM/nmls/KIM_config_electromagnetic.nml
@@ -106,6 +106,7 @@
     Te_file = 'Te.dat'
     Ti_file = 'Ti.dat'
     Vz_file = 'Vz.dat'
+    parallel_flow_convention = 'toroidal'
     Er_file = 'Er.dat'
     q_file = 'q.dat'
 /

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -9,7 +9,8 @@ module periodic_background_m
     !>
     !> LEGACY SAMPLING CONTRACT: the public five-value sampler returns
     !>     funs = [ n_e, Te, Ti, q, Er ].
-    !> The full periodic build caches and samples n_s and T_s for every species.
+    !> The full periodic build caches and samples n_s, T_s, and V_parallel,s for
+    !> every species.
 
     use KIM_kinds_m, only: dp
     use periodization_m, only: make_periodic
@@ -55,12 +56,12 @@ module periodic_background_m
     !> reset is needed after set_profiles_from_arrays.
     !>
     !> Order in cache_prim for S species:
-    !>   [ n_0..n_(S-1), T_0..T_(S-1), q, Er ].
+    !>   [ n_0..n_(S-1), T_0..T_(S-1), Vpar_0..Vpar_(S-1), q, Er ].
     !> Order in cache_geom: [ B0, ks, kp, om_E ]     (matches kim_geom_aperfuns).
     integer, save :: cached_generation = -1
     integer, save :: cached_n_species = 0
     real(dp), allocatable, save :: cache_r(:)
-    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, 2*S + 2)
+    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, 3*S + 2)
     real(dp), allocatable, save :: cache_geom(:, :)   ! (grid_size, n_geom)
 
 contains
@@ -95,7 +96,7 @@ contains
 
         gs = plasma%grid_size
         cached_n_species = plasma%n_species
-        ncols = 2*cached_n_species + 2
+        ncols = 3*cached_n_species + 2
         allocate(cache_r(gs), cache_prim(gs, ncols), cache_geom(gs, n_geom))
 
         cache_r = plasma%r_grid(1:gs)
@@ -103,9 +104,10 @@ contains
             do sp = 0, cached_n_species - 1
                 cache_prim(i, sp + 1) = plasma%spec(sp)%n(i)
                 cache_prim(i, cached_n_species + sp + 1) = plasma%spec(sp)%T(i)
+                cache_prim(i, 2*cached_n_species + sp + 1) = plasma%spec(sp)%Vpar(i)
             end do
-            cache_prim(i, 2*cached_n_species + 1) = plasma%q(i)
-            cache_prim(i, 2*cached_n_species + 2) = plasma%Er(i)
+            cache_prim(i, 3*cached_n_species + 1) = plasma%q(i)
+            cache_prim(i, 3*cached_n_species + 2) = plasma%Er(i)
 
             cache_geom(i, 1) = plasma%B0(i)          ! equilibrium field magnitude
             cache_geom(i, 2) = plasma%ks(i)          ! perpendicular wavenumber
@@ -176,20 +178,20 @@ contains
         call capture_true_background()
 
         block
-            real(dp) :: all_funs(2*cached_n_species + 2)
+            real(dp) :: all_funs(3*cached_n_species + 2)
 
             call interp_cache_row(cache_prim, size(all_funs), x, all_funs)
             funs(1) = all_funs(1)
             funs(2) = all_funs(cached_n_species + 1)
             funs(3) = all_funs(cached_n_species + 2)
-            funs(4) = all_funs(2*cached_n_species + 1)
-            funs(5) = all_funs(2*cached_n_species + 2)
+            funs(4) = all_funs(3*cached_n_species + 1)
+            funs(5) = all_funs(3*cached_n_species + 2)
         end block
     end subroutine kim_aperfuns
 
     !> Internal callback used by build_periodic_plasma. Unlike the legacy public
     !> sampler, this passes every species profile through make_periodic in the
-    !> cache order [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+    !> cache order [n_0..n_(S-1), T_0..T_(S-1), Vpar_0..Vpar_(S-1), q, Er].
     subroutine kim_all_profiles_aperfuns(nfuns, x, funs)
         integer, intent(in) :: nfuns
         real(dp), intent(in) :: x
@@ -238,12 +240,14 @@ contains
     end subroutine sample_periodic_primitives
 
     !> Return independently periodized densities and temperatures for every
-    !> configured species, plus q and Er. Arrays use species indices 0:S-1.
+    !> configured species, plus q and Er. When requested, Vpar_per returns each
+    !> species' field-parallel Maxwellian drift. Arrays use indices 0:S-1.
     subroutine sample_periodic_species_profiles(x_mid, dx_asis, dx_tr, x, &
-                                                n_per, T_per, q_per, Er_per)
+                                                n_per, T_per, q_per, Er_per, Vpar_per)
         real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
         real(dp), intent(out) :: n_per(0:), T_per(0:)
         real(dp), intent(out) :: q_per, Er_per
+        real(dp), intent(out), optional :: Vpar_per(0:)
 
         integer :: sp, n_profile_values
 
@@ -252,8 +256,13 @@ contains
             size(T_per) /= cached_n_species) then
             error stop 'periodic species sampler received the wrong species count'
         end if
+        if (present(Vpar_per)) then
+            if (size(Vpar_per) /= cached_n_species) then
+                error stop 'periodic flow sampler received the wrong species count'
+            end if
+        end if
 
-        n_profile_values = 2*cached_n_species + 2
+        n_profile_values = 3*cached_n_species + 2
         block
             real(dp) :: all_funs(n_profile_values)
 
@@ -262,9 +271,12 @@ contains
             do sp = 0, cached_n_species - 1
                 n_per(sp) = all_funs(sp + 1)
                 T_per(sp) = all_funs(cached_n_species + sp + 1)
+                if (present(Vpar_per)) then
+                    Vpar_per(sp) = all_funs(2*cached_n_species + sp + 1)
+                end if
             end do
-            q_per = all_funs(2*cached_n_species + 1)
-            Er_per = all_funs(2*cached_n_species + 2)
+            q_per = all_funs(3*cached_n_species + 1)
+            Er_per = all_funs(3*cached_n_species + 2)
         end block
     end subroutine sample_periodic_species_profiles
 
@@ -320,7 +332,8 @@ contains
 
         real(dp) :: L, r_lo, r_hi, u0_seed
         real(dp), allocatable :: r_win(:)
-        real(dp), allocatable :: n_win(:, :), T_win(:, :), q_win(:), Er_win(:)
+        real(dp), allocatable :: n_win(:, :), T_win(:, :), Vpar_win(:, :)
+        real(dp), allocatable :: q_win(:), Er_win(:)
         integer :: j, sigma, npts, n_species, profile_status
 
         if (present(info)) info = PERIODIC_BACKGROUND_OK
@@ -341,22 +354,24 @@ contains
         ! kim_aperfuns reads the CACHED true primitives (captured above), so this
         ! is robust to the redirect and to repeated calls. Sample into temporaries;
         ! only a valid profile is allowed to mutate rg_grid or plasma below.
-        ! Dynamic order: [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+        ! Dynamic order: [n_0..n_(S-1), T_0..T_(S-1),
+        !                 Vpar_0..Vpar_(S-1), q, Er].
         allocate(r_win(n_rg), n_win(n_rg, 0:n_species - 1), &
-                 T_win(n_rg, 0:n_species - 1), q_win(n_rg), Er_win(n_rg))
+                 T_win(n_rg, 0:n_species - 1), &
+                 Vpar_win(n_rg, 0:n_species - 1), q_win(n_rg), Er_win(n_rg))
         do j = 1, n_rg
             r_win(j) = r_lo + L*real(j - 1, dp)/real(n_rg, dp)
             call sample_periodic_species_profiles(rm, dx_asis, dx_tr, r_win(j), &
-                n_win(j, :), T_win(j, :), q_win(j), Er_win(j))
+                n_win(j, :), T_win(j, :), q_win(j), Er_win(j), Vpar_win(j, :))
         end do
 
         ! Preserve independently periodized impurity densities and use the main
         ! ion (species 1) as the dependent density. This documents one unique
         ! quasineutrality policy and avoids changing impurity concentration
         ! ratios merely because a species has a higher charge state.
-        call enforce_dependent_main_ion_density(n_win, T_win, profile_status)
+        call enforce_dependent_main_ion_density(n_win, T_win, Vpar_win, profile_status)
         if (profile_status /= PERIODIC_BACKGROUND_OK) then
-            deallocate(r_win, n_win, T_win, q_win, Er_win)
+            deallocate(r_win, n_win, T_win, Vpar_win, q_win, Er_win)
             if (present(info)) then
                 info = profile_status
                 return
@@ -409,15 +424,19 @@ contains
         call reallocate(plasma%Er, rg_grid%npts_b)
         call reallocate(plasma%spec(0)%n, rg_grid%npts_b)
         call reallocate(plasma%spec(0)%T, rg_grid%npts_b)
+        call reallocate(plasma%spec(0)%Vpar, rg_grid%npts_b)
         plasma%q  = q_win
         plasma%Er = Er_win
         plasma%spec(0)%n = n_win(:, 0)
         plasma%spec(0)%T = T_win(:, 0)
+        plasma%spec(0)%Vpar = Vpar_win(:, 0)
         do sigma = 1, number_of_ion_species
             call reallocate(plasma%spec(sigma)%n, rg_grid%npts_b)
             call reallocate(plasma%spec(sigma)%T, rg_grid%npts_b)
+            call reallocate(plasma%spec(sigma)%Vpar, rg_grid%npts_b)
             plasma%spec(sigma)%n = n_win(:, sigma)
             plasma%spec(sigma)%T = T_win(:, sigma)
+            plasma%spec(sigma)%Vpar = Vpar_win(:, sigma)
         end do
 
         ! Force calculate_equil / calc_plasma_parameter_derivs to recompute the
@@ -429,7 +448,7 @@ contains
         end do
         if (allocated(plasma%dqdr)) deallocate(plasma%dqdr)
 
-        deallocate(r_win, n_win, T_win, q_win, Er_win)
+        deallocate(r_win, n_win, T_win, Vpar_win, q_win, Er_win)
 
         ! ---- 4./5. Recompute derivatives + all derived quantities. ------------
         ! calculate_equil: recomputes dndr/dTdr/dqdr (via calc_plasma_parameter_
@@ -556,11 +575,13 @@ contains
             dfdr(N) = (f(1) - f(N-1)) / (2.0_dp * h)
         end subroutine periodic_central_diff
 
-        subroutine enforce_dependent_main_ion_density(density, temperature, status)
+        subroutine enforce_dependent_main_ion_density(density, temperature, &
+                                                      parallel_velocity, status)
             use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
             real(dp), intent(inout) :: density(:, 0:)
             real(dp), intent(in) :: temperature(:, 0:)
+            real(dp), intent(in) :: parallel_velocity(:, 0:)
             integer, intent(out) :: status
             real(dp) :: impurity_charge_density(size(density, 1))
             integer :: sp
@@ -577,7 +598,8 @@ contains
             if (any(.not. ieee_is_finite(density(:, 0))) .or. &
                 any(density(:, 0) <= 0.0_dp) .or. &
                 any(.not. ieee_is_finite(temperature)) .or. &
-                any(temperature <= 0.0_dp)) then
+                any(temperature <= 0.0_dp) .or. &
+                any(.not. ieee_is_finite(parallel_velocity))) then
                 return
             end if
             do sp = 2, number_of_ion_species
@@ -627,6 +649,7 @@ contains
                 if (allocated(plasma%spec(sp)%dndr_cc)) deallocate(plasma%spec(sp)%dndr_cc)
                 if (allocated(plasma%spec(sp)%T_cc)) deallocate(plasma%spec(sp)%T_cc)
                 if (allocated(plasma%spec(sp)%dTdr_cc)) deallocate(plasma%spec(sp)%dTdr_cc)
+                if (allocated(plasma%spec(sp)%Vpar_cc)) deallocate(plasma%spec(sp)%Vpar_cc)
                 if (allocated(plasma%spec(sp)%nu_cc)) deallocate(plasma%spec(sp)%nu_cc)
                 if (allocated(plasma%spec(sp)%vT_cc)) deallocate(plasma%spec(sp)%vT_cc)
                 if (allocated(plasma%spec(sp)%omega_c_cc)) deallocate(plasma%spec(sp)%omega_c_cc)

--- a/KIM/src/background_equilibrium/profile_input_m.f90
+++ b/KIM/src/background_equilibrium/profile_input_m.f90
@@ -5,7 +5,8 @@ module profile_input_m
     use KIM_kinds_m, only: dp
     use config_m, only: coord_type, input_profile_dir, equil_file, geqdsk_file, profile_location, &
                         n_input_file, Te_input_file, Ti_input_file, Vz_input_file, &
-                        n_file, Te_file, Ti_file, Vz_file, Er_file, q_file
+                        n_file, Te_file, Ti_file, Vz_file, parallel_flow_convention, &
+                        Er_file, q_file
     use setup_m, only: btor, R0
     use constants_m, only: e_charge, sol, ev
     use grid_m, only: r_min, r_plas
@@ -17,6 +18,12 @@ module profile_input_m
     public :: prepare_profiles
     ! I/O-free seams exercised by KIM/tests/test_profile_input*.f90
     public :: classify_coordinate_type, calculate_derivative, compute_er_force_balance
+    public :: read_parallel_flow_profile
+
+    integer, parameter, public :: FLOW_PROFILE_OK = 0
+    integer, parameter, public :: FLOW_PROFILE_AMBIGUOUS_CONVENTION = 1
+    integer, parameter, public :: FLOW_PROFILE_INCOMPATIBLE_COVERAGE = 2
+    integer, parameter, public :: FLOW_PROFILE_INVALID_DATA = 3
 
     ! Coordinate detection threshold
     real(dp), parameter :: COORD_THRESHOLD = 2.0_dp
@@ -412,6 +419,98 @@ contains
         deallocate(dn_dr, dTi_dr)
 
     end subroutine compute_er_force_balance
+
+    subroutine read_parallel_flow_profile(target_r, q, Vpar, info)
+        !> Read the configured equilibrium-flow profile onto target_r and return
+        !> the field-parallel velocity used by the drifting ion Maxwellians.
+        !>
+        !> Vz.dat is the cylindrical z component (the toroidal component in the
+        !> straight-cylinder model) already used by radial force balance. For a
+        !> flow parallel to B, Vz = h_z*V_parallel, with
+        !>   h_z = sign(B_z)/sqrt(1 + (r/(q R0))**2).
+        !> The projection V_parallel = Vz/h_z is applied exactly once here.
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        real(dp), intent(in) :: target_r(:), q(:)
+        real(dp), intent(out) :: Vpar(:)
+        integer, intent(out) :: info
+
+        real(dp), allocatable :: source_r(:), Vz_source(:), Vz_target(:)
+        real(dp) :: coverage_tol, hz, weight
+        integer :: n_source, i, j
+        character(512) :: filename
+        logical :: file_exists
+
+        info = FLOW_PROFILE_INVALID_DATA
+        Vpar = 0.0_dp
+        if (size(q) /= size(target_r) .or. size(Vpar) /= size(target_r)) return
+        if (size(target_r) < 1) return
+        if (any(.not. ieee_is_finite(target_r)) .or. &
+            any(.not. ieee_is_finite(q))) return
+
+        filename = trim(profile_location)//'/'//trim(Vz_file)
+        inquire(file=trim(filename), exist=file_exists)
+        if (.not. file_exists) then
+            info = FLOW_PROFILE_OK
+            return
+        end if
+
+        call read_profile_data(trim(filename), source_r, Vz_source, n_source)
+        if (n_source < 2 .or. any(.not. ieee_is_finite(source_r)) .or. &
+            any(.not. ieee_is_finite(Vz_source))) return
+        do i = 2, n_source
+            if (source_r(i) <= source_r(i - 1)) return
+        end do
+
+        coverage_tol = 100.0_dp*epsilon(1.0_dp)*max(1.0_dp, maxval(abs(target_r)))
+        if (minval(target_r) < source_r(1) - coverage_tol .or. &
+            maxval(target_r) > source_r(n_source) + coverage_tol) then
+            info = FLOW_PROFILE_INCOMPATIBLE_COVERAGE
+            return
+        end if
+
+        allocate(Vz_target(size(target_r)))
+        j = 1
+        do i = 1, size(target_r)
+            do while (j < n_source - 1 .and. source_r(j + 1) < target_r(i))
+                j = j + 1
+            end do
+            weight = (target_r(i) - source_r(j)) / &
+                     (source_r(j + 1) - source_r(j))
+            weight = max(0.0_dp, min(1.0_dp, weight))
+            Vz_target(i) = Vz_source(j) + weight*(Vz_source(j + 1) - Vz_source(j))
+        end do
+
+        if (maxval(abs(Vz_target)) <= tiny(1.0_dp)) then
+            info = FLOW_PROFILE_OK
+            deallocate(source_r, Vz_source, Vz_target)
+            return
+        end if
+        if (trim(parallel_flow_convention) /= 'toroidal') then
+            info = FLOW_PROFILE_AMBIGUOUS_CONVENTION
+            deallocate(source_r, Vz_source, Vz_target)
+            return
+        end if
+        if (abs(btor) <= tiny(1.0_dp) .or. abs(R0) <= tiny(1.0_dp) .or. &
+            any(abs(q) <= tiny(1.0_dp))) then
+            deallocate(source_r, Vz_source, Vz_target)
+            return
+        end if
+
+        do i = 1, size(target_r)
+            hz = sign(1.0_dp, btor) / &
+                 sqrt(1.0_dp + (target_r(i)/(q(i)*R0))**2)
+            Vpar(i) = Vz_target(i)/hz
+        end do
+        if (any(.not. ieee_is_finite(Vpar))) then
+            Vpar = 0.0_dp
+            deallocate(source_r, Vz_source, Vz_target)
+            return
+        end if
+
+        info = FLOW_PROFILE_OK
+        deallocate(source_r, Vz_source, Vz_target)
+    end subroutine read_parallel_flow_profile
 
     subroutine read_profile_data(filename, r, data, npts)
         !> Read two-column profile data file

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -33,6 +33,9 @@ module species_m
         real(dp), allocatable :: dndr(:) ! density gradient
         real(dp), allocatable :: T(:) ! temperature
         real(dp), allocatable :: dTdr(:) ! temperature gradient
+        ! Field-parallel equilibrium Maxwellian drift [cm/s]. File input Vz is
+        ! projected from the cylindrical toroidal component before storage.
+        real(dp), allocatable :: Vpar(:)
         real(dp), allocatable :: A1(:) ! thermodynamic force
         real(dp), allocatable :: A2(:) ! thermodynamic force
         real(dp), allocatable :: nu(:) ! collision frequency
@@ -61,6 +64,7 @@ module species_m
         real(dp), allocatable :: dndr_cc(:)
         real(dp), allocatable :: T_cc(:)
         real(dp), allocatable :: dTdr_cc(:)
+        real(dp), allocatable :: Vpar_cc(:)
         real(dp), allocatable :: A1_cc(:)
         real(dp), allocatable :: A2_cc(:)
         real(dp), allocatable :: nu_cc(:)
@@ -304,6 +308,7 @@ module species_m
                 allocate(plasma_in%spec(sp)%dndr_cc(rg_grid%npts_c))
                 allocate(plasma_in%spec(sp)%T_cc(rg_grid%npts_c))
                 allocate(plasma_in%spec(sp)%dTdr_cc(rg_grid%npts_c))
+                allocate(plasma_in%spec(sp)%Vpar_cc(rg_grid%npts_c))
                 allocate(plasma_in%spec(sp)%nu_cc(rg_grid%npts_c))
                 allocate(plasma_in%spec(sp)%vT_cc(rg_grid%npts_c))
                 allocate(plasma_in%spec(sp)%omega_c_cc(rg_grid%npts_c))
@@ -321,6 +326,7 @@ module species_m
                 plasma_in%spec(sp)%dndr_cc(j)     = 0.5d0 * (plasma_in%spec(sp)%dndr(j)     + plasma_in%spec(sp)%dndr(j+1))
                 plasma_in%spec(sp)%T_cc(j)        = 0.5d0 * (plasma_in%spec(sp)%T(j)        + plasma_in%spec(sp)%T(j+1))
                 plasma_in%spec(sp)%dTdr_cc(j)     = 0.5d0 * (plasma_in%spec(sp)%dTdr(j)     + plasma_in%spec(sp)%dTdr(j+1))
+                plasma_in%spec(sp)%Vpar_cc(j)     = 0.5d0 * (plasma_in%spec(sp)%Vpar(j)     + plasma_in%spec(sp)%Vpar(j+1))
                 plasma_in%spec(sp)%nu_cc(j)       = 0.5d0 * (plasma_in%spec(sp)%nu(j)       + plasma_in%spec(sp)%nu(j+1))
                 plasma_in%spec(sp)%vT_cc(j)       = 0.5d0 * (plasma_in%spec(sp)%vT(j)       + plasma_in%spec(sp)%vT(j+1))
                 plasma_in%spec(sp)%omega_c_cc(j)  = 0.5d0 * (plasma_in%spec(sp)%omega_c(j)  + plasma_in%spec(sp)%omega_c(j+1))
@@ -401,8 +407,17 @@ module species_m
                 plasma_in%spec(sp)%x1(j) = plasma_in%kp(j) * plasma_in%spec(sp)%vT(j) / plasma_in%spec(sp)%nu(j)
                 do mphi = -mphi_max, mphi_max
                     plasma_in%spec(sp)%x2(j, mphi) = - (plasma_in%om_E(j) & !* ion_flr_scale_factor & !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
-                                                    + mphi * plasma%spec(sp)%omega_c(j)  - omega) &
+                                                    + mphi * plasma_in%spec(sp)%omega_c(j)  - omega) &
                                                     / plasma_in%spec(sp)%nu(j)
+                    ! Preserve the historical operation sequence bit-for-bit
+                    ! when Vpar=0; enabled drifting species receive the Doppler
+                    ! correction -k_parallel*Vpar/nu.
+                    if (abs(plasma_in%spec(sp)%Vpar(j)) > tiny(1.0_dp)) then
+                        plasma_in%spec(sp)%x2(j, mphi) = &
+                            plasma_in%spec(sp)%x2(j, mphi) - &
+                            plasma_in%kp(j)*plasma_in%spec(sp)%Vpar(j) / &
+                            plasma_in%spec(sp)%nu(j)
+                    end if
 
                     call getIfunc(plasma_in%spec(sp)%x1(j), plasma_in%spec(sp)%x2(j, mphi), plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
@@ -434,6 +449,12 @@ module species_m
                     plasma_in%spec(sp)%x2_cc(j, mphi) = - (plasma_in%om_E_cc(j)  & !* ion_flr_scale_factor & !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                                                         + mphi * plasma_in%spec(sp)%omega_c(j) - omega) &
                                                         / plasma_in%spec(sp)%nu_cc(j)
+                    if (abs(plasma_in%spec(sp)%Vpar_cc(j)) > tiny(1.0_dp)) then
+                        plasma_in%spec(sp)%x2_cc(j, mphi) = &
+                            plasma_in%spec(sp)%x2_cc(j, mphi) - &
+                            0.5_dp*(plasma_in%kp(j) + plasma_in%kp(j + 1))* &
+                            plasma_in%spec(sp)%Vpar_cc(j) / plasma_in%spec(sp)%nu_cc(j)
+                    end if
 
                     call getIfunc(plasma_in%spec(sp)%x1_cc(j), plasma_in%spec(sp)%x2_cc(j, mphi), plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00_cc(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
@@ -651,6 +672,9 @@ module species_m
             'Temperature T', 'eV')
         call write_profile(r_grid, spec%n, size(r_grid), 'backs/'//trim(spec%name)//'/n', &
             'Particle density n', '1/cm^3')
+        call write_profile(r_grid, spec%Vpar, size(r_grid), &
+            'backs/'//trim(spec%name)//'/Vpar', &
+            'Field-parallel equilibrium Maxwellian drift', 'cm/s')
 
     end subroutine
 
@@ -782,6 +806,7 @@ module species_m
                 plasma_temp%spec(sp)%dndr(i)     = sum(coef(0,:) * plasma_in%spec(sp)%dndr(ibeg:iend))
                 plasma_temp%spec(sp)%T(i)        = sum(coef(0,:) * plasma_in%spec(sp)%T(ibeg:iend))
                 plasma_temp%spec(sp)%dTdr(i)     = sum(coef(0,:) * plasma_in%spec(sp)%dTdr(ibeg:iend))
+                plasma_temp%spec(sp)%Vpar(i)     = sum(coef(0,:) * plasma_in%spec(sp)%Vpar(ibeg:iend))
                 plasma_temp%spec(sp)%nu(i)       = sum(coef(0,:) * plasma_in%spec(sp)%nu(ibeg:iend))
                 plasma_temp%spec(sp)%vT(i)       = sum(coef(0,:) * plasma_in%spec(sp)%vT(ibeg:iend))
                 plasma_temp%spec(sp)%omega_c(i)  = sum(coef(0,:) * plasma_in%spec(sp)%omega_c(ibeg:iend))
@@ -818,6 +843,7 @@ module species_m
         call reallocate(spec%dndr, grid_size)
         call reallocate(spec%T, grid_size)
         call reallocate(spec%dTdr, grid_size)
+        call reallocate(spec%Vpar, grid_size)
         call reallocate(spec%nu, grid_size)
         call reallocate(spec%vT, grid_size)
         call reallocate(spec%omega_c, grid_size)
@@ -1070,7 +1096,8 @@ module species_m
 
     end subroutine
 
-    subroutine set_profiles_from_arrays(r_in, n_in, Te_in, Ti_in, q_in, Er_in, npts)
+    subroutine set_profiles_from_arrays(r_in, n_in, Te_in, Ti_in, q_in, Er_in, &
+                                        npts, Vpar_in)
         !! Populate the module-level `plasma` struct from arrays passed by
         !! the caller (e.g. QL-Balance).  Replicates the effect of
         !! read_from_text but without file I/O.  Handles reallocation for
@@ -1089,6 +1116,9 @@ module species_m
         real(dp), intent(in) :: Ti_in(npts)
         real(dp), intent(in) :: q_in(npts)
         real(dp), intent(in) :: Er_in(npts)
+        ! Explicit field-parallel ion flow. All ions are enabled; electrons
+        ! remain stationary. Omission preserves the historical zero-flow path.
+        real(dp), intent(in), optional :: Vpar_in(npts)
 
         integer :: sigma, total_Z
 
@@ -1120,11 +1150,19 @@ module species_m
         call reallocate(plasma%spec(0)%T, npts)
         plasma%spec(0)%n = n_in
         plasma%spec(0)%T = Te_in
+        call reallocate(plasma%spec(0)%Vpar, npts)
+        plasma%spec(0)%Vpar = 0.0_dp
 
         ! Ion temperatures (all ion species get Ti)
         do sigma = 1, number_of_ion_species
             call reallocate(plasma%spec(sigma)%T, npts)
             plasma%spec(sigma)%T = Ti_in
+            call reallocate(plasma%spec(sigma)%Vpar, npts)
+            if (present(Vpar_in)) then
+                plasma%spec(sigma)%Vpar = Vpar_in
+            else
+                plasma%spec(sigma)%Vpar = 0.0_dp
+            end if
         end do
 
         ! Enforce quasineutrality for ion densities
@@ -1192,14 +1230,18 @@ module species_m
         use KIM_kinds_m, only: dp
         use setup_m, only: set_profiles_constant
         use grid_m, only: r_plas
+        use profile_input_m, only: read_parallel_flow_profile, FLOW_PROFILE_OK, &
+                                   FLOW_PROFILE_AMBIGUOUS_CONVENTION, &
+                                   FLOW_PROFILE_INCOMPATIBLE_COVERAGE
 
         implicit none
 
         integer :: i, sigma
         integer :: ierr
         integer :: ios
-        integer :: total_Z
+        integer :: total_Z, flow_info
         real(dp) :: r_temp
+        real(dp), allocatable :: Vpar(:)
 
         call log_info('Reading profiles from text files')
 
@@ -1261,6 +1303,31 @@ module species_m
         end do
         close(11)
 
+        ! Vz.dat is the toroidal/axial velocity used by force balance. The
+        ! profile-input module validates coverage and projects it once to the
+        ! field-parallel Maxwellian drift stored on every ion species.
+        allocate(Vpar(plasma%grid_size))
+        call read_parallel_flow_profile(plasma%r_grid, plasma%q, Vpar, flow_info)
+        if (flow_info /= FLOW_PROFILE_OK) then
+            if (flow_info == FLOW_PROFILE_AMBIGUOUS_CONVENTION) then
+                call log_error('Finite Vz profile requires parallel_flow_convention="toroidal"')
+            else if (flow_info == FLOW_PROFILE_INCOMPATIBLE_COVERAGE) then
+                call log_error('Vz profile does not cover the full plasma profile grid')
+            else
+                call log_error('Vz profile contains invalid flow data or geometry')
+            end if
+            error stop 'invalid equilibrium parallel-flow profile'
+        end if
+        do sigma = 0, number_of_ion_species
+            allocate(plasma%spec(sigma)%Vpar(plasma%grid_size))
+            if (sigma == 0) then
+                plasma%spec(sigma)%Vpar = 0.0_dp
+            else
+                plasma%spec(sigma)%Vpar = Vpar
+            end if
+        end do
+        deallocate(Vpar)
+
         total_Z = 0
         do sigma = 1, number_of_ion_species
             total_Z = total_Z + plasma%spec(sigma)%Zspec
@@ -1279,6 +1346,7 @@ module species_m
             do sigma = 0, number_of_ion_species
                 plasma%spec(sigma)%n(:) = plasma%spec(sigma)%n(1)
                 plasma%spec(sigma)%T(:) = plasma%spec(sigma)%T(1)
+                plasma%spec(sigma)%Vpar(:) = plasma%spec(sigma)%Vpar(1)
             end do
         end if
 

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -46,7 +46,8 @@ subroutine kim_read_config
 
     namelist /KIM_PROFILES/ coord_type, input_profile_dir, equil_file, geqdsk_file, &
                         n_input_file, Te_input_file, Ti_input_file, Vz_input_file, &
-                        n_file, Te_file, Ti_file, Vz_file, Er_file, q_file
+                        n_file, Te_file, Ti_file, Vz_file, parallel_flow_convention, &
+                        Er_file, q_file
 
     ! Optional group for the forced-periodicity electrostatic run-type. Read
     ! separately (iostat-guarded, below) so config files without it still parse.

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -77,6 +77,9 @@ module config_m
     character(256) :: Te_file = 'Te.dat'
     character(256) :: Ti_file = 'Ti.dat'
     character(256) :: Vz_file = 'Vz.dat'
+    ! Velocity stored in Vz_file. 'toroidal' means the cylindrical z/toroidal
+    ! component used by radial force balance; 'none' permits only zero flow.
+    character(20) :: parallel_flow_convention = 'none'
     character(256) :: Er_file = 'Er.dat'
     character(256) :: q_file = 'q.dat'
 

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -135,6 +135,18 @@ add_test(NAME test_periodic_background_build
 set_tests_properties(test_periodic_background_build PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
 
+# Equilibrium parallel-flow contribution to harmonic-resolved FP x2, including
+# the global and forced-periodic background paths.
+add_executable(test_fp_parallel_flow ${CMAKE_SOURCE_DIR}/KIM/tests/test_fp_parallel_flow.f90)
+set_target_properties(test_fp_parallel_flow PROPERTIES
+                        OUTPUT_NAME test_fp_parallel_flow.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_fp_parallel_flow KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_fp_parallel_flow
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_fp_parallel_flow.x)
+set_tests_properties(test_fp_parallel_flow PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
 # Assemble the dense periodic Fourier matrices K_{m,m'} (Phase-2.4).
 add_executable(test_periodic_assembly ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_assembly.f90)
 set_target_properties(test_periodic_assembly PROPERTIES

--- a/KIM/tests/test_data/KIM_config_em_small.nml
+++ b/KIM/tests/test_data/KIM_config_em_small.nml
@@ -106,6 +106,7 @@
     Te_file = 'Te.dat'
     Ti_file = 'Ti.dat'
     Vz_file = 'Vz.dat'
+    parallel_flow_convention = 'toroidal'
     Er_file = 'Er.dat'
     q_file = 'q.dat'
 /

--- a/KIM/tests/test_fp_parallel_flow.f90
+++ b/KIM/tests/test_fp_parallel_flow.f90
@@ -1,0 +1,347 @@
+program test_fp_parallel_flow
+    use KIM_kinds_m, only: dp
+    use periodic_background_m, only: build_periodic_plasma, &
+                                     sample_periodic_species_profiles
+    use profile_input_m, only: read_parallel_flow_profile, FLOW_PROFILE_OK, &
+                               FLOW_PROFILE_AMBIGUOUS_CONVENTION, &
+                               FLOW_PROFILE_INCOMPATIBLE_COVERAGE
+
+    implicit none
+
+    call test_global_and_periodic_flow()
+    call test_file_input_contract()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_global_and_periodic_flow()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use grid_m, only: rg_grid
+        use setup_m, only: omega
+
+        integer, parameter :: npts = 201
+        real(dp) :: r(npts), ne(npts), Te(npts), Ti(npts), q(npts), Er(npts)
+        real(dp) :: Vpar(npts), rm, rho_ref, dx_asis, dx_tr, period_length
+        real(dp) :: r_asis, Vpar_true, Vpar_built, expected, delta_expected
+        real(dp), allocatable :: x2_zero_e(:, :), x2_zero_i(:, :)
+        complex(dp), allocatable :: I00_zero_i(:, :)
+        real(dp) :: n_per(0:1), T_per(0:1), Vpar_per(0:1)
+        real(dp) :: n_shift(0:1), T_shift(0:1), Vpar_shift(0:1)
+        real(dp) :: q_per, Er_per, q_shift, Er_shift
+        class(kim_t), allocatable :: kim_instance
+        integer :: j, mphi, n_rg
+
+        call make_profiles(r, ne, Te, Ti, q, Er)
+        call write_test_namelist('./KIM_config_fp_parallel_flow.nml')
+        nml_config_path = './KIM_config_fp_parallel_flow.nml'
+        profiles_in_memory = .true.
+        call kim_init()
+
+        ! Baseline: an explicitly zero field-parallel ion flow must retain the
+        ! exact historical arithmetic for x2 and its susceptibility tables.
+        Vpar = 0.0_dp
+        call set_profiles_from_arrays(r, ne, Te, Ti, q, Er, npts, Vpar_in=Vpar)
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        allocate(x2_zero_e(size(plasma%spec(0)%x2, 1), -1:1))
+        allocate(x2_zero_i(size(plasma%spec(1)%x2, 1), -1:1))
+        allocate(I00_zero_i(size(plasma%spec(1)%I00, 1), -1:1))
+        x2_zero_e = plasma%spec(0)%x2
+        x2_zero_i = plasma%spec(1)%x2
+        I00_zero_i = plasma%spec(1)%I00
+
+        do j = 1, rg_grid%npts_b
+            do mphi = -1, 1
+                expected = -(plasma%om_E(j) + &
+                    real(mphi, dp)*plasma%spec(1)%omega_c(j) - omega) / &
+                    plasma%spec(1)%nu(j)
+                call assert_bitwise_equal('zero-flow x2', &
+                                          plasma%spec(1)%x2(j, mphi), expected)
+            end do
+        end do
+        print *, 'PASS: zero flow is bitwise equivalent to the historical x2 formula'
+
+        ! Finite constant field-parallel flow: all ion harmonics receive the
+        ! same -kp*Vpar/nu shift, while the non-drifting electrons are unchanged.
+        Vpar = 2.5e6_dp
+        call set_profiles_from_arrays(r, ne, Te, Ti, q, Er, npts, Vpar_in=Vpar)
+        call kim_instance%init()
+
+        do j = 1, rg_grid%npts_b
+            if (abs(plasma%spec(0)%Vpar(j)) > tiny(1.0_dp)) then
+                print *, 'FAIL: electron Maxwellian was enabled for ion flow'
+                error stop
+            end if
+            call assert_relative_close('constant ion Vpar', plasma%spec(1)%Vpar(j), &
+                                       Vpar(1), 10.0_dp*epsilon(1.0_dp))
+            do mphi = -1, 1
+                expected = -(plasma%om_E(j) + plasma%kp(j)*plasma%spec(1)%Vpar(j) + &
+                    real(mphi, dp)*plasma%spec(1)%omega_c(j) - omega) / &
+                    plasma%spec(1)%nu(j)
+                call assert_relative_close('finite-flow x2', &
+                                           plasma%spec(1)%x2(j, mphi), expected, 5.0e-13_dp)
+                delta_expected = -plasma%kp(j)*plasma%spec(1)%Vpar(j) / &
+                                 plasma%spec(1)%nu(j)
+                call assert_relative_close('finite-flow x2 shift', &
+                    plasma%spec(1)%x2(j, mphi) - x2_zero_i(j, mphi), &
+                    delta_expected, 1.0e-10_dp)
+                call assert_bitwise_equal('stationary-electron x2', &
+                                          plasma%spec(0)%x2(j, mphi), &
+                                          x2_zero_e(j, mphi))
+            end do
+        end do
+        if (maxval(abs(plasma%spec(1)%I00 - I00_zero_i)) <= 100.0_dp*epsilon(1.0_dp)) then
+            print *, 'FAIL: finite flow did not change ion susceptibility'
+            error stop
+        end if
+        print *, 'PASS: finite flow shifts every ion harmonic with the correct sign'
+
+        ! Preserve the same field-parallel profile through forced periodization.
+        call prepare_resonances
+        rm = r_res
+        if (.not. (rm > 0.0_dp)) error stop 'parallel-flow test resonance not found'
+        j = minloc(abs(plasma%r_grid - rm), dim=1)
+        rho_ref = plasma%spec(1)%rho_L(j)
+        dx_asis = 5.0_dp*rho_ref
+        dx_tr = 10.0_dp*rho_ref
+        n_rg = 96
+        r_asis = rm + 0.5_dp*dx_asis
+        Vpar_true = interp_lagrange4(plasma%r_grid, plasma%spec(1)%Vpar, &
+                                     plasma%grid_size, r_asis)
+
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+        Vpar_built = interp_lagrange4(rg_grid%xb, plasma%spec(1)%Vpar, &
+                                      plasma%grid_size, r_asis)
+        call assert_relative_close('periodic as-is Vpar', Vpar_built, Vpar_true, 1.0e-10_dp)
+
+        period_length = 2.0_dp*(dx_asis + dx_tr)
+        call sample_periodic_species_profiles(rm, dx_asis, dx_tr, &
+            rm - 0.5_dp*period_length, n_per, T_per, q_per, Er_per, Vpar_per)
+        call sample_periodic_species_profiles(rm, dx_asis, dx_tr, &
+            rm + 0.5_dp*period_length, n_shift, T_shift, q_shift, Er_shift, Vpar_shift)
+        call assert_relative_close('periodic seam Vpar', Vpar_shift(1), &
+                                   Vpar_per(1), 1.0e-12_dp)
+
+        do j = 1, rg_grid%npts_b
+            do mphi = -1, 1
+                expected = -(plasma%om_E(j) + plasma%kp(j)*plasma%spec(1)%Vpar(j) + &
+                    real(mphi, dp)*plasma%spec(1)%omega_c(j) - omega) / &
+                    plasma%spec(1)%nu(j)
+                if (.not. ieee_is_finite(plasma%spec(1)%x2(j, mphi))) then
+                    print *, 'FAIL: non-finite periodic x2 at ', j, mphi
+                    error stop
+                end if
+                call assert_relative_close('periodic finite-flow x2', &
+                                           plasma%spec(1)%x2(j, mphi), expected, 5.0e-13_dp)
+            end do
+        end do
+        print *, 'PASS: finite flow survives periodization and susceptibility rebuild'
+    end subroutine test_global_and_periodic_flow
+
+    subroutine test_file_input_contract()
+        use config_m, only: profile_location, Vz_file, parallel_flow_convention
+        use setup_m, only: btor, R0
+
+        real(dp) :: r(5), q(5), velocity(5), Vpar(5), expected_hz
+        integer :: info, i, iunit
+
+        call execute_command_line('mkdir -p ./flow_profile_contract')
+        profile_location = './flow_profile_contract'
+        Vz_file = 'Vz.dat'
+        r = [10.0_dp, 20.0_dp, 30.0_dp, 40.0_dp, 50.0_dp]
+        q = 3.0_dp
+        velocity = 1.0e6_dp
+        call write_flow_file(trim(profile_location)//'/'//trim(Vz_file), r, velocity)
+
+        parallel_flow_convention = 'none'
+        call read_parallel_flow_profile(r, q, Vpar, info)
+        if (info /= FLOW_PROFILE_AMBIGUOUS_CONVENTION) then
+            print *, 'FAIL: undeclared finite velocity convention status = ', info
+            error stop
+        end if
+
+        parallel_flow_convention = 'toroidal'
+        call read_parallel_flow_profile(r, q, Vpar, info)
+        if (info /= FLOW_PROFILE_OK) then
+            print *, 'FAIL: valid toroidal velocity profile status = ', info
+            error stop
+        end if
+        do i = 1, size(r)
+            expected_hz = sign(1.0_dp, btor) / &
+                          sqrt(1.0_dp + (r(i)/(q(i)*R0))**2)
+            call assert_relative_close('toroidal-to-parallel projection', Vpar(i), &
+                                       velocity(i)/expected_hz, 5.0e-15_dp)
+        end do
+
+        call write_flow_file(trim(profile_location)//'/'//trim(Vz_file), &
+                             r(2:4), velocity(2:4))
+        call read_parallel_flow_profile(r, q, Vpar, info)
+        if (info /= FLOW_PROFILE_INCOMPATIBLE_COVERAGE) then
+            print *, 'FAIL: short velocity profile coverage status = ', info
+            error stop
+        end if
+
+        open(newunit=iunit, file=trim(profile_location)//'/'//trim(Vz_file), &
+             status='old')
+        close(iunit, status='delete')
+        print *, 'PASS: velocity convention and radial coverage are validated'
+    end subroutine test_file_input_contract
+
+    subroutine make_profiles(r, ne, Te, Ti, q, Er)
+        real(dp), intent(out) :: r(:), ne(:), Te(:), Ti(:), q(:), Er(:)
+        integer :: i
+
+        do i = 1, size(r)
+            r(i) = 2.0_dp + 58.0_dp*real(i - 1, dp)/real(size(r) - 1, dp)
+            ne(i) = 2.0e13_dp*(1.1_dp - r(i)/100.0_dp)
+            Te(i) = 1.0e3_dp*(1.2_dp - r(i)/100.0_dp)
+            Ti(i) = 0.8e3_dp*(1.15_dp - r(i)/120.0_dp)
+            q(i) = 1.5_dp + 2.5_dp*(r(i) - 2.0_dp)/58.0_dp
+            Er(i) = -0.5_dp
+        end do
+    end subroutine make_profiles
+
+    subroutine write_flow_file(path, r, velocity)
+        character(len=*), intent(in) :: path
+        real(dp), intent(in) :: r(:), velocity(:)
+        integer :: i, iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        do i = 1, size(r)
+            write(iunit, '(2(ES24.16,1X))') r(i), velocity(i)
+        end do
+        close(iunit)
+    end subroutine write_flow_file
+
+    subroutine assert_bitwise_equal(label, actual, expected)
+        use, intrinsic :: iso_fortran_env, only: int64
+
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected
+
+        if (transfer(actual, 0_int64) /= transfer(expected, 0_int64)) then
+            print *, 'FAIL: ', trim(label), ' is not bitwise equal'
+            print *, '  actual = ', actual, ' expected = ', expected
+            error stop
+        end if
+    end subroutine assert_bitwise_equal
+
+    subroutine assert_relative_close(label, actual, expected, tolerance)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected, tolerance
+        real(dp) :: relative_error
+
+        relative_error = abs(actual - expected) / max(abs(expected), tiny(1.0_dp))
+        if (relative_error > tolerance) then
+            print *, 'FAIL: ', trim(label)
+            print *, '  actual = ', actual, ' expected = ', expected
+            print *, '  relative error = ', relative_error, ' tolerance = ', tolerance
+            error stop
+        end if
+    end subroutine assert_relative_close
+
+    real(dp) function interp_lagrange4(grid, vals, ngrid, x) result(fx)
+        integer, intent(in) :: ngrid
+        real(dp), intent(in) :: grid(ngrid), vals(ngrid), x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: ir, ibeg, iend
+
+        call binsrc(grid, 1, ngrid, x, ir)
+        ibeg = max(1, ir - nlagr/2)
+        iend = ibeg + nlagr - 1
+        if (iend > ngrid) then
+            iend = ngrid
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, grid(ibeg:iend), coef)
+        fx = sum(coef(0, :)*vals(ibeg:iend))
+    end function interp_lagrange4
+
+    subroutine write_test_namelist(path)
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_fp_parallel_flow/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 1'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') " parallel_flow_convention = 'none'"
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_fp_parallel_flow


### PR DESCRIPTION
## Summary

- add toroidal-flow profile input and configuration plumbing
- include the parallel-flow contribution in the FP susceptibility argument x2
- verify zero-flow compatibility, sign behavior, interpolation, and periodic-background handling

## Why

The FP response now represents the configured plasma flow instead of silently omitting its parallel component.

## Validation

Validated cumulatively at the stack head:

- `cmake --build build -j2`
- `ctest --test-dir build -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global' --output-on-failure` — 35/35 passed

Known red gates are intentionally excluded from that command: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation acceptance gate, and the unresolved periodic-vs-global 5% agreement gate.

## Stack

Base: `fix/kim-fp-02-multispecies-background`
Head: `fix/kim-fp-37-parallel-flow`

Closes #37