### PR TITLE
[kim-fp-05] Make periodic convergence and solve checks hard gates

### DIFF
--- a/KIM/src/electrostatic_poisson/periodic_solve.f90
+++ b/KIM/src/electrostatic_poisson/periodic_solve.f90
@@ -22,6 +22,12 @@ module periodic_solve_m
     integer, parameter, public :: PERIODIC_SOLVE_GAUGE_REQUIRED = -101
     integer, parameter, public :: PERIODIC_SOLVE_INCOMPATIBLE_NULLSPACE = -102
     integer, parameter, public :: PERIODIC_SOLVE_PROJECTION_REJECTED = -103
+    integer, parameter, public :: PERIODIC_SOLVE_ILL_CONDITIONED = -104
+    integer, parameter, public :: PERIODIC_SOLVE_INACCURATE = -105
+    integer, parameter, public :: PERIODIC_SOLVE_NONFINITE = -106
+    integer, parameter, public :: PERIODIC_SOLVE_SINGULAR = -107
+    real(dp), parameter, public :: SOLVE_RCOND_TOLERANCE = 1.0e-12_dp
+    real(dp), parameter, public :: SOLVE_RESIDUAL_TOLERANCE = 1.0e-10_dp
 
     public :: solve_periodic, solve_periodic_deviation
     public :: assemble_periodic_operator, magnetic_drive_rhs
@@ -222,7 +228,11 @@ contains
         end if
 
         call dense_solve(A, rhs, info)
-        solution = rhs
+        if (info == PERIODIC_SOLVE_OK) then
+            solution = rhs
+        else
+            solution = (0.0_dp, 0.0_dp)
+        end if
     end subroutine solve_with_derived_gauge
 
     subroutine project_onto_periodic_basis(values, r_nodes, L, M, coefficients)
@@ -277,16 +287,164 @@ contains
         second_derivative = (120.0_dp * t**3 - 180.0_dp * t**2 + 60.0_dp * t) / width**2
     end subroutine smootherstep_with_second
 
-    subroutine dense_solve(A, b, info)
+    subroutine dense_solve(A, b, info, reciprocal_condition, backward_error)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
         complex(dp), intent(inout) :: A(:,:), b(:)
         integer, intent(out) :: info
+        real(dp), intent(out), optional :: reciprocal_condition, backward_error
 
         integer, allocatable :: ipiv(:)
-        integer :: dim
+        complex(dp), allocatable :: A0(:,:), b0(:), A_condition(:,:)
+        complex(dp), allocatable :: condition_work(:), residual(:)
+        real(dp), allocatable :: condition_real_work(:)
+        real(dp) :: anorm, condition_scale, matrix_norm, solution_norm, rhs_norm
+        real(dp) :: residual_norm, rcond_local, backward_error_local
+        integer :: dim, condition_info
 
         dim = size(A, 1)
+        rcond_local = 0.0_dp
+        backward_error_local = huge(1.0_dp)
+        if (size(A, 2) /= dim .or. size(b) /= dim .or. dim == 0) then
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            call export_diagnostics()
+            return
+        end if
+        if (.not. all(ieee_is_finite(real(A, dp))) .or. &
+            .not. all(ieee_is_finite(aimag(A))) .or. &
+            .not. all(ieee_is_finite(real(b, dp))) .or. &
+            .not. all(ieee_is_finite(aimag(b)))) then
+            info = PERIODIC_SOLVE_NONFINITE
+            call export_diagnostics()
+            return
+        end if
+
+        A0 = A
+        b0 = b
         allocate(ipiv(dim))
         call zgesv(dim, 1, A, dim, ipiv, b, dim, info)
