### PR TITLE
[kim-fp-04] Match the periodic and hat electrostatic boundary-value problem

### DIFF
--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -18,7 +18,8 @@ module periodic_background_m
     implicit none
     private
 
-    public :: kim_aperfuns, sample_periodic_primitives, build_periodic_plasma
+    public :: kim_aperfuns, kim_geom_aperfuns
+    public :: sample_periodic_primitives, build_periodic_plasma
     public :: sample_periodic_species_profiles
     public :: reset_true_background_cache
 

--- a/KIM/src/electrostatic_poisson/periodic_solve.f90
+++ b/KIM/src/electrostatic_poisson/periodic_solve.f90
@@ -1,50 +1,72 @@
 module periodic_solve_m
-    !> Dense solve of the periodic electrostatic system and inverse-DFT
-    !> reconstruction of the potential (Phase-2.5).
+    !> Fourier discretization of the reduced radial CGS Poisson problem.
     !>
-    !> Over Fourier modes m = -M..M with k_m = 2*pi*m/L, the electrostatic
-    !> forced-periodicity system (design section 3.4) is
+    !> The chapter-15 KIM model uses the radial operator d2/dr2.  In the
+    !> exp(+i k_m r) basis its symbol is D_m=-k_m^2, so
     !>
-    !>   [ D_m delta_{m,m'} + 4*pi K^{rhoPhi}_{m,m'} ] Phi_{m'}
-    !>                                        = -4*pi K^{rhoB}_{m,m'} Br_{m'},
+    !>   A = D + 4*pi*K^{rhoPhi},       g = -4*pi*K^{rhoB}*Br.
     !>
-    !> with D_m = -k_m^2 the (diagonal) Fourier-space radial Poisson operator.
-    !> This matches solve_poisson.f90, whose left-hand operator is
-    !> A_mat = Laplace + 4*pi K_rho_phi (solve_poisson.f90:49): the FEM Laplace
-    !> operator there (prepare_Laplace_matrix) is the RADIAL second derivative
-    !> only, which in the Fourier basis maps to -k_m^2. There is NO perpendicular
-    !> -k_s^2 term in that operator, so D_m = -k_m^2 as the design specifies.
-    !> (Convention question flagged for the P2.7 cross-check: whether a physical
-    !> perpendicular k_s^2 contribution belongs on the diagonal.)
-    !>
-    !> The right-hand side matches create_rhs_vector's sign convention
-    !> (solve_poisson.f90:129, rhs = -4*pi * K_rho_B * Br). For type_br_field=12
-    !> Br is constant over the window, so its Fourier coefficient is nonzero only
-    !> at m' = 0:  Br_{m'} = Br_const * delta_{m',0}. The RHS therefore reduces to
-    !>
-    !>   b_m = -4*pi * Br_const * KB(m, m'=0) = -4*pi * Br_const * KB(:, M+1).
-    !>
-    !> The dense complex system is solved with LAPACK zgesv (same argument
-    !> pattern as electromagnetic_solver.f90:243), then the potential is
-    !> reconstructed on an output radial grid as
-    !>
-    !>   dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r).
+    !> The physical solution is represented as deltaPhi=Phi_ref+psi.  Phi_ref
+    !> remains a physical-space lifting field; only its kinetic action and
+    !> supplied continuous second derivative are projected.  Projecting and
+    !> adding Phi_ref in the same finite basis would cancel algebraically and
+    !> silently reproduce the old direct-periodic solve.
 
     use KIM_kinds_m, only: dp
 
     implicit none
     private
 
-    public :: solve_periodic, reconstruct_delta_phi, dense_solve
+    integer, parameter, public :: PERIODIC_SOLVE_OK = 0
+    integer, parameter, public :: PERIODIC_SOLVE_INVALID_INPUT = -100
+    integer, parameter, public :: PERIODIC_SOLVE_GAUGE_REQUIRED = -101
+    integer, parameter, public :: PERIODIC_SOLVE_INCOMPATIBLE_NULLSPACE = -102
+    integer, parameter, public :: PERIODIC_SOLVE_PROJECTION_REJECTED = -103
+
+    public :: solve_periodic, solve_periodic_deviation
+    public :: assemble_periodic_operator, magnetic_drive_rhs
+    public :: project_onto_periodic_basis, solve_with_derived_gauge
+    public :: reconstruct_delta_phi, reconstruct_delta_phi_from_lift
+    public :: build_physical_c2_lift, dense_solve
 
 contains
 
-    !> Solve the periodic electrostatic system for the Fourier coefficients
-    !> Phi_m of the potential, given the Phase-2.4 matrices Kphi/KB, the period
-    !> L, the mode cutoff M, and the constant drive amplitude Br_const.
-    subroutine solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+    subroutine assemble_periodic_operator(Kphi, L, M, A)
         use constants_m, only: pi
 
+        complex(dp), intent(in) :: Kphi(:,:)
+        real(dp), intent(in) :: L
+        integer, intent(in) :: M
+        complex(dp), allocatable, intent(out) :: A(:,:)
+
+        real(dp) :: k_m
+        integer :: dim, im, m_row
+
+        dim = 2 * M + 1
+        allocate(A(dim, dim))
+        A = 4.0_dp * pi * Kphi
+        do m_row = -M, M
+            im = m_row + M + 1
+            k_m = 2.0_dp * pi * real(m_row, dp) / L
+            A(im, im) = A(im, im) - k_m * k_m
+        end do
+    end subroutine assemble_periodic_operator
+
+    subroutine magnetic_drive_rhs(KB, Br_m, rhs)
+        use constants_m, only: pi
+
+        complex(dp), intent(in) :: KB(:,:), Br_m(:)
+        complex(dp), allocatable, intent(out) :: rhs(:)
+
+        allocate(rhs(size(Br_m)))
+        rhs = -4.0_dp * pi * matmul(KB, Br_m)
+    end subroutine magnetic_drive_rhs
+
+    !> Compatibility wrapper for the original constant-drive direct solve.
+    !> It now uses the same operator, source, and explicit zero-mode policy as
+    !> the deviation path.  A vacuum null space without a declared gauge is an
+    !> error rather than an arbitrary LAPACK result.
+    subroutine solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
         complex(dp), intent(in) :: Kphi(:,:), KB(:,:)
         real(dp), intent(in) :: L
         integer, intent(in) :: M
@@ -52,35 +74,209 @@ contains
         complex(dp), allocatable, intent(out) :: Phi_m(:)
         integer, intent(out) :: info
 
-        complex(dp), allocatable :: A(:,:), b(:)
-        real(dp) :: k_m
-        integer :: dim, im, m_row
+        complex(dp), allocatable :: A(:,:), Br_m(:), rhs(:)
+        integer :: dim
 
         dim = 2 * M + 1
-        allocate(A(dim, dim), b(dim))
+        if (M < 0 .or. L <= 0.0_dp .or. any(shape(Kphi) /= [dim, dim]) .or. &
+            any(shape(KB) /= [dim, dim])) then
+            allocate(Phi_m(max(0, dim)))
+            Phi_m = (0.0_dp, 0.0_dp)
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            return
+        end if
 
-        ! A = 4*pi Kphi with the diagonal Fourier-space radial operator
-        ! D_m = -k_m^2 (k_m = 2*pi*m/L) added on the diagonal.
-        A = 4.0_dp * pi * Kphi
+        allocate(Br_m(dim))
+        Br_m = (0.0_dp, 0.0_dp)
+        Br_m(M + 1) = Br_const
+        call assemble_periodic_operator(Kphi, L, M, A)
+        call magnetic_drive_rhs(KB, Br_m, rhs)
+        call solve_with_derived_gauge(A, rhs, M, .false., Phi_m, info)
+    end subroutine solve_periodic
+
+    !> Solve L psi = g-L Phi_ref.  The caller supplies physical-space samples
+    !> of Phi_ref and its continuous radial second derivative on the DFT grid.
+    subroutine solve_periodic_deviation(Kphi, KB, L, M, Br_m, r_nodes, &
+                                        Phi_ref, d2Phi_ref, projection_tolerance, &
+                                        psi_m, projection_residual, info, &
+                                        declare_mean_zero_gauge, projection_mask)
+        use constants_m, only: pi
+
+        complex(dp), intent(in) :: Kphi(:,:), KB(:,:), Br_m(:)
+        real(dp), intent(in) :: L, r_nodes(:), projection_tolerance
+        integer, intent(in) :: M
+        complex(dp), intent(in) :: Phi_ref(:), d2Phi_ref(:)
+        complex(dp), allocatable, intent(out) :: psi_m(:)
+        real(dp), intent(out) :: projection_residual
+        integer, intent(out) :: info
+        logical, intent(in), optional :: declare_mean_zero_gauge
+        logical, intent(in), optional :: projection_mask(:)
+
+        complex(dp), allocatable :: A(:,:), rhs(:), ref_m(:), d2ref_m(:)
+        complex(dp), allocatable :: projected_ref(:)
+        real(dp) :: reference_norm
+        integer :: dim
+        logical :: use_gauge
+
+        dim = 2 * M + 1
+        projection_residual = huge(1.0_dp)
+        if (M < 0 .or. L <= 0.0_dp .or. projection_tolerance < 0.0_dp .or. &
+            size(r_nodes) == 0 .or. size(Phi_ref) /= size(r_nodes) .or. &
+            size(d2Phi_ref) /= size(r_nodes) .or. size(Br_m) /= dim .or. &
+            any(shape(Kphi) /= [dim, dim]) .or. any(shape(KB) /= [dim, dim])) then
+            allocate(psi_m(max(0, dim)))
+            psi_m = (0.0_dp, 0.0_dp)
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            return
+        end if
+        if (present(projection_mask)) then
+            if (size(projection_mask) /= size(r_nodes) .or. .not. any(projection_mask)) then
+                allocate(psi_m(dim))
+                psi_m = (0.0_dp, 0.0_dp)
+                info = PERIODIC_SOLVE_INVALID_INPUT
+                return
+            end if
+        end if
+
+        call project_onto_periodic_basis(Phi_ref, r_nodes, L, M, ref_m)
+        call project_onto_periodic_basis(d2Phi_ref, r_nodes, L, M, d2ref_m)
+        projected_ref = reconstruct_delta_phi(ref_m, L, M, r_nodes)
+        if (present(projection_mask)) then
+            reference_norm = sqrt(sum(abs(Phi_ref)**2, mask=projection_mask))
+        else
+            reference_norm = sqrt(sum(abs(Phi_ref)**2))
+        end if
+        if (reference_norm > tiny(1.0_dp)) then
+            if (present(projection_mask)) then
+                projection_residual = sqrt(sum(abs(projected_ref - Phi_ref)**2, &
+                    mask=projection_mask)) / reference_norm
+            else
+                projection_residual = sqrt(sum(abs(projected_ref - Phi_ref)**2)) / reference_norm
+            end if
+        else
+            if (present(projection_mask)) then
+                projection_residual = sqrt(sum(abs(projected_ref - Phi_ref)**2, mask=projection_mask))
+            else
+                projection_residual = sqrt(sum(abs(projected_ref - Phi_ref)**2))
+            end if
+        end if
+        if (projection_residual > projection_tolerance) then
+            allocate(psi_m(dim))
+            psi_m = (0.0_dp, 0.0_dp)
+            info = PERIODIC_SOLVE_PROJECTION_REJECTED
+            return
+        end if
+
+        call assemble_periodic_operator(Kphi, L, M, A)
+        call magnetic_drive_rhs(KB, Br_m, rhs)
+        rhs = rhs - d2ref_m - 4.0_dp * pi * matmul(Kphi, ref_m)
+        use_gauge = .false.
+        if (present(declare_mean_zero_gauge)) use_gauge = declare_mean_zero_gauge
+        call solve_with_derived_gauge(A, rhs, M, use_gauge, psi_m, info)
+    end subroutine solve_periodic_deviation
+
+    !> Explicit zero-mode rule.  Screening retains and solves mode zero.  If
+    !> the mode is a true decoupled null space, the source must be compatible
+    !> and the caller must declare the mean-zero gauge.
+    subroutine solve_with_derived_gauge(A_in, rhs_in, M, declare_mean_zero_gauge, &
+                                        solution, info)
+        complex(dp), intent(in) :: A_in(:,:), rhs_in(:)
+        integer, intent(in) :: M
+        logical, intent(in) :: declare_mean_zero_gauge
+        complex(dp), allocatable, intent(out) :: solution(:)
+        integer, intent(out) :: info
+
+        complex(dp), allocatable :: A(:,:), rhs(:)
+        real(dp) :: scale, null_tolerance
+        integer :: dim, izero
+        logical :: zero_is_null
+
+        dim = 2 * M + 1
+        allocate(solution(max(0, dim)))
+        solution = (0.0_dp, 0.0_dp)
+        if (M < 0 .or. any(shape(A_in) /= [dim, dim]) .or. size(rhs_in) /= dim) then
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            return
+        end if
+
+        A = A_in
+        rhs = rhs_in
+        izero = M + 1
+        scale = max(1.0_dp, maxval(abs(A)))
+        null_tolerance = 100.0_dp * epsilon(1.0_dp) * scale
+        zero_is_null = maxval(abs(A(izero, :))) <= null_tolerance .and. &
+                       maxval(abs(A(:, izero))) <= null_tolerance
+        if (zero_is_null) then
+            if (abs(rhs(izero)) > null_tolerance) then
+                info = PERIODIC_SOLVE_INCOMPATIBLE_NULLSPACE
+                return
+            end if
+            if (.not. declare_mean_zero_gauge) then
+                info = PERIODIC_SOLVE_GAUGE_REQUIRED
+                return
+            end if
+            A(izero, :) = (0.0_dp, 0.0_dp)
+            A(:, izero) = (0.0_dp, 0.0_dp)
+            A(izero, izero) = (1.0_dp, 0.0_dp)
+            rhs(izero) = (0.0_dp, 0.0_dp)
+        end if
+
+        call dense_solve(A, rhs, info)
+        solution = rhs
+    end subroutine solve_with_derived_gauge
+
+    subroutine project_onto_periodic_basis(values, r_nodes, L, M, coefficients)
+        use constants_m, only: pi, com_unit
+
+        complex(dp), intent(in) :: values(:)
+        real(dp), intent(in) :: r_nodes(:), L
+        integer, intent(in) :: M
+        complex(dp), allocatable, intent(out) :: coefficients(:)
+
+        real(dp) :: k_m
+        integer :: m_row, im
+
+        allocate(coefficients(2 * M + 1))
         do m_row = -M, M
             im = m_row + M + 1
             k_m = 2.0_dp * pi * real(m_row, dp) / L
-            A(im, im) = A(im, im) - k_m * k_m
+            coefficients(im) = sum(values * exp(-com_unit * k_m * r_nodes)) / &
+                               real(size(values), dp)
         end do
+    end subroutine project_onto_periodic_basis
 
-        ! b = -4*pi Br_const KB(:, m'=0). The constant drive projects onto the
-        ! m' = 0 column only (column index M+1).
-        b = -4.0_dp * pi * Br_const * KB(:, M + 1)
+    !> C2 physical-space lifting field between the two ideal aligned edge
+    !> values.  Quintic smootherstep gives zero slope and curvature at both
+    !> ends while avoiding the 1/k_parallel singularity at resonance.  Its
+    !> unequal endpoint values are intentionally not made periodic: doing so
+    !> would restore the old boundary-value problem.
+    subroutine build_physical_c2_lift(r_nodes, rm, dx_asis, dx_tr, &
+                                      phi_left, phi_right, Phi_ref, d2Phi_ref)
+        real(dp), intent(in) :: r_nodes(:), rm, dx_asis, dx_tr
+        complex(dp), intent(in) :: phi_left, phi_right
+        complex(dp), intent(out) :: Phi_ref(size(r_nodes)), d2Phi_ref(size(r_nodes))
 
-        call dense_solve(A, b, info)
+        real(dp) :: x, t, width, s, d2s
+        integer :: i
 
-        Phi_m = b
-    end subroutine solve_periodic
+        width = 2.0_dp * (dx_asis + dx_tr)
+        do i = 1, size(r_nodes)
+            x = r_nodes(i) - rm
+            t = max(0.0_dp, min(1.0_dp, (x + 0.5_dp * width) / width))
+            call smootherstep_with_second(t, width, s, d2s)
+            Phi_ref(i) = phi_left + (phi_right - phi_left) * s
+            d2Phi_ref(i) = (phi_right - phi_left) * d2s
+        end do
+    end subroutine build_physical_c2_lift
 
-    !> Solve the dense complex system A x = b in place via LAPACK zgesv, using
-    !> the same argument pattern as electromagnetic_solver.f90:243. On entry b
-    !> is the RHS; on exit b holds the solution and A is LU-overwritten.
-    !> info == 0 on success.
+    subroutine smootherstep_with_second(t, width, value, second_derivative)
+        real(dp), intent(in) :: t, width
+        real(dp), intent(out) :: value, second_derivative
+
+        value = 6.0_dp * t**5 - 15.0_dp * t**4 + 10.0_dp * t**3
+        second_derivative = (120.0_dp * t**3 - 180.0_dp * t**2 + 60.0_dp * t) / width**2
+    end subroutine smootherstep_with_second
+
     subroutine dense_solve(A, b, info)
         complex(dp), intent(inout) :: A(:,:), b(:)
         integer, intent(out) :: info
@@ -91,12 +287,8 @@ contains
         dim = size(A, 1)
         allocate(ipiv(dim))
         call zgesv(dim, 1, A, dim, ipiv, b, dim, info)
-        deallocate(ipiv)
     end subroutine dense_solve
 
-    !> Inverse DFT: reconstruct dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r)
-    !> on the output radial grid r_out, with k_m = 2*pi*m/L. Phi_m is indexed
-    !> im = m + M + 1 (size 2M+1).
     function reconstruct_delta_phi(Phi_m, L, M, r_out) result(dPhi)
         use constants_m, only: pi, com_unit
 
@@ -106,16 +298,23 @@ contains
         complex(dp) :: dPhi(size(r_out))
 
         real(dp) :: k_m
-        integer :: i, m_row, im
+        integer :: m_row, im
 
         dPhi = (0.0_dp, 0.0_dp)
         do m_row = -M, M
             im = m_row + M + 1
             k_m = 2.0_dp * pi * real(m_row, dp) / L
-            do i = 1, size(r_out)
-                dPhi(i) = dPhi(i) + Phi_m(im) * exp(com_unit * k_m * r_out(i))
-            end do
+            dPhi = dPhi + Phi_m(im) * exp(com_unit * k_m * r_out)
         end do
     end function reconstruct_delta_phi
+
+    function reconstruct_delta_phi_from_lift(psi_m, L, M, r_out, Phi_ref) result(dPhi)
+        complex(dp), intent(in) :: psi_m(:), Phi_ref(:)
+        real(dp), intent(in) :: L, r_out(:)
+        integer, intent(in) :: M
+        complex(dp) :: dPhi(size(r_out))
+
+        dPhi = Phi_ref + reconstruct_delta_phi(psi_m, L, M, r_out)
+    end function reconstruct_delta_phi_from_lift
 
 end module periodic_solve_m

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -3,13 +3,13 @@
 ! On a given (m, n) case this run-type locates the resonant surface rm, sizes a
 ! periodic window from a representative Larmor radius rho_L(rm), builds the
 ! periodic plasma on that window (Phase-2.3), assembles the dense Fourier
-! matrices K^{rhoPhi}/K^{rhoB} over one period (Phase-2.4), solves the periodic
-! electrostatic system for the Fourier coefficients Phi_m and inverse-DFTs them
-! into delta_Phi(r) on the window grid (Phase-2.5), then packs delta_Phi into
-! fields_m::EBdat.
+! matrices K^{rhoPhi}/K^{rhoB} over one period, solves for the periodic
+! deviation from a physical aligned-potential lift, reconstructs delta_Phi(r)
+! on the window grid, then packs it into fields_m::EBdat.
 module rt_electrostatic_periodic_m
 
     use kim_base_m, only: kim_t
+    use KIM_kinds_m, only: dp
 
     implicit none
 
@@ -22,14 +22,15 @@ module rt_electrostatic_periodic_m
     integer, parameter, public :: PERIODIC_SCALE_OK = 0
     integer, parameter, public :: PERIODIC_SCALE_NO_ACTIVE = 1
     integer, parameter, public :: PERIODIC_SCALE_INVALID_RHO = 2
+    real(dp), parameter :: PERIODIC_LIFT_PROJECTION_TOLERANCE = 5.0e-2_dp
 
     public :: compute_periodic_delta_phi, select_periodic_reference_scale
 
     contains
 
     !> Reusable periodic core: build the window plasma, assemble the Fourier
-    !> matrices, solve for the coefficients Phi_m under a constant Br drive, and
-    !> reconstruct delta_Phi on the EXPLICIT output grid r_out (NOT on the window
+    !> matrices, solve for deviation coefficients under a constant Br drive, and
+    !> reconstruct physical delta_Phi on the EXPLICIT output grid r_out (not the window
     !> grid rg_grid%xb). All window sizing is passed in EXPLICITLY so both the
     !> run-type and the Phase-3 convergence harness can evaluate delta_Phi on a
     !> fixed diagnostic grid independent of the (n_rg, M, dx) discretization.
@@ -37,12 +38,15 @@ module rt_electrostatic_periodic_m
     !> Does NOT error stop on a singular solve: it returns info /= 0 so the
     !> caller can decide (the run-type error stops; the tests inspect info).
     subroutine compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                          r_out, dPhi, info)
+                                          r_out, dPhi, info, lift_projection_residual)
         use KIM_kinds_m, only: dp
         use species_m, only: plasma
+        use grid_m, only: rg_grid
         use periodic_background_m, only: build_periodic_plasma
         use periodic_assembly_m, only: assemble_periodic_matrices
-        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi
+        use periodic_solve_m, only: solve_periodic_deviation, &
+            reconstruct_delta_phi_from_lift, build_physical_c2_lift, &
+            PERIODIC_SOLVE_INVALID_INPUT
 
         real(dp),    intent(in)  :: rm, dx_asis, dx_tr
         integer,     intent(in)  :: M, n_rg
@@ -50,19 +54,86 @@ module rt_electrostatic_periodic_m
         real(dp),    intent(in)  :: r_out(:)
         complex(dp), allocatable, intent(out) :: dPhi(:)
         integer,     intent(out) :: info
+        real(dp), intent(out), optional :: lift_projection_residual
 
-        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:)
-        real(dp) :: L
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), psi_m(:), Br_m(:)
+        complex(dp), allocatable :: Phi_ref_grid(:), d2Phi_ref_grid(:)
+        complex(dp), allocatable :: Phi_ref_out(:), d2Phi_ref_out(:)
+        logical, allocatable :: projection_mask(:)
+        complex(dp) :: phi_left, phi_right
+        real(dp) :: L, projection_residual
+        integer :: dim
 
+        if (present(lift_projection_residual)) lift_projection_residual = huge(1.0_dp)
+        if (dx_asis <= 0.0_dp .or. dx_tr <= 0.0_dp .or. M < 0 .or. n_rg <= 0) then
+            info = PERIODIC_SOLVE_INVALID_INPUT
+            return
+        end if
         L = 2.0_dp * (dx_asis + dx_tr)
 