+        if (info /= 0) then
+            if (info > 0) then
+                info = PERIODIC_SOLVE_SINGULAR
+            else
+                info = PERIODIC_SOLVE_INVALID_INPUT
+            end if
+            call export_diagnostics()
+            return
+        end if
+        if (.not. all(ieee_is_finite(real(b, dp))) .or. &
+            .not. all(ieee_is_finite(aimag(b)))) then
+            info = PERIODIC_SOLVE_NONFINITE
+            call export_diagnostics()
+            return
+        end if
+
+        ! ZGECON estimates reciprocal condition number in the matrix 1-norm.
+        ! Uniform scaling preserves the condition number and prevents the
+        ! column sums/factorization used only for estimation from overflowing.
+        condition_scale = maxval(abs(A0))
+        A_condition = A0 / condition_scale
+        anorm = maxval(sum(abs(A_condition), dim=1))
+        call zgetrf(dim, dim, A_condition, dim, ipiv, condition_info)
+        if (condition_info /= 0) then
+            if (condition_info > 0) then
+                info = PERIODIC_SOLVE_SINGULAR
+            else
+                info = PERIODIC_SOLVE_INVALID_INPUT
+            end if
+            call export_diagnostics()
+            return
+        end if
+        allocate(condition_work(2*dim), condition_real_work(2*dim))
+        call zgecon('1', dim, A_condition, dim, anorm, rcond_local, &
+                    condition_work, condition_real_work, condition_info)
+        if (condition_info /= 0) then
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            call export_diagnostics()
+            return
+        end if
+
+        ! Frobenius/L2 norms give a submultiplicative scaled backward residual.
+        residual = matmul(A0, b) - b0
+        if (.not. all(ieee_is_finite(real(residual, dp))) .or. &
+            .not. all(ieee_is_finite(aimag(residual)))) then
+            info = PERIODIC_SOLVE_NONFINITE
+            call export_diagnostics()
+            return
+        end if
+        matrix_norm = scaled_matrix_norm(A0)
+        solution_norm = scaled_vector_norm(b)
+        rhs_norm = scaled_vector_norm(b0)
+        residual_norm = scaled_vector_norm(residual)
+        backward_error_local = scaled_backward_ratio(residual_norm, matrix_norm, &
+                                                     solution_norm, rhs_norm)
+
+        if (.not. ieee_is_finite(rcond_local) .or. &
+            .not. ieee_is_finite(backward_error_local)) then
+            info = PERIODIC_SOLVE_NONFINITE
+        else if (rcond_local <= SOLVE_RCOND_TOLERANCE) then
+            info = PERIODIC_SOLVE_ILL_CONDITIONED
+        else if (backward_error_local >= SOLVE_RESIDUAL_TOLERANCE) then
+            info = PERIODIC_SOLVE_INACCURATE
+        else
+            info = PERIODIC_SOLVE_OK
+        end if
+        call export_diagnostics()
+
+    contains
+
+        subroutine export_diagnostics()
+            if (present(reciprocal_condition)) reciprocal_condition = rcond_local
+            if (present(backward_error)) backward_error = backward_error_local
+            write(*, '(A,ES12.4,A,ES12.4,A,I0)') ' dense_solve: rcond=', &
+                rcond_local, ' backward_error=', backward_error_local, &
+                ' status=', info
+        end subroutine export_diagnostics
+
+        real(dp) function scaled_vector_norm(values) result(norm)
+            complex(dp), intent(in) :: values(:)
+            real(dp) :: scale
+
+            scale = maxval(abs(values))
+            if (scale > 0.0_dp) then
+                norm = scale * sqrt(sum((abs(values)/scale)**2))
+            else
+                norm = 0.0_dp
+            end if
+        end function scaled_vector_norm
+
+        real(dp) function scaled_matrix_norm(values) result(norm)
+            complex(dp), intent(in) :: values(:,:)
+            real(dp) :: scale
+
+            scale = maxval(abs(values))
+            if (scale > 0.0_dp) then
+                norm = scale * sqrt(sum((abs(values)/scale)**2))
+            else
+                norm = 0.0_dp
+            end if
+        end function scaled_matrix_norm
+
+        real(dp) function scaled_backward_ratio(residual_norm, matrix_norm, &
+                                                solution_norm, rhs_norm) result(ratio)
+            real(dp), intent(in) :: residual_norm, matrix_norm, solution_norm, rhs_norm
+            real(dp) :: product_norm, scale
+
+            if (matrix_norm > 0.0_dp .and. solution_norm > 0.0_dp .and. &
+                matrix_norm > huge(1.0_dp)/solution_norm) then
+                ratio = (residual_norm/matrix_norm)/solution_norm
+                return
+            end if
+            product_norm = matrix_norm * solution_norm
+            scale = max(product_norm, rhs_norm)
+            if (scale > 0.0_dp) then
+                ratio = (residual_norm/scale) / &
+                        (product_norm/scale + rhs_norm/scale)
+            else
+                ratio = residual_norm
+            end if
+        end function scaled_backward_ratio
+
     end subroutine dense_solve
 
     function reconstruct_delta_phi(Phi_m, L, M, r_out) result(dPhi)

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -25,16 +25,64 @@ program test_periodic_convergence
 
     implicit none
 
+    real(dp), parameter :: numerical_tolerance = 1.0e-3_dp
+    real(dp), parameter :: deformation_tolerance = 1.0e-2_dp
+
     call test_reference_scale_validation()
+    call test_gate_policy()
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
     call test_M_convergence()
+    call test_harmonic_convergence()
     call test_dr_deformation_scan()
 
     print *, 'All tests PASSED'
     stop 0
 
 contains