+        ! Capture the two physical ideal-MHD edge values before periodization
+        ! replaces the outer background by artificial periodic transitions.
+        call aligned_lift_anchor(rm - 0.5_dp * L, Br_const, phi_left, info)
+        if (info /= 0) return
+        call aligned_lift_anchor(rm + 0.5_dp * L, Br_const, phi_right, info)
+        if (info /= 0) return
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
         call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
-        call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+
+        allocate(Phi_ref_grid(size(rg_grid%xb)), d2Phi_ref_grid(size(rg_grid%xb)))
+        call build_physical_c2_lift(rg_grid%xb, rm, dx_asis, dx_tr, phi_left, phi_right, &
+                                    Phi_ref_grid, d2Phi_ref_grid)
+        allocate(projection_mask(size(rg_grid%xb)))
+        projection_mask = abs(rg_grid%xb - rm) <= dx_asis
+        dim = 2 * M + 1
+        allocate(Br_m(dim))
+        Br_m = (0.0_dp, 0.0_dp)
+        Br_m(M + 1) = Br_const
+        call solve_periodic_deviation(Kphi, KB, L, M, Br_m, rg_grid%xb, &
+            Phi_ref_grid, d2Phi_ref_grid, PERIODIC_LIFT_PROJECTION_TOLERANCE, &
+            psi_m, projection_residual, info, projection_mask=projection_mask)
+        if (present(lift_projection_residual)) lift_projection_residual = projection_residual
         if (info /= 0) return
 
-        dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+        allocate(Phi_ref_out(size(r_out)), d2Phi_ref_out(size(r_out)))
+        call build_physical_c2_lift(r_out, rm, dx_asis, dx_tr, phi_left, phi_right, &
+                                    Phi_ref_out, d2Phi_ref_out)
+        dPhi = reconstruct_delta_phi_from_lift(psi_m, L, M, r_out, Phi_ref_out)
     end subroutine compute_periodic_delta_phi
+
+    subroutine aligned_lift_anchor(x, Br_const, phi_anchor, info)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use KIM_kinds_m, only: dp
+        use constants_m, only: com_unit
+        use periodic_background_m, only: kim_aperfuns, kim_geom_aperfuns
+        use periodic_solve_m, only: PERIODIC_SOLVE_OK, PERIODIC_SOLVE_INVALID_INPUT
+
+        real(dp), intent(in) :: x
+        complex(dp), intent(in) :: Br_const
+        complex(dp), intent(out) :: phi_anchor
+        integer, intent(out) :: info
+
+        real(dp) :: primitives(5), geometry(4), Er_x, kp_x, B0_x
+
+        phi_anchor = (0.0_dp, 0.0_dp)
+        info = PERIODIC_SOLVE_INVALID_INPUT
+        ! Both callbacks sample the cached true background, so repeated
+        ! convergence solves never derive anchors from an already-periodized
+        ! live plasma.
+        call kim_aperfuns(size(primitives), x, primitives)
+        call kim_geom_aperfuns(size(geometry), x, geometry)
+        Er_x = primitives(5)
+        B0_x = geometry(1)
+        kp_x = geometry(3)
+        if (.not. ieee_is_finite(Er_x) .or. .not. ieee_is_finite(kp_x) .or. &
+            .not. ieee_is_finite(B0_x) .or. abs(B0_x) <= tiny(1.0_dp) .or. &
+            abs(kp_x) <= sqrt(epsilon(1.0_dp))) return
+
+        ! Global bc_type=3 imposes Phi=-phi_aligned with
+        ! phi_aligned=+i Er Br/(B0 k_parallel).
+        phi_anchor = -com_unit * Er_x * Br_const / (B0_x * kp_x)
+        info = PERIODIC_SOLVE_OK
+    end subroutine aligned_lift_anchor
 
     !> Select the largest Larmor radius among species active in the FP kernel.
     subroutine select_periodic_reference_scale(plasma_in, x, electrons_active, ions_active, &
@@ -199,7 +270,7 @@ module rt_electrostatic_periodic_m
         complex(dp), allocatable :: dPhi(:)
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
-        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max, lift_projection_residual
         integer :: M, n_rg, info, i, reference_species
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
@@ -260,11 +331,13 @@ module rt_electrostatic_periodic_m
         ! periodic core. It does NOT error stop on a singular solve; do it here.
         Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
         call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                        r_win, dPhi, info)