+
+    subroutine test_gate_policy()
+        real(dp) :: converged(3), nonmonotone(3)
+
+        converged = [1.0e-1_dp, 1.0e-2_dp, 5.0e-4_dp]
+        nonmonotone = [0.3570_dp, 0.3028_dp, 0.7836_dp]
+        if (.not. sequence_passes_gate(converged, numerical_tolerance)) then
+            error stop 'convergence gate rejected a valid sequence'
+        end if
+        if (sequence_passes_gate(nonmonotone, deformation_tolerance)) then
+            error stop 'convergence gate accepted non-monotone 78% deformation'
+        end if
+        if (conservative_ceiling(256.0_dp + 8.0_dp*spacing(256.0_dp)) /= 256 .or. &
+            conservative_ceiling(256.25_dp) /= 257) then
+            error stop 'resolution ceiling mishandled integer roundoff'
+        end if
+        print *, 'PASS: hard convergence policy accepts/refuses declared fixtures'
+    end subroutine test_gate_policy
+
+    logical function sequence_passes_gate(residual, tolerance) result(passes)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        real(dp), intent(in) :: residual(:), tolerance
+        integer :: k
+
+        passes = size(residual) > 0 .and. tolerance > 0.0_dp
+        if (.not. passes) return
+        passes = all(ieee_is_finite(residual)) .and. all(residual >= 0.0_dp)
+        do k = 2, size(residual)
+            passes = passes .and. residual(k) <= residual(k - 1)
+        end do
+        passes = passes .and. residual(size(residual)) < tolerance
+    end function sequence_passes_gate
+
+    integer function conservative_ceiling(value) result(rounded)
+        ! Preserve mathematical integers that arrive a few ulps high while
+        ! retaining ceiling behavior for genuinely non-integral resolutions.
+        real(dp), intent(in) :: value
+        real(dp) :: roundoff
+
+        roundoff = 32.0_dp * epsilon(value) * max(1.0_dp, abs(value))
+        rounded = ceiling(value - roundoff)
+    end function conservative_ceiling
 
     subroutine test_reference_scale_validation()
         use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
@@ -202,7 +250,7 @@ contains
     !> radial quadrature nodes n_rg and reconstruct delta-Phi on a FIXED
     !> diagnostic grid. The periodic-trapezoidal rule is spectrally accurate for
     !> the near-periodic window integrand, so the Cauchy residual between
-    !> successive refinements must fall fast and beat 1e-2. A failure to converge
+    !> successive refinements must fall fast and beat 1e-3. A failure to converge
     !> is a real finding about the quadrature / seam handling, not a reason to
     !> loosen the tolerance.
     subroutine test_nrg_convergence()
@@ -214,11 +262,12 @@ contains
         use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
 
         integer, parameter :: npts = 201
-        integer, parameter :: M = 32, ndiag = 41, nseq = 4
-        ! 2*M+1=65 coefficients require at least 65 endpoint-exclusive DFT
-        ! samples.  Starting at 48 aliases distinct harmonics and is no longer
-        ! accepted by the physical-lift projection gate.
-        integer, parameter :: n_rg_seq(nseq) = [72, 96, 192, 384]
+        integer, parameter :: M = 256, ndiag = 41, nseq = 5
+        ! Hold the accepted finest Fourier basis fixed. 2*M+1=513 coefficients
+        ! require more than 512 endpoint-exclusive samples; every point stays
+        ! above that Nyquist floor while n_rg alone is refined in equal steps;
+        ! the 640 -> 680 pair directly bounds the accepted n_rg=640 control.
+        integer, parameter :: n_rg_seq(nseq) = [520, 560, 600, 640, 680]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -231,7 +280,6 @@ contains
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr
         real(dp) :: denom_L2, denom_max
         integer :: i, k, info
-        logical :: decreasing
 
         print *, ''
         print *, '=== test_nrg_convergence: r_g quadrature convergence ==='
@@ -297,7 +345,7 @@ contains
             end if
             dphi_k(:, k) = dPhi
         end do
-        print *, 'PASS: all four solves returned info == 0'
+        print *, 'PASS: all quadrature-refinement solves returned info == 0'
 
         ! Cauchy relative residual between successive refinements.
         res_L2  = 0.0_dp
@@ -318,40 +366,31 @@ contains
         end do
         print *, '-----------------------------------------------------------'
 
-        ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
-        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
-        if (.not. decreasing) then
-            print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
-            print *, '   -> real finding about r_g quadrature / seam handling;'
-            print *, '      investigate, do NOT loosen the threshold blindly.'
-            error stop 'test_nrg_convergence: residual not decreasing'
-        end if
-        if (.not. (res_L2(4) < 1.0e-2_dp)) then
-            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+        if (.not. sequence_passes_gate(res_L2(2:nseq), numerical_tolerance)) then
+            print *, 'FAIL: n_rg residual sequence violates the 1e-3 gate:'
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> quadrature has NOT converged; investigate, do NOT'
             print *, '      loosen the threshold blindly.'
             error stop 'test_nrg_convergence: quadrature not converged'
         end if
 
-        print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
+        print *, 'PASS: res_L2 non-increasing and res_L2(finest) < 1.0e-3'
         print *, '=== test_nrg_convergence PASSED ==='
     end subroutine test_nrg_convergence
 
     !> Phase-3 Task 3: FOURIER BASIS truncation convergence of the periodic
     !> solver.
     !>
-    !> With the r_g quadrature (n_rg = 512, converged in P3.2) and the window
+    !> With the r_g quadrature (n_rg = 640, converged in P3.2) and the window
     !> (dx_asis, dx_tr) FIXED, refine only the number of Fourier modes M (the
     !> basis has 2M+1 modes) and reconstruct delta-Phi on a FIXED diagnostic
     !> grid. The localized solution's Fourier coefficients decay for
     !> |k_m| >> 1/rho_L, so the Cauchy residual between successive M must fall