+                                        r_win, dPhi, info, lift_projection_residual)
         if (info /= 0) then
             print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
             error stop "electrostatic_periodic: periodic solve failed"
         end if
+        print *, "electrostatic_periodic: aligned-lift projection residual = ", &
+                 lift_projection_residual
 
         ! Lock: the core has installed rg_grid%xb via build_periodic_plasma; the
         ! run-type's output grid r_win MUST equal it so EBdat is on the window.

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -184,6 +184,8 @@ set_target_properties(test_periodic_solve PROPERTIES
                         OUTPUT_NAME test_periodic_solve.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
 target_link_libraries(test_periodic_solve KIM_lib kilca_lib lapack cerf ddeabm slatec)
+configure_file(${CMAKE_SOURCE_DIR}/verification/oracles/field_operator_matrices.dat
+               ${CMAKE_BINARY_DIR}/tests/field_operator_matrices.dat COPYONLY)
 add_test(NAME test_periodic_solve
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_solve.x)
 set_tests_properties(test_periodic_solve PROPERTIES

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -215,7 +215,10 @@ contains
 
         integer, parameter :: npts = 201
         integer, parameter :: M = 32, ndiag = 41, nseq = 4
-        integer, parameter :: n_rg_seq(nseq) = [48, 96, 192, 384]
+        ! 2*M+1=65 coefficients require at least 65 endpoint-exclusive DFT
+        ! samples.  Starting at 48 aliases distinct harmonics and is no longer
+        ! accepted by the physical-lift projection gate.
+        integer, parameter :: n_rg_seq(nseq) = [72, 96, 192, 384]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)

--- a/KIM/tests/test_periodic_solve.f90
+++ b/KIM/tests/test_periodic_solve.f90
@@ -1,7 +1,6 @@
 program test_periodic_solve
-    ! Validates periodic_solve_m (Phase-2.5): the dense zgesv solve of the
-    ! periodic electrostatic system and the inverse-DFT reconstruction of the
-    ! potential.
+    ! Validates the derived periodic electrostatic operator, physical-space
+    ! deviation lift, explicit gauge policy, and inverse-DFT reconstruction.
     !
     ! System over Fourier modes m = -M..M (k_m = 2*pi*m/L):
     !   [ D_m delta_{m,m'} + 4*pi K^{rhoPhi}_{m,m'} ] Phi_{m'}
@@ -29,12 +28,21 @@ program test_periodic_solve
 
     use KIM_kinds_m, only: dp
     use constants_m, only: pi, com_unit
-    use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, dense_solve
+    use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, dense_solve, &
+        assemble_periodic_operator, project_onto_periodic_basis, &
+        solve_with_derived_gauge, solve_periodic_deviation, &
+        reconstruct_delta_phi_from_lift, build_physical_c2_lift, &
+        PERIODIC_SOLVE_OK, PERIODIC_SOLVE_GAUGE_REQUIRED, &
+        PERIODIC_SOLVE_INCOMPATIBLE_NULLSPACE, PERIODIC_SOLVE_PROJECTION_REJECTED
 
     implicit none
 
     call test_dense_solve_roundtrip()
     call test_inverse_dft()
+    call test_field_operator_oracle()
+    call test_zero_mode_policy()
+    call test_manufactured_deviation()
+    call test_projection_rejection()
     call test_end_to_end()
 
     print *, 'All tests PASSED'
@@ -137,6 +145,163 @@ contains
         print *, 'PASS: inverse DFT two-mode superposition, max err =', &
                  maxval(abs(dPhi - expected))
     end subroutine test_inverse_dft
+
+    subroutine test_field_operator_oracle()
+        integer, parameter :: M = 2, dim = 2 * M + 1
+        complex(dp) :: Kphi(dim, dim), A_expected(dim, dim), psi(dim), rhs(dim)
+        complex(dp), allocatable :: A(:,:), solved(:), drive_m(:)
+        complex(dp) :: drive_values(4)
+        real(dp) :: values(20), nodes(4), L, kappa, hat_nodes(3)
+        real(dp) :: hat_mass(3), hat_laplace(3), current_correct, current_printed
+        character(len=1024) :: line
+        integer :: unit, ios, kind, icase, row, col, idx, seen
+
+        Kphi = (0.0_dp, 0.0_dp)
+        A_expected = (0.0_dp, 0.0_dp)
+        psi = (0.0_dp, 0.0_dp)
+        rhs = (0.0_dp, 0.0_dp)
+        seen = 0
+        open(newunit=unit, file='field_operator_matrices.dat', status='old', action='read', iostat=ios)
+        if (ios /= 0) error stop 'cannot open field_operator_matrices.dat'
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            if (len_trim(line) == 0 .or. line(1:1) == '#') cycle
+            read(line, *, iostat=ios) kind, icase, row, col, values
+            if (ios /= 0) error stop 'invalid field_operator_matrices.dat row'
+            seen = seen + 1
+            select case (kind)
+            case (1)
+                idx = row + M + 1
+                L = values(1)
+                kappa = values(2)
+                Kphi(idx, idx) = -kappa * kappa / (4.0_dp * pi)
+                A_expected(idx, idx) = cmplx(values(4), values(5), dp)
+                psi(idx) = cmplx(values(8), values(9), dp)
+                rhs(idx) = cmplx(values(12), values(13), dp)
+            case (2)
+                hat_nodes(col) = values(2)
+                hat_mass(col) = values(3)
+                hat_laplace(col) = values(4)
+            case (4)
+                current_correct = values(11)
+                current_printed = values(13)
+            end select
+        end do
+        close(unit)
+        if (seen /= 14) error stop 'field/operator oracle row count mismatch'
+
+        call assemble_periodic_operator(Kphi, L, M, A)
+        if (maxval(abs(A - A_expected)) > &
+            128.0_dp * epsilon(1.0_dp) * max(1.0_dp, maxval(abs(A_expected)))) &
+            error stop 'field/operator oracle periodic matrix mismatch'
+        call solve_with_derived_gauge(A, rhs, M, .false., solved, ios)
+        if (ios /= PERIODIC_SOLVE_OK .or. maxval(abs(solved - psi)) > 1.0e-13_dp) &
+            error stop 'field/operator oracle screened solution mismatch'
+
+        nodes = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        drive_values = 2.0_dp + exp(com_unit * 2.0_dp * pi * nodes / 4.0_dp)
+        call project_onto_periodic_basis(drive_values, nodes, 4.0_dp, M, drive_m)
+        if (maxval(abs(drive_m - [cmplx(0.0_dp, 0.0_dp, dp), &
+            cmplx(0.0_dp, 0.0_dp, dp), cmplx(2.0_dp, 0.0_dp, dp), &
+            cmplx(1.0_dp, 0.0_dp, dp), cmplx(0.0_dp, 0.0_dp, dp)])) > 1.0e-13_dp) &
+            error stop 'field/operator oracle drive transform mismatch'
+        if (maxval(abs(hat_nodes - [0.0_dp, 1.0_dp, 3.0_dp])) > 1.0e-15_dp .or. &
+            maxval(abs(hat_mass - [1.0_dp/6.0_dp, 1.0_dp, 1.0_dp/3.0_dp])) > 1.0e-15_dp .or. &
+            maxval(abs(hat_laplace - [1.0_dp, -1.5_dp, 0.5_dp])) > 1.0e-15_dp) &
+            error stop 'field/operator oracle hat row mismatch'
+        if (abs(current_correct - current_printed) < 1.0e-6_dp) &
+            error stop 'field/operator oracle current mutation not distinguished'
+        print *, 'PASS: all 14 field/operator oracle rows consumed'
+    end subroutine test_field_operator_oracle
+
+    subroutine test_zero_mode_policy()
+        integer, parameter :: M = 1, dim = 3
+        complex(dp) :: A(dim, dim), rhs(dim)
+        complex(dp), allocatable :: solution(:)
+        integer :: info
+
+        A = (0.0_dp, 0.0_dp)
+        A(1, 1) = (-1.0_dp, 0.0_dp)
+        A(3, 3) = (-1.0_dp, 0.0_dp)
+        rhs = (0.0_dp, 0.0_dp)
+        call solve_with_derived_gauge(A, rhs, M, .false., solution, info)
+        if (info /= PERIODIC_SOLVE_GAUGE_REQUIRED) error stop 'missing vacuum gauge was accepted'
+        call solve_with_derived_gauge(A, rhs, M, .true., solution, info)
+        if (info /= PERIODIC_SOLVE_OK .or. abs(solution(M + 1)) > 1.0e-15_dp) &
+            error stop 'declared mean-zero vacuum gauge failed'
+        rhs(M + 1) = (1.0_dp, 0.0_dp)
+        call solve_with_derived_gauge(A, rhs, M, .true., solution, info)
+        if (info /= PERIODIC_SOLVE_INCOMPATIBLE_NULLSPACE) &
+            error stop 'incompatible vacuum source was accepted'
+        print *, 'PASS: screened/vacuum zero-mode policy'
+    end subroutine test_zero_mode_policy
+
+    subroutine test_manufactured_deviation()
+        integer, parameter :: M = 12, dim = 25, n = 96
+        real(dp), parameter :: L = 30.0_dp, dx_asis = 5.0_dp
+        real(dp) :: nodes(n), residual
+        logical :: projection_mask(n)
+        complex(dp) :: Kphi(dim, dim), KB(dim, dim), Br_m(dim), psi_known(dim)
+        complex(dp) :: phi_ref(n), d2phi_ref(n), total(n), expected(n)
+        complex(dp), allocatable :: A(:,:), ref_m(:), d2ref_m(:), psi_m(:)
+        integer :: i, info
+
+        do i = 1, n
+            nodes(i) = -0.5_dp * L + real(i - 1, dp) * L / real(n, dp)
+        end do
+        call build_physical_c2_lift(nodes, 0.0_dp, dx_asis, 10.0_dp, &
+            cmplx(-1.0_dp, 0.4_dp, dp), cmplx(0.7_dp, -0.2_dp, dp), phi_ref, d2phi_ref)
+        projection_mask = abs(nodes) <= dx_asis
+        Kphi = (0.0_dp, 0.0_dp)
+        KB = (0.0_dp, 0.0_dp)
+        do i = 1, dim
+            Kphi(i, i) = -0.75_dp**2 / (4.0_dp * pi)
+            KB(i, i) = (1.0_dp, 0.0_dp)
+        end do
+        call assemble_periodic_operator(Kphi, L, M, A)
+        call project_onto_periodic_basis(phi_ref, nodes, L, M, ref_m)
+        call project_onto_periodic_basis(d2phi_ref, nodes, L, M, d2ref_m)
+        psi_known = (0.0_dp, 0.0_dp)
+        psi_known(M) = (0.2_dp, -0.1_dp)
+        psi_known(M + 1) = (-0.3_dp, 0.25_dp)
+        psi_known(M + 2) = (0.15_dp, 0.05_dp)
+        Br_m = -(d2ref_m + 4.0_dp * pi * matmul(Kphi, ref_m) + &
+            matmul(A, psi_known)) / (4.0_dp * pi)
+        call solve_periodic_deviation(Kphi, KB, L, M, Br_m, nodes, phi_ref, d2phi_ref, &
+            6.0e-2_dp, psi_m, residual, info, projection_mask=projection_mask)
+        if (info /= PERIODIC_SOLVE_OK .or. maxval(abs(psi_m - psi_known)) > 2.0e-12_dp) &
+            error stop 'manufactured periodic deviation was not recovered'
+        total = reconstruct_delta_phi_from_lift(psi_m, L, M, nodes, phi_ref)
+        expected = phi_ref + reconstruct_delta_phi(psi_known, L, M, nodes)
+        if (maxval(abs(total - expected)) > 2.0e-12_dp) &
+            error stop 'physical-space lift reconstruction mismatch'
+        print *, 'PASS: manufactured complex deviation, projection residual =', residual
+    end subroutine test_manufactured_deviation
+
+    subroutine test_projection_rejection()
+        integer, parameter :: M = 2, dim = 5, n = 96
+        real(dp), parameter :: L = 30.0_dp
+        real(dp) :: nodes(n), residual
+        complex(dp) :: Kphi(dim, dim), KB(dim, dim), Br_m(dim)
+        complex(dp) :: phi_ref(n), d2phi_ref(n)
+        complex(dp), allocatable :: psi_m(:)
+        integer :: i, info
+
+        do i = 1, n
+            nodes(i) = -0.5_dp * L + real(i - 1, dp) * L / real(n, dp)
+        end do
+        call build_physical_c2_lift(nodes, 0.0_dp, 5.0_dp, 10.0_dp, &
+            cmplx(-1.0_dp, 0.0_dp, dp), cmplx(1.0_dp, 0.0_dp, dp), phi_ref, d2phi_ref)
+        Kphi = (0.0_dp, 0.0_dp)
+        KB = (0.0_dp, 0.0_dp)
+        Br_m = (0.0_dp, 0.0_dp)
+        call solve_periodic_deviation(Kphi, KB, L, M, Br_m, nodes, phi_ref, d2phi_ref, &
+            1.0e-2_dp, psi_m, residual, info)
+        if (info /= PERIODIC_SOLVE_PROJECTION_REJECTED) &
+            error stop 'under-resolved physical lift was accepted'
+        print *, 'PASS: under-resolved lift rejected, projection residual =', residual
+    end subroutine test_projection_rejection
 
     !> (c) End-to-end sanity with the REAL assembled matrices. Mirrors
     !> test_periodic_assembly's setup: build the (m,n)=(-6,2) periodic plasma,

--- a/docs/plans/2026-07-13-kim-poisson-deviation-design.md
+++ b/docs/plans/2026-07-13-kim-poisson-deviation-design.md
@@ -1,0 +1,63 @@
+# KIM Periodic Poisson Deviation Design
+
+## Decision
+
+Use the one-dimensional radial Poisson operator already defined by the KIM
+integral-model hat formulation, not an empirical `-k_s^2` correction. The full
+cylindrical harmonic Laplacian contains radial metric and helical terms, but
+chapter 15 reduces the numerical integral model to the local radial coordinate
+`x` and the hat solver implements that same reduction. The periodic symbol is
+therefore `D_m=-k_m^2`. The Mathematica gate records both formulas and the
+declared reduction so a future real-geometry extension cannot silently inherit
+the slab approximation.
+
+## Deviation Formulation
+
+Let `L = d^2/dr^2 + 4 pi K^{rho Phi}` and
+`g = -4 pi K^{rho B} B_r`. Choose a finite, smooth reference field
+`Phi_ref(r)` that agrees with global `bc_type=3` at the two physical window
+edges. A quintic C2 lift connects those values without evaluating singular
+`1/k_parallel` expressions at resonance. Solve
+
+`L psi = g - L Phi_ref`
+
+in the periodic Fourier space and reconstruct the physical field as
+
+`delta Phi(r) = Phi_ref(r) + psi(r)`.
+
+`Phi_ref` must remain a physical-space lifting function during reconstruction.
+If it is projected into the same finite Fourier space and added there, exact
+linear algebra cancels the shift and reproduces the original direct-periodic
+solution. Tests must include this no-op identity as a negative design check.
+
+For the tracer bullet, the reference and its analytic radial second derivative
+are sampled on the endpoint-exclusive periodic grid. `K Phi_ref` is evaluated
+by the same Fourier kernel after projection. Unequal physical edge values
+necessarily create a Fourier jump, so the declared residual measures Gibbs
+contamination in the untouched central plasma region, not at the artificial
+period boundary; residuals above 5% are rejected. The default benchmark gives
+3.16%. Excessive residual is a configuration error, not a curve-fit tolerance.
+
+## Operator and Gauge Policy
+
+Screening makes the zero Fourier mode nonsingular. In a true vacuum/null-space
+case, the mode-zero source must satisfy the compatibility condition and an
+explicit mean-zero gauge is required; otherwise the solver returns a nonzero
+status. No unconditional deletion of mode zero is allowed.
+
+## Verification
+
+The independent oracle covers Fourier measure and phase, hat overlap and weak
+derivative matrices, radial versus full cylindrical symbols, `4 pi` source
+sign, constant/nonconstant magnetic-drive coefficients, screened mode zero,
+manufactured complex `Phi_ref`/`psi`, electric-field reconstruction, and
+rho-B/j-Phi/j-B response signs. Fortran tests consume all 14 committed rows
+without requiring Mathematica, recover a manufactured complex deviation,
+exercise screened and vacuum zero modes, and reject an under-resolved lift.
+The independent mutation gate checks source sign, transform factor, transpose,
+boundary term, gauge removal, and `k_s^2`.
+
+The first benchmark after implementation showed that this boundary correction
+is not the dominant curve discrepancy: DC-removed periodic/global relative L2
+remained 0.72443. That result is evidence for the next diagnostic step rather
+than a reason to tune the lift to the target curve.

--- a/verification/FORMULA_INDEX.md
+++ b/verification/FORMULA_INDEX.md
@@ -565,7 +565,7 @@ path exists and that each code family has a source-to-check chain.
 | KIM-05 | `KIM/src/kernels/FP_kernel_plasma_prefacs.f90` | finite-radius FP kernel prefactors | Ch. 14 | independent #196 derivation; production Fourier consumption #187 verified |
 | KIM-06 | `KIM/src/kernels/kernel.f90` | real-space charge/current kernels and 1/(4 pi) normalization | Ch. 13–14 | independent #196 derivation; off-diagonal normalization #187 verified; current moments #197 verified |
 | KIM-07 | `KIM/src/electrostatic_poisson/poisson.f90` | global Gaussian-CGS weak Poisson problem | (12.25), Ch. 15 | weak matrix, boundary term, and source sign verified by #197 |
-| KIM-08 | `KIM/src/electrostatic_poisson/periodic_solve.f90` | periodic Fourier Poisson matrix/RHS | (12.25), Ch. 15 | basis/operator/gauge oracle #197; deviation implementation #188 pending |
+| KIM-08 | `KIM/src/electrostatic_poisson/periodic_solve.f90` | periodic Fourier Poisson matrix/RHS | (12.25), Ch. 15 | basis/operator/gauge oracle #197; physical-space deviation and projection gate #188 verified |
 | KIM-09 | `KIM/src/asymptotics/FLR2_asymptotics.f90` | aligned potential and FLR2 limits | Ch. 5 | aligned phase/sign and real-field convention verified by #197 |
 | KIM-10 | `KIM/src/grid/prepare_resonances.f90` | q_res=abs(m/n) | (3.5)–(3.6) | conventions script |
 | KIM-11 | `KIM/src/background_equilibrium/profile_input_m.f90` | radial force balance and Vz-to-Vparallel projection | (8.8)–(8.9) | profile/flow tests |
@@ -637,7 +637,11 @@ current response and records why the thesis (14.6) `I02/I22` pair is rejected.
 `verification/oracles/field_operator_matrices.dat` commits 14 deterministic
 Fourier, hat, drive-transform, and current rows. Six negative fixtures mutate
 the source sign, boundary term, transform factor, kernel transpose, gauge, and
-an undeclared `k_s^2` term.
+an undeclared `k_s^2` term. `test_periodic_solve` consumes all rows and adds a
+manufactured complex physical-lift solve, explicit screened/vacuum zero-mode
+tests, and an under-resolved projection rejection. #188 reconstructs the
+non-periodic aligned lift in physical space and keeps its analytic radial
+second derivative distinct from the projected kinetic action.
 
 The inventory script requires all 494 thesis labels, all 19 convention rows,
 and all 25 semantic code sites. It rejects a missing equation, missing code


### PR DESCRIPTION
## Summary

- solve for a periodic deviation around an explicit physical aligned-potential lift
- derive and enforce screened zero-mode and null-space behavior
- add manufactured complex solves, projection checks, reconstruction checks, and failure cases

## Why

The periodic solver no longer relies on an implicit periodic full-potential boundary condition.

## Validation

Validated cumulatively at the stack head:

- `cmake --build build -j2`
- `ctest --test-dir build -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global' --output-on-failure` — 35/35 passed

Known red gates are intentionally excluded from that command: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation acceptance gate, and the unresolved periodic-vs-global 5% agreement gate.

## Stack

Base: `fix/kim-fp-197-poisson-oracle`
Head: `fix/kim-fp-188-matched-bvp`

Closes #188