-    !> and beat 1e-2 at the finest tested M. A failure to converge is a real finding about
+    !> and beat 1e-3 at the finest tested M. A failure to converge is a real finding about
     !> the basis truncation or the k-resolution, not a reason to loosen the
     !> tolerance (bump n_rg first: the exp(i(k_m - k_m')r) quadrature is exact
-    !> for |m - m'| < n_rg by Nyquist, and 2M = 256 < 512, so n_rg = 512 resolves
-    !> M up to 128).
+    !> for |m - m'| < n_rg by Nyquist, and 2M = 512 < 640, so n_rg = 640 resolves
+    !> M up to 256).
     subroutine test_M_convergence()
         use config_m, only: profiles_in_memory, nml_config_path
         use species_m, only: set_profiles_from_arrays
@@ -361,8 +400,9 @@ contains
         use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
 
         integer, parameter :: npts = 201
-        integer, parameter :: n_rg = 512, ndiag = 41, nseq = 5
-        integer, parameter :: M_seq(nseq) = [32, 48, 64, 96, 128]
+        integer, parameter :: n_rg = 640, ndiag = 41, nseq = 9
+        integer, parameter :: M_seq(nseq) = &
+            [32, 48, 64, 96, 128, 160, 192, 224, 256]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -375,7 +415,6 @@ contains
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr
         real(dp) :: denom_L2, denom_max
         integer :: i, k, info
-        logical :: decreasing
 
         print *, ''
         print *, '=== test_M_convergence: Fourier basis truncation convergence ==='
@@ -409,8 +448,8 @@ contains
         print *, 'resonant radius rm       = ', rm
         print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
-        ! FIXED quadrature and window (only M is refined here). n_rg = 512 is the
-        ! P3.2-converged node count; it resolves the k-modes for M up to 128.
+        ! FIXED quadrature and window (only M is refined here). n_rg = 640 is the
+        ! converged node count; it resolves the k-modes for M up to 256.
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
         print *, 'FIXED n_rg               = ', n_rg
@@ -462,30 +501,113 @@ contains
         end do
         print *, '-----------------------------------------------------------'
 
-        ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
-        decreasing = .true.
-        do k = 3, nseq
-            decreasing = decreasing .and. (res_L2(k) < res_L2(k - 1))
-        end do
-        if (.not. decreasing) then
-            print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
-            print *, '   res_L2 =', res_L2(2:nseq)
-            print *, '   -> real finding about basis truncation / k-resolution;'
-            print *, '      investigate (bump n_rg first), do NOT loosen the'
-            print *, '      threshold blindly.'
-            error stop 'test_M_convergence: residual not decreasing'
-        end if
-        if (.not. (res_L2(nseq) < 1.0e-2_dp)) then
-            print *, 'FAIL: finest res_L2 =', res_L2(nseq), ' not < 1.0e-2'
+        if (.not. sequence_passes_gate(res_L2(2:nseq), numerical_tolerance)) then
+            print *, 'FAIL: M residual sequence violates the 1e-3 gate:'
             print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> Fourier basis has NOT converged; investigate (bump'
             print *, '      n_rg first), do NOT loosen the threshold blindly.'
             error stop 'test_M_convergence: basis not converged'
         end if
 
-        print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
+        print *, 'PASS: res_L2 non-increasing and res_L2(finest) < 1.0e-3'
         print *, '=== test_M_convergence PASSED ==='
     end subroutine test_M_convergence
+
+    !> Cyclotron-harmonic truncation convergence. Vary only mphi_max while
+    !> retaining the converged Fourier basis, quadrature, physical window, and
+    !> diagnostic grid. The successive shell contribution must decrease and
+    !> the |m_phi|=2 shell must change delta-Phi by less than 1e-3 relative L2.
+    subroutine test_harmonic_convergence()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
+
+        integer, parameter :: npts = 201, M = 256, n_rg = 640
+        integer, parameter :: ndiag = 41, nseq = 3
+        integer, parameter :: harmonic_seq(nseq) = [0, 1, 2]
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        complex(dp), allocatable :: dPhi(:)
+        complex(dp) :: dphi_k(ndiag, nseq)
+        real(dp) :: r_diag(ndiag), res_L2(nseq), res_max(nseq)
+        real(dp) :: rm, rm_k, rhoL_rm, rhoL_k, dx_asis, dx_tr
+        real(dp) :: denom_L2, denom_max
+        integer :: i, k, info
+
+        print *, ''
+        print *, '=== test_harmonic_convergence: cyclotron-harmonic range ==='
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        profiles_in_memory = .true.
+        do k = 1, nseq
+            call write_test_namelist('./KIM_config_periodic_conv_test.nml', &
+                                     harmonic_seq(k))
+            nml_config_path = './KIM_config_periodic_conv_test.nml'
+            call kim_init()
+            call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                          q_prof, Er_prof, npts)
+            if (allocated(kim_instance)) deallocate(kim_instance)
+            call from_kim_factory_get_kim('electrostatic', kim_instance)
+            call kim_instance%init()
+            call prepare_resonances
+            if (.not. (r_res > 0.0_dp)) then
+                error stop 'test_harmonic_convergence: resonance not found'
+            end if
+            rm_k = r_res
+            rhoL_k = interp_rho_L(rm_k)
+            if (k == 1) then
+                rm = rm_k
+                rhoL_rm = rhoL_k
+                dx_asis = 5.0_dp * rhoL_rm
+                dx_tr = 10.0_dp * rhoL_rm
+                do i = 1, ndiag
+                    r_diag(i) = (rm - 3.0_dp * rhoL_rm) + &
+                        6.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
+                end do
+            else if (abs(rm_k - rm) > 10.0_dp * epsilon(rm) * abs(rm) .or. &
+                     abs(rhoL_k - rhoL_rm) > 10.0_dp * epsilon(rhoL_rm) * rhoL_rm) then
+                error stop 'test_harmonic_convergence: physical scale changed'
+            end if
+
+            call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, &
+                                            (1.0_dp, 0.0_dp), r_diag, dPhi, info)
+            if (info /= 0) then
+                print *, 'FAIL: harmonic solve info /= 0 at mphi_max =', &
+                    harmonic_seq(k), ' info =', info
+                error stop 'test_harmonic_convergence: solve rejected'
+            end if
+            dphi_k(:, k) = dPhi
+        end do
+
+        res_L2 = 0.0_dp
+        res_max = 0.0_dp
+        do k = 2, nseq
+            denom_L2 = sqrt(sum(abs(dphi_k(:, k))**2))
+            denom_max = maxval(abs(dphi_k(:, k)))
+            res_L2(k) = sqrt(sum(abs(dphi_k(:, k) - dphi_k(:, k-1))**2)) / denom_L2
+            res_max(k) = maxval(abs(dphi_k(:, k) - dphi_k(:, k-1))) / denom_max
+        end do
+
+        print *, '--- harmonic convergence (fixed M, n_rg, window, grid) ---'
+        print '(A)', '   mphi_max pair       res_L2            res_max'
+        do k = 2, nseq
+            print '(3X,I5," ->",I5,4X,ES16.8,2X,ES16.8)', &
+                harmonic_seq(k-1), harmonic_seq(k), res_L2(k), res_max(k)
+        end do
+        if (.not. sequence_passes_gate(res_L2(2:nseq), numerical_tolerance)) then
+            print *, 'FAIL: harmonic shell sequence violates the 1e-3 gate:'
+            print *, '   res_L2 =', res_L2(2:nseq)
+            error stop 'test_harmonic_convergence: harmonic range not converged'
+        end if
+        print *, 'PASS: harmonic shell contribution decreases below 1.0e-3'
+        print *, '=== test_harmonic_convergence PASSED ==='
+    end subroutine test_harmonic_convergence
 
     !> Phase-3 Task 4: PERIODIZATION-DEFORMATION error bar (design section 5.1).
     !>
@@ -500,20 +622,17 @@ contains
     !> across the scan so the residual measures PHYSICAL deformation, not
     !> numerical under-resolution. Hold dx_tr fixed at 10 rho_L so dx_asis is
     !> the only physical knob. As dx_asis grows, L = 2*(dx_asis + dx_tr) grows,
-    !> so M and n_rg are SCALED with L:
-    !>   M    = ceiling( (27/rhoL) * L / (2 pi) ) -> fixed converged k_max
-    !>   n_rg = max(ceiling(16 L/rhoL), 4 M)      -> converged quadrature/Nyquist
-    !> The cutoff follows the preceding M scan, where M=128 on the 15-rho_L
-    !> half-window reduced the Cauchy residual below 1e-2. This scan therefore
-    !> measures deformation rather than the known under-resolution at k_max=5/rho_L.
+    !> so M and n_rg are SCALED with L. The accepted controls at the reference
+    !> full-window length L=30 rho_L are M=256 and n_rg=640:
+    !>   k_max       = 2 pi*256/(30 rho_L)
+    !>   M           = ceiling(k_max L/(2 pi))
+    !>   n_rg/L      = 640/(30 rho_L)
+    !>   n_rg        = max(ceiling((640/30)L/rho_L), ceiling(2.5 M))
+    !> Thus the converged spectral cutoff, r_g spacing, and Nyquist margin are
+    ! held fixed while dx_asis is the only physical knob.
     !>
-    !> SOFT GATE (this REPORTS the error bar, it does NOT tightly pass/fail): the
-    !> test error-stops ONLY on a genuine defect -- non-finite / all-zero dPhi, a
-    !> non-finite residual, or a residual sequence that GROWS without bound (a
-    !> growing residual means the deformation is NOT converging: a real finding).
-    !> A decreasing / plateauing residual is the physical expectation; the plateau
-    !> value (residual at the largest dx_asis) is the reported deformation error
-    !> bar. A small-but-finite plateau does NOT hard-fail.
+    !> HARD GATE: the residual sequence must be non-increasing and its final
+    !> value must be below the pre-registered 1% periodization tolerance.
     subroutine test_dr_deformation_scan()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         use config_m, only: profiles_in_memory, nml_config_path
@@ -536,11 +655,10 @@ contains
         complex(dp) :: dphi_k(ndiag, nseq)
         real(dp) :: r_diag(ndiag)
         real(dp) :: res_L2(nseq), res_max(nseq)
-        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max, pi
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max, pi, rg_density
         real(dp) :: denom_L2, denom_max
         integer :: M_seq(nseq), n_rg_seq(nseq)
         integer :: i, k, info
-        logical :: growing
 
         pi = acos(-1.0_dp)
 
@@ -589,15 +707,17 @@ contains
 
         ! Scan ONLY the as-is half-width. Keep dx_tr fixed at the run-type's
         ! configured 10-rho_L transition scale, and hold numerical resolution
-        ! constant by scaling M and n_rg with L. The fixed k_max = 27/rho_L is
-        ! justified by test_M_convergence above.
+        ! constant by scaling M and n_rg with L. The fixed cutoff and grid
+        ! density are the accepted M=256, n_rg=640 controls on L=30 rho_L.
+        k_max = 2.0_dp * pi * 256.0_dp / (30.0_dp * rhoL_rm)
+        rg_density = 640.0_dp / 30.0_dp
         do k = 1, nseq
             dx_asis = dx_asis_scale(k) * rhoL_rm
             dx_tr   = 10.0_dp * rhoL_rm
             L       = 2.0_dp * (dx_asis + dx_tr)
-            k_max   = 27.0_dp / rhoL_rm
-            M_seq(k)    = ceiling(k_max * L / (2.0_dp * pi))
-            n_rg_seq(k) = max(ceiling(16.0_dp * L / rhoL_rm), 4 * M_seq(k))
+            M_seq(k) = conservative_ceiling(k_max * L / (2.0_dp * pi))
+            n_rg_seq(k) = max(conservative_ceiling(rg_density * L / rhoL_rm), &
+                              conservative_ceiling(2.5_dp * real(M_seq(k), dp)))
 
             print '(A,F6.1,A,ES14.6,A,I5,A,I6)', &
                 '   dx_asis = ', dx_asis_scale(k), ' rho_L  (=', dx_asis, &
@@ -667,31 +787,15 @@ contains
             res_max(nseq)
         print *, '==================================================================='
 
-        ! SOFT GATE: only error-stop on a genuinely GROWING residual sequence (the
-        ! deformation is NOT converging -- a finding to investigate). Non-finite /
-        ! all-zero / non-finite-residual defects are already caught above. A
-        ! decreasing / plateauing sequence is the physical expectation and is
-        ! reported, NOT failed, however small the finite plateau.
-        growing = (res_L2(3) > res_L2(2)) .and. (res_L2(4) > res_L2(3))
-        if (growing) then
-            print *, 'FINDING: res_L2 sequence GROWS across the dx_asis scan:'
+        if (.not. sequence_passes_gate(res_L2(2:nseq), deformation_tolerance)) then
+            print *, 'FAIL: periodization deformation violates the 1% gate:'
             print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
-            print *, '   -> periodization deformation is NOT converging as the'
-            print *, '      as-is window grows; this is a real finding to'
-            print *, '      investigate, not a numerical-resolution artifact'
-            print *, '      (M and n_rg were scaled with L to hold resolution).'
-            error stop 'test_dr_deformation_scan: deformation residual growing'
+            print *, '   -> non-monotone or above tolerance; M and n_rg were'
+            print *, '      scaled with L, so this is not a resolution plateau.'
+            error stop 'test_dr_deformation_scan: deformation gate failed'
         end if
 
-        if (res_L2(nseq) <= res_L2(2)) then
-            print *, 'PASS: deformation residual decreases / plateaus (converging);'
-            print '(A,ES14.6)', &
-                '       reported periodization-deformation error bar = ', res_L2(nseq)
-        else
-            print *, 'NOTE: non-monotone but non-growing residual; plateau reported'
-            print '(A,ES14.6)', &
-                '       reported periodization-deformation error bar = ', res_L2(nseq)
-        end if
+        print *, 'PASS: deformation residual non-increasing and below 1%'
         print *, '=== test_dr_deformation_scan PASSED ==='
     end subroutine test_dr_deformation_scan
 
@@ -732,11 +836,15 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path)
+    subroutine write_test_namelist(path, max_harmonic)
         ! Minimal electrostatic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         character(len=*), intent(in) :: path
-        integer :: iunit
+        integer, intent(in), optional :: max_harmonic
+        integer :: harmonic, iunit
+
+        harmonic = 0
+        if (present(max_harmonic)) harmonic = max_harmonic
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
@@ -776,7 +884,7 @@ contains
         write(iunit, '(A)') ' collisions_off = .false.'
         write(iunit, '(A)') ' set_profiles_constant = 0'
         write(iunit, '(A)') ' bc_type = 3'
-        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A,I0)') ' mphi_max = ', harmonic
         write(iunit, '(A)') ' Br_boundary_re = 1.0'
         write(iunit, '(A)') ' Br_boundary_im = 0.0'
         write(iunit, '(A)') '/'

--- a/KIM/tests/test_periodic_solve.f90
+++ b/KIM/tests/test_periodic_solve.f90
@@ -38,6 +38,9 @@ program test_periodic_solve
     implicit none
 
     call test_dense_solve_roundtrip()
+    call test_dense_solve_singular_rejection()
+    call test_dense_solve_condition_rejection()
+    call test_dense_solve_nonfinite_rejection()
     call test_inverse_dft()
     call test_field_operator_oracle()
     call test_zero_mode_policy()
@@ -55,11 +58,13 @@ contains
     !> conditioned diagonally-dominant complex A0, pick a known Phi, form
     !> b0 = A0*Phi, solve, and assert recovery to < 1e-10.
     subroutine test_dense_solve_roundtrip()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
         integer, parameter :: M = 3
         integer, parameter :: dim = 2 * M + 1
         complex(dp) :: A0(dim, dim), Phi_known(dim), b0(dim), x(dim)
         integer :: i, j, info
-        real(dp) :: re, im
+        real(dp) :: re, im, rcond, backward_error
 
         do j = 1, dim
             do i = 1, dim
@@ -75,7 +80,7 @@ contains
 
         b0 = matmul(A0, Phi_known)
         x = b0
-        call dense_solve(A0, x, info)
+        call dense_solve(A0, x, info, rcond, backward_error)
 
         if (info /= 0) then
             print *, 'FAIL: dense_solve info /= 0:', info
@@ -86,9 +91,79 @@ contains
                      maxval(abs(x - Phi_known))
             error stop
         end if
+        if (.not. ieee_is_finite(rcond) .or. rcond <= 1.0e-12_dp) then
+            print *, 'FAIL: dense_solve invalid rcond =', rcond
+            error stop
+        end if
+        if (.not. ieee_is_finite(backward_error) .or. &
+            backward_error >= 1.0e-10_dp) then
+            print *, 'FAIL: dense_solve backward error =', backward_error
+            error stop
+        end if
         print *, 'PASS: dense_solve round-trip, max err =', &
                  maxval(abs(x - Phi_known))
+        print *, '  rcond =', rcond, ' backward error =', backward_error
     end subroutine test_dense_solve_roundtrip
+
+    subroutine test_dense_solve_singular_rejection()
+        use periodic_solve_m, only: PERIODIC_SOLVE_SINGULAR
+
+        complex(dp) :: matrix(2, 2), rhs(2)
+        integer :: info
+
+        matrix = (0.0_dp, 0.0_dp)
+        matrix(1, 1) = (1.0_dp, 0.0_dp)
+        rhs = [(1.0_dp, 0.0_dp), (0.0_dp, 0.0_dp)]
+        call dense_solve(matrix, rhs, info)
+        if (info /= PERIODIC_SOLVE_SINGULAR) then
+            print *, 'FAIL: singular dense solve status =', info
+            error stop
+        end if
+        print *, 'PASS: exactly singular dense solve rejected with host status'
+    end subroutine test_dense_solve_singular_rejection
+
+    subroutine test_dense_solve_condition_rejection()
+        use periodic_solve_m, only: PERIODIC_SOLVE_ILL_CONDITIONED
+
+        complex(dp) :: matrix(2, 2), rhs(2)
+        real(dp) :: rcond, backward_error
+        integer :: info
+
+        matrix = (0.0_dp, 0.0_dp)
+        matrix(1, 1) = (1.0_dp, 0.0_dp)
+        matrix(2, 2) = (1.0e-14_dp, 0.0_dp)
+        rhs = [(1.0_dp, 0.0_dp), (1.0e-14_dp, 0.0_dp)]
+        call dense_solve(matrix, rhs, info, rcond, backward_error)
+
+        if (info /= PERIODIC_SOLVE_ILL_CONDITIONED) then
+            print *, 'FAIL: nearly singular solve status =', info
+            print *, '  rcond =', rcond, ' backward error =', backward_error
+            error stop
+        end if
+        if (rcond >= 1.0e-12_dp) then
+            print *, 'FAIL: nearly singular fixture rcond =', rcond
+            error stop
+        end if
+        print *, 'PASS: nearly singular dense solve rejected, rcond =', rcond
+    end subroutine test_dense_solve_condition_rejection
+
+    subroutine test_dense_solve_nonfinite_rejection()
+        use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+        use periodic_solve_m, only: PERIODIC_SOLVE_NONFINITE
+
+        complex(dp) :: matrix(1, 1), rhs(1)
+        real(dp) :: rcond, backward_error
+        integer :: info
+
+        matrix(1, 1) = cmplx(ieee_value(0.0_dp, ieee_quiet_nan), 0.0_dp, dp)
+        rhs(1) = (1.0_dp, 0.0_dp)
+        call dense_solve(matrix, rhs, info, rcond, backward_error)
+        if (info /= PERIODIC_SOLVE_NONFINITE) then
+            print *, 'FAIL: non-finite dense solve status =', info
+            error stop
+        end if
+        print *, 'PASS: non-finite dense solve input rejected'
+    end subroutine test_dense_solve_nonfinite_rejection
 
     !> (b) Inverse DFT correctness. A single nonzero coefficient at m=1 must
     !> reconstruct exp(i k_1 r); a two-mode case confirms linear superposition.

--- a/KIM/tests/test_periodic_vs_global.f90
+++ b/KIM/tests/test_periodic_vs_global.f90
@@ -7,9 +7,8 @@ program test_periodic_vs_global
     ! run-type, then compare their reconstructed delta_Phi(r) on the resonant
     ! layer.
     !
-    ! This is a VALIDATION/DIAGNOSTIC task (design 5.2): approx-vs-approx, so
-    ! the deliverable is a measured cross-check number, not a brittle hard
-    ! pass/fail. The global electrostatic solver writes EBdat%Phi on the FIELD
+    ! This is a VALIDATION task (design 5.2). The global electrostatic solver
+    ! writes EBdat%Phi on the FIELD
     ! grid (xl_grid%xb); the periodic solver writes it on the window grid
     ! (rg_grid%xb). We build a common equidistant grid over a few Larmor radii
     ! around rm = r_res, intersect it with BOTH solutions' radial ranges,
@@ -18,11 +17,10 @@ program test_periodic_vs_global
     ! (mean) removed, since a constant gauge/offset in Phi is physically
     ! irrelevant.
     !
-    ! Soft gate: error stop ONLY if a solution is missing / all-zero / NaN, or
-    ! if a computed relative difference is non-finite. A large-but-finite
-    ! discrepancy is a Phase-2 finding, not a test failure: it is printed in a
-    ! CROSS-CHECK DIAGNOSTIC block (with a WARNING when rel_L2 > 0.5) and the
-    ! test still exits 0 so CI stays green -- the number is the diagnostic.
+    ! Missing, non-finite, or degenerate solutions fail distinctly from the
+    ! pre-registered 5% relative-L2 physical agreement gate. The current
+    ! mismatch therefore remains visible as a nonzero test until the matched
+    ! benchmark work resolves it; it can never silently return success.
 
     use KIM_kinds_m, only: dp
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
@@ -325,7 +323,7 @@ contains
         call write_curve_data('periodic_vs_global_curve.dat', r_c(1:nc), &
                               pg_c(1:nc), pp_c(1:nc), pg_dc, pp_dc)
 
-        ! Soft gate: bail only on non-finite results, never on a large finite one.
+        ! Numerical sanity is separate from the physical agreement gate below.
         if (.not. ieee_is_finite(rel_L2) .or. .not. ieee_is_finite(rel_max) .or. &
             .not. ieee_is_finite(rel_L2_dc) .or. &
             .not. ieee_is_finite(rel_max_dc)) then
@@ -368,17 +366,19 @@ contains
             print *, '   cross-check finding to investigate (electrostatic Poisson solve),'
             print *, '   NOT a failure of the periodic solver or of this diagnostic.'
             print *, '======================================================================'
+            error stop 'periodic/global reference is degenerate'
         else
             print *, '  rel_L2  (raw)              = ', rel_L2
             print *, '  rel_max (raw)              = ', rel_max
             print *, '  rel_L2_dc_removed          = ', rel_L2_dc
             print *, '  rel_max_dc_removed         = ', rel_max_dc
             print *, '======================================================================'
-            if (rel_L2 > 0.5_dp) then
-                print *, ' WARNING: periodic vs global differ by >50% -- investigate'
-                print *, '   (candidates: k_s^2 D_m convention, DC/gauge,'
-                print *, '    periodization deformation, normalization)'
+            if (rel_L2 >= 5.0e-2_dp) then
+                print *, ' FAIL: periodic/global relative L2 exceeds 5% policy'
+                print *, '   This is a physical cross-method gate, distinct from'
+                print *, '   dense-solve residual and numerical self-convergence.'
                 print *, '======================================================================'
+                error stop 'periodic/global matched-problem tolerance failed'
             end if
         end if
         print *, ''


### PR DESCRIPTION
## Summary

- report reciprocal condition estimates and scaled backward errors for dense solves
- reject singular, non-finite, ill-conditioned, and inaccurate systems with explicit statuses
- turn quadrature, Fourier, harmonic, deformation, and cross-method tolerances into nonzero test exits

## Why

Numerical trust failures are visible and cannot be mistaken for accepted physics.

## Validation

Validated cumulatively at the stack head:

- `cmake --build build -j2`
- `ctest --test-dir build -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global' --output-on-failure` — 35/35 passed

Known red gates are intentionally excluded from that command: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation acceptance gate, and the unresolved periodic-vs-global 5% agreement gate.

## Stack

Base: `fix/kim-fp-198-equilibrium-oracle`
Head: `fix/kim-fp-189-numerical-gates`

Closes #189