### PR TITLE
[kim-fp-02] Preserve multispecies profiles in periodic backgrounds

### DIFF
--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -7,10 +7,9 @@ module periodic_background_m
     !>   - sample_periodic_primitives: a thin wrapper that returns the PERIODIZED
     !>                    primitives at a query radius by driving make_periodic.
     !>
-    !> ORDER CONTRACT (relied upon by Phase-2.3): the five sampled functions are
-    !> returned in the FIXED order
+    !> LEGACY SAMPLING CONTRACT: the public five-value sampler returns
     !>     funs = [ n_e, Te, Ti, q, Er ].
-    !> Do not reorder without updating every consumer.
+    !> The full periodic build caches and samples n_s and T_s for every species.
 
     use KIM_kinds_m, only: dp
     use periodization_m, only: make_periodic
@@ -19,10 +18,15 @@ module periodic_background_m
     private
 
     public :: kim_aperfuns, sample_periodic_primitives, build_periodic_plasma
+    public :: sample_periodic_species_profiles
     public :: reset_true_background_cache
 
-    !> Number of primitive functions sampled, and their FIXED order.
-    integer, parameter :: n_primitives = 5
+    integer, parameter, public :: PERIODIC_BACKGROUND_OK = 0
+    integer, parameter, public :: PERIODIC_BACKGROUND_INVALID_MAIN_ION = 1
+    integer, parameter, public :: PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE = 2
+
+    !> Number of values in the legacy public primitive-sampling interface.
+    integer, parameter :: n_legacy_primitives = 5
 
     !> Number of GEOMETRY functions periodized, and their FIXED order.
     !>     geom = [ B0, ks, kp, om_E ].
@@ -50,11 +54,13 @@ module periodic_background_m
     !> this cache (which would create a circular module dependency). No manual
     !> reset is needed after set_profiles_from_arrays.
     !>
-    !> Order in cache_prim: [ n_e, Te, Ti, q, Er ]  (matches kim_aperfuns).
+    !> Order in cache_prim for S species:
+    !>   [ n_0..n_(S-1), T_0..T_(S-1), q, Er ].
     !> Order in cache_geom: [ B0, ks, kp, om_E ]     (matches kim_geom_aperfuns).
     integer, save :: cached_generation = -1
+    integer, save :: cached_n_species = 0
     real(dp), allocatable, save :: cache_r(:)
-    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, n_primitives)
+    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, 2*S + 2)
     real(dp), allocatable, save :: cache_geom(:, :)   ! (grid_size, n_geom)
 
 contains
@@ -65,6 +71,7 @@ contains
     !> kept for callers that want to drop the snapshot explicitly.
     subroutine reset_true_background_cache()
         cached_generation = -1
+        cached_n_species = 0
         if (allocated(cache_r))    deallocate(cache_r)
         if (allocated(cache_prim)) deallocate(cache_prim)
         if (allocated(cache_geom)) deallocate(cache_geom)
@@ -78,7 +85,7 @@ contains
     subroutine capture_true_background()
         use species_m, only: plasma, profiles_generation
 
-        integer :: gs, i
+        integer :: gs, i, sp, ncols
 
         if (cached_generation == profiles_generation) return
 
@@ -87,15 +94,18 @@ contains
         if (allocated(cache_geom)) deallocate(cache_geom)
 
         gs = plasma%grid_size
-        allocate(cache_r(gs), cache_prim(gs, n_primitives), cache_geom(gs, n_geom))
+        cached_n_species = plasma%n_species
+        ncols = 2*cached_n_species + 2
+        allocate(cache_r(gs), cache_prim(gs, ncols), cache_geom(gs, n_geom))
 
         cache_r = plasma%r_grid(1:gs)
         do i = 1, gs
-            cache_prim(i, 1) = plasma%spec(0)%n(i)   ! electron density
-            cache_prim(i, 2) = plasma%spec(0)%T(i)   ! electron temperature
-            cache_prim(i, 3) = plasma%spec(1)%T(i)   ! ion temperature
-            cache_prim(i, 4) = plasma%q(i)           ! safety factor
-            cache_prim(i, 5) = plasma%Er(i)          ! radial electric field
+            do sp = 0, cached_n_species - 1
+                cache_prim(i, sp + 1) = plasma%spec(sp)%n(i)
+                cache_prim(i, cached_n_species + sp + 1) = plasma%spec(sp)%T(i)
+            end do
+            cache_prim(i, 2*cached_n_species + 1) = plasma%q(i)
+            cache_prim(i, 2*cached_n_species + 2) = plasma%Er(i)
 
             cache_geom(i, 1) = plasma%B0(i)          ! equilibrium field magnitude
             cache_geom(i, 2) = plasma%ks(i)          ! perpendicular wavenumber
@@ -165,8 +175,29 @@ contains
         ! no-op in the normal solver path (build_periodic_plasma already captured).
         call capture_true_background()
 
-        call interp_cache_row(cache_prim, nfuns, x, funs)
+        block
+            real(dp) :: all_funs(2*cached_n_species + 2)
+
+            call interp_cache_row(cache_prim, size(all_funs), x, all_funs)
+            funs(1) = all_funs(1)
+            funs(2) = all_funs(cached_n_species + 1)
+            funs(3) = all_funs(cached_n_species + 2)
+            funs(4) = all_funs(2*cached_n_species + 1)
+            funs(5) = all_funs(2*cached_n_species + 2)
+        end block
     end subroutine kim_aperfuns
+
+    !> Internal callback used by build_periodic_plasma. Unlike the legacy public
+    !> sampler, this passes every species profile through make_periodic in the
+    !> cache order [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+    subroutine kim_all_profiles_aperfuns(nfuns, x, funs)
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+
+        call capture_true_background()
+        call interp_cache_row(cache_prim, nfuns, x, funs)
+    end subroutine kim_all_profiles_aperfuns
 
     !> Aperiodic sample callback for the equilibrium GEOMETRY, conforming to
     !> periodization_m::aperfuns_i. Evaluates the TRUE geometry at radius x via
@@ -200,10 +231,42 @@ contains
     !> kim_aperfuns: funs_per = [ n_e, Te, Ti, q, Er ].
     subroutine sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
         real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
-        real(dp), intent(out) :: funs_per(n_primitives)
+        real(dp), intent(out) :: funs_per(n_legacy_primitives)
 
-        call make_periodic(kim_aperfuns, n_primitives, x_mid, dx_asis, dx_tr, x, funs_per)
+        call make_periodic(kim_aperfuns, n_legacy_primitives, x_mid, dx_asis, dx_tr, &
+                           x, funs_per)
     end subroutine sample_periodic_primitives
+
+    !> Return independently periodized densities and temperatures for every
+    !> configured species, plus q and Er. Arrays use species indices 0:S-1.
+    subroutine sample_periodic_species_profiles(x_mid, dx_asis, dx_tr, x, &
+                                                n_per, T_per, q_per, Er_per)
+        real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
+        real(dp), intent(out) :: n_per(0:), T_per(0:)
+        real(dp), intent(out) :: q_per, Er_per
+
+        integer :: sp, n_profile_values
+
+        call capture_true_background()
+        if (size(n_per) /= cached_n_species .or. &
+            size(T_per) /= cached_n_species) then
+            error stop 'periodic species sampler received the wrong species count'
+        end if
+
+        n_profile_values = 2*cached_n_species + 2
+        block
+            real(dp) :: all_funs(n_profile_values)
+
+            call make_periodic(kim_all_profiles_aperfuns, n_profile_values, x_mid, &
+                               dx_asis, dx_tr, x, all_funs)
+            do sp = 0, cached_n_species - 1
+                n_per(sp) = all_funs(sp + 1)
+                T_per(sp) = all_funs(cached_n_species + sp + 1)
+            end do
+            q_per = all_funs(2*cached_n_species + 1)
+            Er_per = all_funs(2*cached_n_species + 2)
+        end block
+    end subroutine sample_periodic_species_profiles
 
     !> Return the PERIODIZED geometry [ B0, ks, kp, om_E ] at query radius x,
     !> driving make_periodic with kim_geom_aperfuns. Same window layout as
@@ -239,7 +302,7 @@ contains
     !> unconditionally calls write_species_backs / write_plasma_backs, which
     !> create output_path//backs/ and write the background profile .dat files
     !> (rho_L, lambda_D, kp, om_E, ...) for the window plasma.
-    subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+    subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg, info)
         use species_m, only: plasma, reallocate, deallocate_plasma_derived, &
                              calc_plasma_parameter_derivs, calculate_plasma_backs, &
                              interpolate_plasma_backs, compute_rg_cell_centers, &
@@ -253,45 +316,63 @@ contains
 
         real(dp), intent(in) :: rm, dx_asis, dx_tr
         integer, intent(in) :: n_rg
+        integer, intent(out), optional :: info
 
         real(dp) :: L, r_lo, r_hi, u0_seed
-        real(dp) :: funs(n_primitives)
         real(dp), allocatable :: r_win(:)
-        real(dp), allocatable :: n_win(:), Te_win(:), Ti_win(:), q_win(:), Er_win(:)
-        integer :: j, sigma, npts
+        real(dp), allocatable :: n_win(:, :), T_win(:, :), q_win(:), Er_win(:)
+        integer :: j, sigma, npts, n_species, profile_status
+
+        if (present(info)) info = PERIODIC_BACKGROUND_OK
 
         ! Capture the TRUE background (r-grid, primitives, geometry) from the
         ! global plasma ONCE, before any redirect destroys it; all periodization
         ! (primitives AND geometry) then reads this cache, so repeated calls stay
         ! correct even though `plasma` is redirected onto the window after call 1.
         call capture_true_background()
+        n_species = cached_n_species
 
-        ! ---- 1. Equidistant window grid, reused as the global rg_grid. --------
+        ! ---- 1. Construct an equidistant window without mutating globals. -----
         L = 2.0_dp * (dx_asis + dx_tr)
         r_lo = rm - 0.5_dp * L
         r_hi = rm + 0.5_dp * L
 
-        ! grid_init_equidistant takes npts as intent(inout); pass a variable.
+        ! ---- 2. Sample and validate PERIODIZED primitives before redirect. ----
+        ! kim_aperfuns reads the CACHED true primitives (captured above), so this
+        ! is robust to the redirect and to repeated calls. Sample into temporaries;
+        ! only a valid profile is allowed to mutate rg_grid or plasma below.
+        ! Dynamic order: [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+        allocate(r_win(n_rg), n_win(n_rg, 0:n_species - 1), &
+                 T_win(n_rg, 0:n_species - 1), q_win(n_rg), Er_win(n_rg))
+        do j = 1, n_rg
+            r_win(j) = r_lo + L*real(j - 1, dp)/real(n_rg, dp)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, r_win(j), &
+                n_win(j, :), T_win(j, :), q_win(j), Er_win(j))
+        end do
+
+        ! Preserve independently periodized impurity densities and use the main
+        ! ion (species 1) as the dependent density. This documents one unique
+        ! quasineutrality policy and avoids changing impurity concentration
+        ! ratios merely because a species has a higher charge state.
+        call enforce_dependent_main_ion_density(n_win, T_win, profile_status)
+        if (profile_status /= PERIODIC_BACKGROUND_OK) then
+            deallocate(r_win, n_win, T_win, q_win, Er_win)
+            if (present(info)) then
+                info = profile_status
+                return
+            end if
+            if (profile_status == PERIODIC_BACKGROUND_INVALID_MAIN_ION) then
+                error stop 'periodic background requires a positive-Z main ion'
+            end if
+            error stop 'periodic background contains a nonphysical species profile'
+        end if
+
+        ! Validation succeeded. Redirect the global rg grid to the same
+        ! endpoint-exclusive equidistant window used for sampling.
         npts = n_rg
         call rg_grid%grid_init_equidistant(npts, r_lo, r_hi, 'rg')
         call rg_grid%grid_generate_equidistant()
-
-        ! ---- 2. Sample the PERIODIZED primitives on the window FIRST. ----------
-        ! kim_aperfuns reads the CACHED true primitives (captured above), so this
-        ! is robust to the redirect and to repeated calls. Sample into temporaries;
-        ! write them onto the redirected plasma in step 3.
-        ! FIXED order from sample_periodic_primitives: [ n_e, Te, Ti, q, Er ].
-        allocate(r_win(rg_grid%npts_b), n_win(rg_grid%npts_b), Te_win(rg_grid%npts_b), &
-                 Ti_win(rg_grid%npts_b), q_win(rg_grid%npts_b), Er_win(rg_grid%npts_b))
         r_win = rg_grid%xb
-        do j = 1, rg_grid%npts_b
-            call sample_periodic_primitives(rm, dx_asis, dx_tr, r_win(j), funs)
-            n_win(j)  = funs(1)
-            Te_win(j) = funs(2)
-            Ti_win(j) = funs(3)
-            q_win(j)  = funs(4)
-            Er_win(j) = funs(5)
-        end do
 
         ! Capture the TRUE B0 at the window's left edge (from the cached true
         ! geometry) as the force-balance ODE seed u0 = B0(r_lo)**2. Without this
@@ -330,14 +411,14 @@ contains
         call reallocate(plasma%spec(0)%T, rg_grid%npts_b)
         plasma%q  = q_win
         plasma%Er = Er_win
-        plasma%spec(0)%n = n_win
-        plasma%spec(0)%T = Te_win
+        plasma%spec(0)%n = n_win(:, 0)
+        plasma%spec(0)%T = T_win(:, 0)
         do sigma = 1, number_of_ion_species
             call reallocate(plasma%spec(sigma)%n, rg_grid%npts_b)
             call reallocate(plasma%spec(sigma)%T, rg_grid%npts_b)
-            plasma%spec(sigma)%T = Ti_win
+            plasma%spec(sigma)%n = n_win(:, sigma)
+            plasma%spec(sigma)%T = T_win(:, sigma)
         end do
-        call set_ion_density_quasineutral()
 
         ! Force calculate_equil / calc_plasma_parameter_derivs to recompute the
         ! profile derivatives (dndr, dTdr, dqdr) on the window instead of reusing
@@ -348,7 +429,7 @@ contains
         end do
         if (allocated(plasma%dqdr)) deallocate(plasma%dqdr)
 
-        deallocate(r_win, n_win, Te_win, Ti_win, q_win, Er_win)
+        deallocate(r_win, n_win, T_win, q_win, Er_win)
 
         ! ---- 4./5. Recompute derivatives + all derived quantities. ------------
         ! calculate_equil: recomputes dndr/dTdr/dqdr (via calc_plasma_parameter_
@@ -475,20 +556,49 @@ contains
             dfdr(N) = (f(1) - f(N-1)) / (2.0_dp * h)
         end subroutine periodic_central_diff
 
-        subroutine set_ion_density_quasineutral()
-            integer :: total_Z, sp, jj
+        subroutine enforce_dependent_main_ion_density(density, temperature, status)
+            use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
-            total_Z = 0
-            do sp = 1, number_of_ion_species
-                total_Z = total_Z + plasma%spec(sp)%Zspec
+            real(dp), intent(inout) :: density(:, 0:)
+            real(dp), intent(in) :: temperature(:, 0:)
+            integer, intent(out) :: status
+            real(dp) :: impurity_charge_density(size(density, 1))
+            integer :: sp
+
+            status = PERIODIC_BACKGROUND_INVALID_MAIN_ION
+            if (number_of_ion_species < 1 .or. plasma%spec(1)%Zspec <= 0) then
+                return
+            end if
+            do sp = 2, number_of_ion_species
+                if (plasma%spec(sp)%Zspec <= 0) return
             end do
-            if (total_Z == 0) return
-            do sp = 1, number_of_ion_species
-                do jj = 1, rg_grid%npts_b
-                    plasma%spec(sp)%n(jj) = plasma%spec(0)%n(jj) * plasma%spec(sp)%Zspec / total_Z
-                end do
+
+            status = PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE
+            if (any(.not. ieee_is_finite(density(:, 0))) .or. &
+                any(density(:, 0) <= 0.0_dp) .or. &
+                any(.not. ieee_is_finite(temperature)) .or. &
+                any(temperature <= 0.0_dp)) then
+                return
+            end if
+            do sp = 2, number_of_ion_species
+                if (any(.not. ieee_is_finite(density(:, sp))) .or. &
+                    any(density(:, sp) <= 0.0_dp)) return
             end do
-        end subroutine set_ion_density_quasineutral
+
+            impurity_charge_density = 0.0_dp
+            do sp = 2, number_of_ion_species
+                impurity_charge_density = impurity_charge_density + &
+                    real(plasma%spec(sp)%Zspec, dp)*density(:, sp)
+            end do
+            density(:, 1) = (density(:, 0) - impurity_charge_density) / &
+                            real(plasma%spec(1)%Zspec, dp)
+
+            if (any(.not. ieee_is_finite(density(:, 1))) .or. &
+                any(density(:, 1) <= 0.0_dp)) then
+                return
+            end if
+            status = PERIODIC_BACKGROUND_OK
+        end subroutine enforce_dependent_main_ion_density
 
         !> Deallocate the thermodynamic-force and susceptibility arrays that
         !> calculate_thermodynamic_forces_and_susc allocates behind a

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -19,7 +19,11 @@ module rt_electrostatic_periodic_m
             procedure :: run => run_electrostatic_periodic
     end type electrostatic_periodic_t
 
-    public :: compute_periodic_delta_phi
+    integer, parameter, public :: PERIODIC_SCALE_OK = 0
+    integer, parameter, public :: PERIODIC_SCALE_NO_ACTIVE = 1
+    integer, parameter, public :: PERIODIC_SCALE_INVALID_RHO = 2
+
+    public :: compute_periodic_delta_phi, select_periodic_reference_scale
 
     contains
 
@@ -59,6 +63,80 @@ module rt_electrostatic_periodic_m
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
     end subroutine compute_periodic_delta_phi
+
+    !> Select the largest Larmor radius among species active in the FP kernel.
+    subroutine select_periodic_reference_scale(plasma_in, x, electrons_active, ions_active, &
+                                               rho_ref, reference_species, info)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: x
+        logical, intent(in) :: electrons_active, ions_active
+        real(dp), intent(out) :: rho_ref
+        integer, intent(out) :: reference_species, info
+
+        real(dp) :: rho_sp
+        integer :: sp
+
+        rho_ref = 0.0_dp
+        reference_species = -1
+        info = PERIODIC_SCALE_NO_ACTIVE
+        if (plasma_in%n_species <= 0) return
+        if (.not. allocated(plasma_in%spec) .or. .not. allocated(plasma_in%r_grid) &
+            .or. plasma_in%grid_size < 4) then
+            info = PERIODIC_SCALE_INVALID_RHO
+            return
+        end if
+
+        do sp = 0, plasma_in%n_species - 1
+            if (.not. electrons_active .and. sp == 0) cycle
+            if (.not. ions_active .and. sp >= 1) cycle
+            if (.not. allocated(plasma_in%spec(sp)%rho_L) &
+                .or. size(plasma_in%spec(sp)%rho_L) < plasma_in%grid_size) then
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            rho_sp = interp_species_rho_L(plasma_in, sp, x)
+            if (.not. ieee_is_finite(rho_sp) .or. rho_sp <= 0.0_dp) then
+                rho_ref = rho_sp
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            if (rho_sp > rho_ref) then
+                rho_ref = rho_sp
+                reference_species = sp
+            end if
+        end do
+
+        if (reference_species >= 0) info = PERIODIC_SCALE_OK
+    end subroutine select_periodic_reference_scale
+
+    real(dp) function interp_species_rho_L(plasma_in, sp, x) result(rhoLx)
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma_in%grid_size
+        call binsrc(plasma_in%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma_in%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma_in%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     !> Global setup, identical to the electrostatic run-type's init: build the
     !> grids and equilibrium and populate the GLOBAL plasma. run() reads the
@@ -105,13 +183,14 @@ module rt_electrostatic_periodic_m
         use KIM_kinds_m, only: dp
         use constants_m, only: pi
         use config_m, only: periodic_dr_asis_scale, periodic_dr_tr_scale, &
-                            periodic_kmax_scale, periodic_n_rg, hdf5_output
+                            periodic_kmax_scale, periodic_n_rg, hdf5_output, &
+                            turn_off_electrons, turn_off_ions
         use setup_m, only: Br_boundary_re, Br_boundary_im
         use species_m, only: plasma
         use grid_m, only: rg_grid
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
-        use IO_collection_m, only: write_complex_profile_abs
+        use IO_collection_m, only: write_complex_profile_abs, write_periodic_scale_metadata
 
         implicit none
 
@@ -121,7 +200,7 @@ module rt_electrostatic_periodic_m
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
-        integer :: M, n_rg, info, i
+        integer :: M, n_rg, info, i, reference_species
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
         call prepare_resonances
@@ -131,13 +210,20 @@ module rt_electrostatic_periodic_m
         end if
         rm = r_res
 
-        ! 2. Representative Larmor radius rho_L(rm) (electrons) on the global
-        ! plasma via 4-point Lagrange interpolation.
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, "Error (electrostatic_periodic): rho_L(rm) not positive, = ", rhoL_rm
-            error stop "electrostatic_periodic: invalid rho_L(rm)"
-        end if
+        ! 2. Select the largest Larmor radius among the species that the FP
+        ! kernel will actually assemble. This keeps the full response of every
+        ! active species resolved and is independent of species storage order.
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, info)
+        select case (info)
+        case (PERIODIC_SCALE_NO_ACTIVE)
+            error stop "electrostatic_periodic: no active kinetic species"
+        case (PERIODIC_SCALE_INVALID_RHO)
+            print *, "Error (electrostatic_periodic): invalid rho_L for species ", &
+                     reference_species, " value = ", rhoL_rm
+            error stop "electrostatic_periodic: invalid active-species rho_L(rm)"
+        end select
 
         ! 3. Window geometry and Fourier cutoff from rho_L(rm).
         dx_asis = periodic_dr_asis_scale * rhoL_rm
@@ -147,8 +233,19 @@ module rt_electrostatic_periodic_m
         M       = ceiling(k_max * L / (2.0_dp * pi))
         n_rg    = periodic_n_rg
 
-        print *, "electrostatic_periodic: rm = ", rm, " rho_L(rm) = ", rhoL_rm
-        print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
+        print *, "electrostatic_periodic: reference species = ", reference_species, &
+                 " Z = ", plasma%spec(reference_species)%Zspec, &
+                 " mass [g] = ", plasma%spec(reference_species)%mass
+        print *, "electrostatic_periodic: rm [cm] = ", rm, &
+                 " rho_L(rm) [cm] = ", rhoL_rm
+        print *, "electrostatic_periodic: dx_asis [cm] = ", dx_asis, &
+                 " dx_tr [cm] = ", dx_tr, " L [cm] = ", L
+        print *, "electrostatic_periodic: k_max [1/cm] = ", k_max, &
+                 " M = ", M, " n_rg = ", n_rg
+        call write_periodic_scale_metadata(reference_species, &
+            plasma%spec(reference_species)%Zspec, &
+            plasma%spec(reference_species)%mass, rhoL_rm, dx_asis, dx_tr, &
+            k_max, M, n_rg)
 
         ! 4. Window output grid: n_rg equidistant points on [rm - L/2, rm + L/2],
         ! bit-identical to the grid build_periodic_plasma installs as rg_grid%xb
@@ -187,29 +284,6 @@ module rt_electrostatic_periodic_m
                 'Electrostatic potential perturbation Phi, forced-periodicity solution', &
                 'statV')
         end if
-
-    contains
-
-        !> 4-point Lagrange interpolation of the global electron Larmor radius
-        !> plasma%spec(0)%rho_L at radius x, using the same binsrc + plag_coeff
-        !> stencil as the rest of KIM.
-        real(dp) function interp_rho_L(x) result(rhoLx)
-            real(dp), intent(in) :: x
-            integer, parameter :: nlagr = 4, nder = 0
-            real(dp) :: coef(0:nder, nlagr)
-            integer :: gs, ir, ibeg, iend
-
-            gs = plasma%grid_size
-            call binsrc(plasma%r_grid, 1, gs, x, ir)
-            ibeg = max(1, ir - nlagr/2)
-            iend = ibeg + nlagr - 1
-            if (iend > gs) then
-                iend = gs
-                ibeg = iend - nlagr + 1
-            end if
-            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-            rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-        end function interp_rho_L
 
     end subroutine run_electrostatic_periodic
 

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -58,6 +58,62 @@ module IO_collection_m
 
     end subroutine write_KIM_namelist_to_hdf5
 
+    subroutine write_periodic_scale_metadata(reference_species, charge, mass, rho_ref, &
+                                             dx_asis, dx_tr, k_max, n_modes, n_rg)
+
+        use config_m, only: output_path, hdf5_output
+        use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_open_group, &
+                                   h5_obj_exists, h5_add, h5_close_group
+
+        implicit none
+
+        integer, intent(in) :: reference_species, charge, n_modes, n_rg
+        real(dp), intent(in) :: mass, rho_ref, dx_asis, dx_tr, k_max
+
+        character(len=*), parameter :: header = &
+            '# reference_species charge mass_g rho_ref_cm dx_asis_cm dx_tr_cm ' // &
+            'k_max_cm_inv M N_rg'
+        integer :: iunit
+        integer(HID_T) :: h5grpid
+        logical :: ex
+
+        if (hdf5_output) then
+            call h5_obj_exists(h5id, 'setup/periodic_scale/', ex)
+            if (.not. ex) then
+                call h5_define_group(h5id, 'setup/periodic_scale/', h5grpid)
+            else
+                call h5_open_group(h5id, 'setup/periodic_scale/', h5grpid)
+            end if
+            call h5_add(h5grpid, 'reference_species', reference_species, &
+                        'Zero-based index of the species defining the periodic scale', '1')
+            call h5_add(h5grpid, 'charge', charge, &
+                        'Charge number of the periodic reference species', '1')
+            call h5_add(h5grpid, 'mass', mass, &
+                        'Mass of the periodic reference species', 'g')
+            call h5_add(h5grpid, 'rho_ref', rho_ref, &
+                        'Reference Larmor radius at the resonant surface', 'cm')
+            call h5_add(h5grpid, 'dx_asis', dx_asis, &
+                        'As-is half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'dx_tr', dx_tr, &
+                        'Transition half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'k_max', k_max, &
+                        'Maximum resolved radial wavenumber', '1/cm')
+            call h5_add(h5grpid, 'M', n_modes, &
+                        'Maximum positive periodic Fourier mode', '1')
+            call h5_add(h5grpid, 'N_rg', n_rg, &
+                        'Number of radial quadrature points', '1')
+            call h5_close_group(h5grpid)
+        else
+            open(newunit=iunit, file=trim(output_path)//'setup/periodic_scale.dat', &
+                 status='replace', action='write')
+            write(iunit, '(A)') header
+            write(iunit, *) reference_species, charge, mass, rho_ref, dx_asis, &
+                            dx_tr, k_max, n_modes, n_rg
+            close(iunit)
+        end if
+
+    end subroutine write_periodic_scale_metadata
+
     subroutine write_config_namelist_to_hdf5()
 
         use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_obj_exists, h5_add, h5_close_group

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -25,6 +25,7 @@ program test_kim_solver_periodic
     implicit none
 
     call test_run_type_end_to_end()
+    call test_multi_ion_order_independence()
 
     print *, 'All tests PASSED'
     stop 0
@@ -33,8 +34,9 @@ contains
 
     subroutine test_run_type_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -47,7 +49,7 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        real(dp) :: rm, r_lo, r_hi, tol
+        real(dp) :: rm, r_lo, r_hi, tol, rho_i_rm, expected_r_lo
         integer :: i, N
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
@@ -64,14 +66,23 @@ contains
         ! Full lifecycle through the new run-type.
         call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
         call kim_instance%init()
-        call kim_instance%run()
 
-        ! The resonance the run-type located (q = |m/n| = 3 on the global plasma).
+        ! Capture the reference scale from the TRUE global plasma before run()
+        ! redirects it onto the periodic window. This is the same state used by
+        ! run_electrostatic_periodic to derive and store the window parameters.
+        call prepare_resonances
         rm = r_res
         if (.not. (rm > 0.0_dp)) then
             print *, 'FAIL: resonance not found, r_res = ', rm
             error stop
         end if
+        rho_i_rm = interp_species_rho_L(1, rm)
+        if (.not. (rho_i_rm > 0.0_dp)) then
+            print *, 'FAIL: deuterium rho_L(rm) is not positive:', rho_i_rm
+            error stop
+        end if
+
+        call kim_instance%run()
         print *, 'resonant radius rm = ', rm
 
         N = rg_grid%npts_b
@@ -116,6 +127,14 @@ contains
         r_lo = EBdat%r_grid(1)
         r_hi = EBdat%r_grid(N)
         tol = 1.0e-8_dp * (1.0_dp + abs(rm))
+        expected_r_lo = rm - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_i_rm
+        if (abs(r_lo - expected_r_lo) > tol) then
+            print *, 'FAIL: periodic window is not sized from deuterium rho_L'
+            print *, '  actual lower edge =', r_lo
+            print *, '  expected lower edge =', expected_r_lo
+            print *, '  deuterium rho_L(rm) =', rho_i_rm
+            error stop
+        end if
         if (abs(0.5_dp * (r_lo + r_hi) - rm) > (r_hi - r_lo) / real(N - 1, dp)) then
             print *, 'FAIL: window not centred on rm; midpoint =', &
                      0.5_dp * (r_lo + r_hi), ' rm =', rm
@@ -127,7 +146,157 @@ contains
         end if
         print *, 'PASS: EBdat%r_grid spans window [', r_lo, ',', r_hi, &
                  '] about rm =', rm
+
+        call assert_scale_metadata(rho_i_rm)
     end subroutine test_run_type_end_to_end
+
+    subroutine assert_scale_metadata(expected_rho)
+        use constants_m, only: pi
+        use config_m, only: output_path, periodic_dr_asis_scale, &
+                            periodic_dr_tr_scale, periodic_kmax_scale, periodic_n_rg
+
+        real(dp), intent(in) :: expected_rho
+        character(len=512) :: metadata_path, header
+        integer :: io_unit, io_status, reference_species, charge, M, n_rg
+        real(dp) :: mass, rho_ref, dx_asis, dx_tr, k_max, period, tol
+        logical :: exists
+
+        metadata_path = trim(output_path)//'setup/periodic_scale.dat'
+        inquire(file=trim(metadata_path), exist=exists)
+        if (.not. exists) then
+            print *, 'FAIL: periodic scale metadata was not stored at ', trim(metadata_path)
+            error stop
+        end if
+
+        open(newunit=io_unit, file=trim(metadata_path), status='old', action='read')
+        read(io_unit, '(A)', iostat=io_status) header
+        if (io_status /= 0 .or. index(header, 'reference_species') == 0) then
+            print *, 'FAIL: periodic scale metadata header is missing or invalid'
+            error stop
+        end if
+        read(io_unit, *, iostat=io_status) reference_species, charge, mass, rho_ref, &
+            dx_asis, dx_tr, k_max, M, n_rg
+        close(io_unit)
+        if (io_status /= 0) then
+            print *, 'FAIL: periodic scale metadata row could not be read'
+            error stop
+        end if
+
+        tol = 1.0e-10_dp * max(1.0_dp, expected_rho)
+        period = 2.0_dp * (periodic_dr_asis_scale + periodic_dr_tr_scale) * expected_rho
+        if (reference_species /= 1 .or. charge /= 1 .or. .not. (mass > 0.0_dp) .or. &
+            abs(rho_ref - expected_rho) > tol .or. &
+            abs(dx_asis - periodic_dr_asis_scale * expected_rho) > tol .or. &
+            abs(dx_tr - periodic_dr_tr_scale * expected_rho) > tol .or. &
+            abs(k_max - periodic_kmax_scale / expected_rho) > tol .or. &
+            M /= ceiling((periodic_kmax_scale / expected_rho) * period / (2.0_dp * pi)) .or. &
+            n_rg /= periodic_n_rg) then
+            print *, 'FAIL: stored periodic scale metadata does not match the run'
+            print *, '  species/Z/mass =', reference_species, charge, mass
+            print *, '  rho stored/expected/tol =', rho_ref, expected_rho, tol
+            print *, '  dx_asis stored/expected =', dx_asis, &
+                     periodic_dr_asis_scale * expected_rho
+            print *, '  dx_tr stored/expected =', dx_tr, &
+                     periodic_dr_tr_scale * expected_rho
+            print *, '  k_max stored/expected =', k_max, &
+                     periodic_kmax_scale / expected_rho
+            print *, '  M/N_rg stored =', M, n_rg, ' expected N_rg =', periodic_n_rg
+            error stop
+        end if
+        print *, 'PASS: periodic scale provenance stored in ', trim(metadata_path)
+    end subroutine assert_scale_metadata
+
+    subroutine test_multi_ion_order_independence()
+        integer, parameter :: masses_forward(2) = [2, 12]
+        integer, parameter :: masses_reverse(2) = [12, 2]
+        real(dp) :: lower_forward, lower_reverse, expected_forward, expected_reverse
+        real(dp) :: tol
+
+        call run_multi_ion_case(masses_forward, lower_forward, expected_forward)
+        call run_multi_ion_case(masses_reverse, lower_reverse, expected_reverse)
+
+        tol = 1.0e-8_dp * (1.0_dp + abs(expected_forward))
+        if (abs(lower_forward - expected_forward) > tol) then
+            print *, 'FAIL: forward-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_forward
+            print *, '  expected lower edge =', expected_forward
+            error stop
+        end if
+        if (abs(lower_reverse - expected_reverse) > tol) then
+            print *, 'FAIL: reverse-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_reverse
+            print *, '  expected lower edge =', expected_reverse
+            error stop
+        end if
+        if (abs(lower_forward - lower_reverse) > tol) then
+            print *, 'FAIL: reference scale depends on ion storage order'
+            print *, '  forward lower edge =', lower_forward
+            print *, '  reverse lower edge =', lower_reverse
+            error stop
+        end if
+        print *, 'PASS: largest active-ion rho_L is storage-order independent'
+    end subroutine test_multi_ion_order_independence
+
+    subroutine run_multi_ion_case(ion_masses, lower_edge, expected_lower_edge)
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use fields_m, only: EBdat, EBdat_t
+
+        integer, intent(in) :: ion_masses(:)
+        real(dp), intent(out) :: lower_edge, expected_lower_edge
+        integer, parameter :: npts = 201
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp) :: rho_max
+        class(kim_t), allocatable :: kim_instance
+        integer :: sp
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_run_test.nml', ion_masses)
+        nml_config_path = './KIM_config_periodic_run_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        rho_max = 0.0_dp
+        do sp = 1, plasma%n_species - 1
+            rho_max = max(rho_max, interp_species_rho_L(sp, r_res))
+        end do
+        lower_edge = EBdat%r_grid(1)
+        expected_lower_edge = r_res &
+            - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_max
+    end subroutine run_multi_ion_case
+
+    real(dp) function interp_species_rho_L(sp, x) result(rhoLx)
+        use species_m, only: plasma
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+        call binsrc(plasma%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)
@@ -148,21 +317,27 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path)
+    subroutine write_test_namelist(path, ion_masses)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
         ! config defaults apply when the optional namelist is absent.
         character(len=*), intent(in) :: path
-        integer :: iunit
+        integer, intent(in), optional :: ion_masses(:)
+        integer :: iunit, i, nions
+        logical :: custom_species
+
+        custom_species = present(ion_masses)
+        nions = 1
+        if (custom_species) nions = size(ion_masses)
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
-        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A,I0)') ' number_of_ion_species = ', nions
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic_periodic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
-        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A,L1)') ' read_species_from_namelist = ', custom_species
         write(iunit, '(A)') ' turn_off_ions = .false.'
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
@@ -170,6 +345,20 @@ contains
         write(iunit, '(A)') ' number_density_rescale = 1.0'
         write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
         write(iunit, '(A)') '/'
+        if (custom_species) then
+            write(iunit, '(A)') '&KIM_species'
+            write(iunit, '(A)', advance='no') ' ai ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') ion_masses(i)
+            end do
+            write(iunit, *)
+            write(iunit, '(A)', advance='no') ' zi ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') 1
+            end do
+            write(iunit, *)
+            write(iunit, '(A)') '/'
+        end if
         write(iunit, '(A)') '&WKB_DISPERSION'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_IO'

--- a/KIM/tests/test_periodic_background_build.f90
+++ b/KIM/tests/test_periodic_background_build.f90
@@ -12,7 +12,8 @@ program test_periodic_background_build
     ! The (m,n) = (-6, 2) mode makes q resonant at q = |m/n| = 3, so the
     ! q-profile is built to cross 3 inside the solver domain [r_min, r_plas].
     !
-    ! Assertions on the window:
+    ! The fixture contains D plus a Z=6 impurity with distinct density and
+    ! temperature profiles. Assertions on the window:
     !   (1) rho_L, lambda_D finite and > 0 everywhere,
     !   (2) I00(j,0) finite everywhere (susceptibility recomputed),
     !   (3) as-is fidelity: inside the as-is core the BUILT derived quantities
@@ -20,10 +21,13 @@ program test_periodic_background_build
     !       (the periodized primitives equal the true primitives in the core),
     !   (4) resonance: parallel wavenumber kp ~ 0 at the window point nearest rm
     !       (confirms q = 3 there and a correct kp recompute),
-    !   (5) all finite (no NaN/Inf).
+    !   (5) each ion profile survives independently and quasineutrality holds,
+    !   (6) all finite (no NaN/Inf).
 
     use KIM_kinds_m, only: dp
-    use periodic_background_m, only: build_periodic_plasma
+    use periodic_background_m, only: build_periodic_plasma, &
+                                     sample_periodic_species_profiles, &
+                                     PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE
 
     implicit none
 
@@ -51,8 +55,11 @@ contains
 
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm
         real(dp) :: r_asis, rho_L_true, lambda_D_true, rho_L_built, lambda_D_built
+        real(dp) :: n_D_true, n_C_true, T_D_true, T_C_true
+        real(dp) :: n_D_built, n_C_built, T_D_built, T_C_built
+        real(dp) :: qn_residual, density_scale
         integer :: n_rg
-        integer :: j, gs, j_rm
+        integer :: j, gs, j_rm, sp
         real(dp) :: kp_scale, tol_kp, tol_asis, rel
         logical :: any_bad
 
@@ -66,6 +73,7 @@ contains
         call kim_init()
         call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
                                       q_prof, Er_prof, npts)
+        call set_distinct_two_ion_profiles()
 
         call from_kim_factory_get_kim('electrostatic', kim_instance)
         call kim_instance%init()
@@ -78,6 +86,8 @@ contains
         end if
         rm = r_res
         print *, 'resonant radius rm = ', rm
+
+        call test_multispecies_cache_refresh(rm)
 
         ! Representative Larmor radius near rm (electrons) on the global plasma.
         rho_L_rm = rho_L_near(rm)
@@ -107,6 +117,14 @@ contains
                                          plasma%grid_size, r_asis)
         lambda_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(0)%lambda_D, &
                                          plasma%grid_size, r_asis)
+        n_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(1)%n, &
+                                    plasma%grid_size, r_asis)
+        n_C_true = interp_lagrange4(plasma%r_grid, plasma%spec(2)%n, &
+                                    plasma%grid_size, r_asis)
+        T_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(1)%T, &
+                                    plasma%grid_size, r_asis)
+        T_C_true = interp_lagrange4(plasma%r_grid, plasma%spec(2)%T, &
+                                    plasma%grid_size, r_asis)
 
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
 
@@ -181,6 +199,40 @@ contains
         end if
         print *, 'PASS: periodic build reproduces true rho_L, lambda_D in as-is core'
 
+        ! (5) Preserve every configured species independently. Species 1 is the
+        ! dependent main ion, while the impurity density is preserved and the
+        ! main-ion density enforces n_e = Z_D*n_D + Z_C*n_C. The fixture is
+        ! exactly quasineutral before periodization, so all four profiles must
+        ! reproduce the true as-is values to interpolation accuracy.
+        n_D_built = interp_lagrange4(rg_grid%xb, plasma%spec(1)%n, gs, r_asis)
+        n_C_built = interp_lagrange4(rg_grid%xb, plasma%spec(2)%n, gs, r_asis)
+        T_D_built = interp_lagrange4(rg_grid%xb, plasma%spec(1)%T, gs, r_asis)
+        T_C_built = interp_lagrange4(rg_grid%xb, plasma%spec(2)%T, gs, r_asis)
+
+        call assert_relative_close('D density', n_D_built, n_D_true, tol_asis)
+        call assert_relative_close('C density', n_C_built, n_C_true, tol_asis)
+        call assert_relative_close('D temperature', T_D_built, T_D_true, tol_asis)
+        call assert_relative_close('C temperature', T_C_built, T_C_true, tol_asis)
+
+        density_scale = maxval(plasma%spec(0)%n)
+        qn_residual = maxval(abs(plasma%spec(1)%n + &
+                                 6.0_dp*plasma%spec(2)%n - plasma%spec(0)%n))
+        if (qn_residual > 50.0_dp*epsilon(1.0_dp)*density_scale) then
+            print *, 'FAIL: periodic multispecies background is not quasineutral'
+            print *, '  max residual = ', qn_residual, ' density scale = ', density_scale
+            error stop
+        end if
+        do j = 1, gs
+            if (any([plasma%spec(0)%n(j), plasma%spec(1)%n(j), &
+                     plasma%spec(2)%n(j)] <= 0.0_dp) .or. &
+                any([plasma%spec(0)%T(j), plasma%spec(1)%T(j), &
+                     plasma%spec(2)%T(j)] <= 0.0_dp)) then
+                print *, 'FAIL: non-positive multispecies primitive at j=', j
+                error stop
+            end if
+        end do
+        print *, 'PASS: distinct two-ion profiles preserved and quasineutral'
+
         ! (4) Resonance: kp ~ 0 at the window point nearest rm (q = 3 there).
         j_rm = minloc(abs(rg_grid%xb - rm), dim=1)
         ! Scale for "small": kp away from resonance is O(n_mode/R0) ~ O(1e-2).
@@ -195,7 +247,7 @@ contains
         end if
         print *, 'PASS: kp ~ 0 at window point nearest rm (resonance q=3 confirmed)'
 
-        ! (5) Global finiteness sweep of the load-bearing derived arrays.
+        ! (6) Global finiteness sweep of the load-bearing derived arrays.
         do j = 1, gs
             if (.not. ieee_is_finite(plasma%kp(j)) .or. &
                 .not. ieee_is_finite(plasma%B0(j)) .or. &
@@ -205,9 +257,177 @@ contains
                 print *, 'FAIL: non-finite derived quantity at j=', j
                 error stop
             end if
+            if (.not. ieee_is_finite(plasma%spec(1)%vT(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(1)%nu(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(1)%rho_L(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%vT(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%nu(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%rho_L(j))) then
+                print *, 'FAIL: non-finite ion-derived quantity at j=', j
+                error stop
+            end if
+            do sp = 0, 2
+                if (.not. ieee_is_finite(plasma%spec(sp)%omega_c(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%lambda_D(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%A1(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%A2(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%x1(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%x2(j, 0)) .or. &
+                    .not. ieee_is_finite(real(plasma%spec(sp)%I00(j, 0), dp)) .or. &
+                    .not. ieee_is_finite(aimag(plasma%spec(sp)%I00(j, 0)))) then
+                    print *, 'FAIL: incomplete derived pipeline at j=', j, ' species=', sp
+                    error stop
+                end if
+            end do
         end do
         print *, 'PASS: all derived quantities finite across the window'
+
+        call test_multispecies_periodicity(rm, dx_asis, dx_tr)
+        call test_negative_dependent_density_rejected(rm, dx_asis, dx_tr, n_rg)
     end subroutine test_build_periodic
+
+    subroutine test_multispecies_periodicity(rm, dx_asis, dx_tr)
+        real(dp), intent(in) :: rm, dx_asis, dx_tr
+        real(dp) :: n_left(0:2), T_left(0:2), n_shift(0:2), T_shift(0:2)
+        real(dp) :: q_left, Er_left, q_shift, Er_shift
+        real(dp) :: x_values(5), x, period_length
+        integer :: k, sp
+
+        period_length = 2.0_dp*(dx_asis + dx_tr)
+        x_values = [rm - dx_asis - dx_tr, rm - dx_asis, rm, &
+                    rm + dx_asis, rm + dx_asis + dx_tr]
+        do k = 1, size(x_values)
+            x = x_values(k)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, x, &
+                                                  n_left, T_left, q_left, Er_left)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, &
+                x + period_length, n_shift, T_shift, q_shift, Er_shift)
+            do sp = 0, 2
+                call assert_relative_close('periodic species density', &
+                                           n_shift(sp), n_left(sp), 1.0e-10_dp)
+                call assert_relative_close('periodic species temperature', &
+                                           T_shift(sp), T_left(sp), 1.0e-10_dp)
+            end do
+            call assert_relative_close('periodic q', q_shift, q_left, 1.0e-10_dp)
+            call assert_relative_close('periodic Er', Er_shift, Er_left, 1.0e-10_dp)
+        end do
+        print *, 'PASS: all species primitives are periodic across the seam'
+    end subroutine test_multispecies_periodicity
+
+    subroutine test_negative_dependent_density_rejected(rm, dx_asis, dx_tr, n_rg)
+        use species_m, only: plasma, profiles_generation
+        use grid_m, only: rg_grid
+
+        real(dp), intent(in) :: rm, dx_asis, dx_tr
+        integer, intent(in) :: n_rg
+        real(dp) :: old_grid_start, old_grid_end
+        integer :: info, old_n_rg
+
+        ! Z_C*n_C = 1.2*n_e leaves no positive density for the dependent
+        ! deuterium species. The builder must report a profile error rather than
+        ! advancing into logarithms, collision frequencies, or susceptibilities.
+        old_n_rg = rg_grid%npts_b
+        old_grid_start = rg_grid%xb(1)
+        old_grid_end = rg_grid%xb(old_n_rg)
+        plasma%spec(2)%n = 0.2_dp*plasma%spec(0)%n
+        profiles_generation = profiles_generation + 1
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg + 7, info)
+        if (info /= PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE) then
+            print *, 'FAIL: negative dependent density status = ', info
+            error stop
+        end if
+        if (rg_grid%npts_b /= old_n_rg .or. &
+            abs(rg_grid%xb(1) - old_grid_start) > epsilon(1.0_dp) .or. &
+            abs(rg_grid%xb(old_n_rg) - old_grid_end) > epsilon(1.0_dp)) then
+            print *, 'FAIL: rejected profile mutated the global radial grid'
+            error stop
+        end if
+        print *, 'PASS: negative dependent-ion density rejected as a profile error'
+    end subroutine test_negative_dependent_density_rejected
+
+    subroutine test_multispecies_cache_refresh(rm)
+        ! Model two successive in-process profile cases. The generation bump is
+        ! the same invalidation signal emitted by the profile adapter; case B
+        ! keeps total ion pressure unchanged so the already-computed geometry
+        ! remains a valid true background for the rest of this test.
+        use species_m, only: plasma, profiles_generation
+
+        real(dp), intent(in) :: rm
+        real(dp) :: n_before(0:2), T_before(0:2), n_after(0:2), T_after(0:2)
+        real(dp) :: q_sample, Er_sample, radius_fraction, impurity_fraction
+        real(dp) :: ion_pressure, expected
+        integer :: j
+
+        call sample_periodic_species_profiles(rm, 1.0_dp, 2.0_dp, rm, &
+                                              n_before, T_before, q_sample, Er_sample)
+
+        do j = 1, plasma%grid_size
+            radius_fraction = (plasma%r_grid(j) - plasma%r_grid(1)) / &
+                              (plasma%r_grid(plasma%grid_size) - plasma%r_grid(1))
+            ion_pressure = plasma%spec(1)%n(j)*plasma%spec(1)%T(j) + &
+                           plasma%spec(2)%n(j)*plasma%spec(2)%T(j)
+            impurity_fraction = 0.018_dp + 0.003_dp*radius_fraction
+            plasma%spec(2)%n(j) = impurity_fraction*plasma%spec(0)%n(j)
+            plasma%spec(1)%n(j) = plasma%spec(0)%n(j) - &
+                                  6.0_dp*plasma%spec(2)%n(j)
+            plasma%spec(2)%T(j) = 1050.0_dp + 100.0_dp*radius_fraction
+            plasma%spec(1)%T(j) = (ion_pressure - &
+                                    plasma%spec(2)%n(j)*plasma%spec(2)%T(j)) / &
+                                   plasma%spec(1)%n(j)
+        end do
+        profiles_generation = profiles_generation + 1
+
+        call sample_periodic_species_profiles(rm, 1.0_dp, 2.0_dp, rm, &
+                                              n_after, T_after, q_sample, Er_sample)
+
+        expected = interp_lagrange4(plasma%r_grid, plasma%spec(2)%n, &
+                                    plasma%grid_size, rm)
+        call assert_relative_close('refreshed C density', n_after(2), expected, 1.0e-10_dp)
+        expected = interp_lagrange4(plasma%r_grid, plasma%spec(2)%T, &
+                                    plasma%grid_size, rm)
+        call assert_relative_close('refreshed C temperature', T_after(2), expected, 1.0e-10_dp)
+        if (abs(n_after(2) - n_before(2)) <= 0.1_dp*abs(n_before(2)) .or. &
+            abs(T_after(2) - T_before(2)) <= 0.1_dp*abs(T_before(2))) then
+            print *, 'FAIL: multispecies cache retained the first profile case'
+            error stop
+        end if
+        print *, 'PASS: multispecies cache refreshed for a second profile case'
+    end subroutine test_multispecies_cache_refresh
+
+    subroutine set_distinct_two_ion_profiles()
+        ! Construct an exactly quasineutral D + C background. The carbon
+        ! concentration and both ion temperatures have distinct radial shapes,
+        ! so a single shared ion profile cannot satisfy this fixture.
+        use species_m, only: plasma
+
+        integer :: j
+        real(dp) :: impurity_fraction, radius_fraction
+
+        do j = 1, plasma%grid_size
+            radius_fraction = (plasma%r_grid(j) - plasma%r_grid(1)) / &
+                              (plasma%r_grid(plasma%grid_size) - plasma%r_grid(1))
+            impurity_fraction = 0.010_dp + 0.005_dp*radius_fraction
+            plasma%spec(2)%n(j) = impurity_fraction*plasma%spec(0)%n(j)
+            plasma%spec(1)%n(j) = plasma%spec(0)%n(j) - &
+                                  6.0_dp*plasma%spec(2)%n(j)
+            plasma%spec(1)%T(j) = 700.0_dp + 80.0_dp*radius_fraction
+            plasma%spec(2)%T(j) = 1400.0_dp - 120.0_dp*radius_fraction
+        end do
+    end subroutine set_distinct_two_ion_profiles
+
+    subroutine assert_relative_close(label, actual, expected, tolerance)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected, tolerance
+        real(dp) :: relative_error
+
+        relative_error = abs(actual - expected) / max(abs(expected), tiny(1.0_dp))
+        print *, trim(label), ': true =', expected, ' built =', actual, &
+                 ' rel =', relative_error
+        if (relative_error >= tolerance) then
+            print *, 'FAIL: ', trim(label), ' not preserved in as-is core'
+            error stop
+        end if
+    end subroutine assert_relative_close
 
     real(dp) function rho_L_near(r) result(val)
         !> Return the electron Larmor radius of the global plasma at the grid
@@ -269,11 +489,11 @@ contains
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
-        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' number_of_ion_species = 2'
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
-        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' read_species_from_namelist = .true.'
         write(iunit, '(A)') ' turn_off_ions = .false.'
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
@@ -336,6 +556,10 @@ contains
         write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_species'
+        write(iunit, '(A)') ' ai = 2, 12'
+        write(iunit, '(A)') ' zi = 1, 6'
         write(iunit, '(A)') '/'
         close(iunit)
     end subroutine write_test_namelist

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -25,6 +25,7 @@ program test_periodic_convergence
 
     implicit none
 
+    call test_reference_scale_validation()
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
     call test_M_convergence()
@@ -35,10 +36,48 @@ program test_periodic_convergence
 
 contains
 
+    subroutine test_reference_scale_validation()
+        use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+        use species_m, only: plasma_t
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_NO_ACTIVE, &
+                                               PERIODIC_SCALE_INVALID_RHO
+
+        type(plasma_t) :: test_plasma
+        real(dp) :: rho_ref
+        integer :: sp, reference_species, info
+
+        test_plasma%n_species = 3
+        test_plasma%grid_size = 4
+        allocate(test_plasma%r_grid(4), test_plasma%spec(0:2))
+        test_plasma%r_grid = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        do sp = 0, 2
+            allocate(test_plasma%spec(sp)%rho_L(4))
+            test_plasma%spec(sp)%rho_L = 0.1_dp * real(sp + 1, dp)
+        end do
+
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .false., .false., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_NO_ACTIVE) then
+            print *, 'FAIL: selector did not reject a plasma with no active species'
+            error stop
+        end if
+
+        test_plasma%spec(2)%rho_L(2) = ieee_value(0.0_dp, ieee_quiet_nan)
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .true., .true., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_INVALID_RHO) then
+            print *, 'FAIL: selector accepted a non-finite active-species rho_L'
+            print *, '  info =', info, ' reference species =', reference_species
+            error stop
+        end if
+        print *, 'PASS: reference-scale selector rejects invalid active species'
+    end subroutine test_reference_scale_validation
+
     subroutine test_core_on_fixed_grid()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -79,14 +118,15 @@ contains
         rm = r_res
         print *, 'resonant radius rm = ', rm
 
-        ! Representative electron Larmor radius at rm, via the SAME 4-point
-        ! Lagrange stencil the run-type uses to size its window.
+        ! Reference Larmor radius at rm, selected from the same active species
+        ! set used by the production run type.
         rhoL_rm = interp_rho_L(rm)
         if (.not. (rhoL_rm > 0.0_dp)) then
             print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
             error stop
         end if
-        print *, 'rho_L(rm) [electron] = ', rhoL_rm
+        call assert_convergence_uses_reference_scale(rm, rhoL_rm)
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
@@ -128,6 +168,33 @@ contains
         end if
         print *, 'PASS: dPhi non-zero, max|dPhi| =', maxval(abs(dPhi))
     end subroutine test_core_on_fixed_grid
+
+    subroutine assert_convergence_uses_reference_scale(rm, convergence_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, convergence_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: convergence harness could not select a physical scale'
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(convergence_rho - selected_rho) > tol) then
+            print *, 'FAIL: convergence scans do not use the selected species scale'
+            print *, '  convergence rho_L =', convergence_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_convergence_uses_reference_scale
 
     !> Phase-3 Task 2: r_g QUADRATURE convergence of the periodic solver.
     !>
@@ -193,7 +260,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED window (M and dx_asis / dx_tr do NOT change with n_rg): the only
         ! knob refined here is the r_g quadrature node count.
@@ -272,16 +339,16 @@ contains
     !> Phase-3 Task 3: FOURIER BASIS truncation convergence of the periodic
     !> solver.
     !>
-    !> With the r_g quadrature (n_rg = 192, converged in P3.2) and the window
+    !> With the r_g quadrature (n_rg = 512, converged in P3.2) and the window
     !> (dx_asis, dx_tr) FIXED, refine only the number of Fourier modes M (the
     !> basis has 2M+1 modes) and reconstruct delta-Phi on a FIXED diagnostic
     !> grid. The localized solution's Fourier coefficients decay for
     !> |k_m| >> 1/rho_L, so the Cauchy residual between successive M must fall
-    !> and beat 1e-2 by M ~ 24-32. A failure to converge is a real finding about
+    !> and beat 1e-2 at the finest tested M. A failure to converge is a real finding about
     !> the basis truncation or the k-resolution, not a reason to loosen the
     !> tolerance (bump n_rg first: the exp(i(k_m - k_m')r) quadrature is exact
-    !> for |m - m'| < n_rg by Nyquist, and 2M = 64 < 192, so n_rg = 192 resolves
-    !> M up to 32).
+    !> for |m - m'| < n_rg by Nyquist, and 2M = 256 < 512, so n_rg = 512 resolves
+    !> M up to 128).
     subroutine test_M_convergence()
         use config_m, only: profiles_in_memory, nml_config_path
         use species_m, only: set_profiles_from_arrays
@@ -291,8 +358,8 @@ contains
         use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
 
         integer, parameter :: npts = 201
-        integer, parameter :: n_rg = 192, ndiag = 41, nseq = 4
-        integer, parameter :: M_seq(nseq) = [8, 16, 24, 32]
+        integer, parameter :: n_rg = 512, ndiag = 41, nseq = 5
+        integer, parameter :: M_seq(nseq) = [32, 48, 64, 96, 128]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -337,11 +404,10 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
-        ! FIXED quadrature and window (only M is refined here). n_rg = 192 is the
-        ! P3.2-converged node count; it resolves the k-modes for M up to 32
-        ! (2M = 64 < 192, Nyquist).
+        ! FIXED quadrature and window (only M is refined here). n_rg = 512 is the
+        ! P3.2-converged node count; it resolves the k-modes for M up to 128.
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
         print *, 'FIXED n_rg               = ', n_rg
@@ -372,7 +438,7 @@ contains
             end if
             dphi_k(:, k) = dPhi
         end do
-        print *, 'PASS: all four solves returned info == 0'
+        print *, 'PASS: all Fourier-refinement solves returned info == 0'
 
         ! Cauchy relative residual between successive refinements.
         res_L2  = 0.0_dp
@@ -394,18 +460,21 @@ contains
         print *, '-----------------------------------------------------------'
 
         ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
-        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
+        decreasing = .true.
+        do k = 3, nseq
+            decreasing = decreasing .and. (res_L2(k) < res_L2(k - 1))
+        end do
         if (.not. decreasing) then
             print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> real finding about basis truncation / k-resolution;'
             print *, '      investigate (bump n_rg first), do NOT loosen the'
             print *, '      threshold blindly.'
             error stop 'test_M_convergence: residual not decreasing'
         end if
-        if (.not. (res_L2(4) < 1.0e-2_dp)) then
-            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+        if (.not. (res_L2(nseq) < 1.0e-2_dp)) then
+            print *, 'FAIL: finest res_L2 =', res_L2(nseq), ' not < 1.0e-2'
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> Fourier basis has NOT converged; investigate (bump'
             print *, '      n_rg first), do NOT loosen the threshold blindly.'
             error stop 'test_M_convergence: basis not converged'
@@ -426,12 +495,14 @@ contains
     !>
     !> CRITICAL (design section 4.1): the NUMERICAL resolution is held constant
     !> across the scan so the residual measures PHYSICAL deformation, not
-    !> numerical under-resolution. As dx_asis grows, L = 2*(dx_asis + dx_tr)
-    !> grows, so M and n_rg are SCALED with L:
-    !>   M    = ceiling( (5/rhoL) * L / (2 pi) )  -> fixed k_max = 5/rhoL
-    !>   n_rg = ceiling( 16 * L / rhoL )          -> fixed 16 points per rho_L
-    !> The M formula matches the run-type's own sizing (periodic_kmax_scale = 5),
-    !> and n_rg sits well above the P3.2-converged density.
+    !> numerical under-resolution. Hold dx_tr fixed at 10 rho_L so dx_asis is
+    !> the only physical knob. As dx_asis grows, L = 2*(dx_asis + dx_tr) grows,
+    !> so M and n_rg are SCALED with L:
+    !>   M    = ceiling( (27/rhoL) * L / (2 pi) ) -> fixed converged k_max
+    !>   n_rg = max(ceiling(16 L/rhoL), 4 M)      -> converged quadrature/Nyquist
+    !> The cutoff follows the preceding M scan, where M=128 on the 15-rho_L
+    !> half-window reduced the Cauchy residual below 1e-2. This scan therefore
+    !> measures deformation rather than the known under-resolution at k_max=5/rho_L.
     !>
     !> SOFT GATE (this REPORTS the error bar, it does NOT tightly pass/fail): the
     !> test error-stops ONLY on a genuine defect -- non-finite / all-zero dPhi, a
@@ -500,7 +571,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED diagnostic grid: 41 equidistant points on [rm - 2 rho_L,
         ! rm + 2 rho_L]. The SAME physical grid is used for EVERY dx_asis, so the
@@ -513,16 +584,17 @@ contains
                       + 4.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
         end do
 
-        ! Scan the as-is half-width. Memo ratio dx_tr = 2*dx_asis => L = 6*dx_asis.
-        ! Hold the NUMERICAL resolution constant by scaling M and n_rg with L:
-        ! fixed k_max = 5/rho_L (matches the run-type) and fixed 16 pts / rho_L.
+        ! Scan ONLY the as-is half-width. Keep dx_tr fixed at the run-type's
+        ! configured 10-rho_L transition scale, and hold numerical resolution
+        ! constant by scaling M and n_rg with L. The fixed k_max = 27/rho_L is
+        ! justified by test_M_convergence above.
         do k = 1, nseq
             dx_asis = dx_asis_scale(k) * rhoL_rm
-            dx_tr   = 2.0_dp * dx_asis
+            dx_tr   = 10.0_dp * rhoL_rm
             L       = 2.0_dp * (dx_asis + dx_tr)
-            k_max   = 5.0_dp / rhoL_rm
+            k_max   = 27.0_dp / rhoL_rm
             M_seq(k)    = ceiling(k_max * L / (2.0_dp * pi))
-            n_rg_seq(k) = ceiling(16.0_dp * L / rhoL_rm)
+            n_rg_seq(k) = max(ceiling(16.0_dp * L / rhoL_rm), 4 * M_seq(k))
 
             print '(A,F6.1,A,ES14.6,A,I5,A,I6)', &
                 '   dx_asis = ', dx_asis_scale(k), ' rho_L  (=', dx_asis, &
@@ -620,25 +692,22 @@ contains
         print *, '=== test_dr_deformation_scan PASSED ==='
     end subroutine test_dr_deformation_scan
 
-    !> 4-point Lagrange interpolation of the global electron Larmor radius
-    !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.
+    !> Active-species reference scale selected by the production run type.
     real(dp) function interp_rho_L(x) result(rhoLx)
+        use config_m, only: turn_off_electrons, turn_off_ions
         use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
         real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
+        integer :: reference_species, info
 
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr/2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
+        call select_periodic_reference_scale(plasma, x, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoLx, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select convergence reference scale, info =', info
+            error stop
         end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
     end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_periodic_vs_global.f90
+++ b/KIM/tests/test_periodic_vs_global.f90
@@ -47,6 +47,7 @@ program test_periodic_vs_global
 
     call run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                     r_global, phi_global, rm, rhoL_rm)
+    call assert_diagnostic_uses_reference_scale(rm, rhoL_rm)
     call run_periodic(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                       r_periodic, phi_periodic)
 
@@ -58,18 +59,48 @@ program test_periodic_vs_global
 
 contains
 
+    subroutine assert_diagnostic_uses_reference_scale(rm, diagnostic_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, diagnostic_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select the physical diagnostic scale, info =', info
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(diagnostic_rho - selected_rho) > tol) then
+            print *, 'FAIL: cross-check interval does not use the selected species scale'
+            print *, '  diagnostic rho_L =', diagnostic_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_diagnostic_uses_reference_scale
+
     subroutine run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                           r_out, phi_out, rm, rhoL_rm)
         ! Global electrostatic (FokkerPlanck, hat-basis) run. Captures deep
         ! copies of EBdat%Phi and EBdat%r_grid (the FIELD grid xl_grid%xb), and
         ! reads rm = r_res and rho_L(rm) off the GLOBAL plasma so the periodic
         ! run can be compared on the same resonant layer.
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            turn_off_electrons, turn_off_ions
+        use species_m, only: plasma, set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
 
         real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -78,7 +109,7 @@ contains
         real(dp), intent(out) :: rm, rhoL_rm
 
         class(kim_t), allocatable :: kim_g
-        integer :: N
+        integer :: N, reference_species, scale_info
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                 q_prof, Er_prof)
@@ -103,9 +134,11 @@ contains
             print *, 'FAIL: global run -- resonance not found, r_res = ', rm
             error stop
         end if
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, 'FAIL: global run -- rho_L(rm) not positive, = ', rhoL_rm
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, scale_info)
+        if (scale_info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: global run -- invalid reference rho_L, info = ', scale_info
             error stop
         end if
 
@@ -132,7 +165,8 @@ contains
 
         print *, 'GLOBAL: max|Phi| = ', maxval(abs(phi_out)), &
                  ' on r in [', r_out(1), ',', r_out(N), '], N = ', N
-        print *, 'GLOBAL: rm = ', rm, ' rho_L(rm) = ', rhoL_rm
+        print *, 'GLOBAL: rm = ', rm, ' reference species = ', reference_species, &
+                 ' rho_L(rm) = ', rhoL_rm
 
         ! The global potential is expected to be finite; whether it is non-zero
         ! is a FINDING reported by cross_check (on this coarse in-memory
@@ -288,6 +322,9 @@ contains
                                 sqrt(sum(abs(pg_dc)**2)))
         rel_max_dc = safe_ratio(maxval(abs(diff_dc)), maxval(abs(pg_dc)))
 
+        call write_curve_data('periodic_vs_global_curve.dat', r_c(1:nc), &
+                              pg_c(1:nc), pp_c(1:nc), pg_dc, pp_dc)
+
         ! Soft gate: bail only on non-finite results, never on a large finite one.
         if (.not. ieee_is_finite(rel_L2) .or. .not. ieee_is_finite(rel_max) .or. &
             .not. ieee_is_finite(rel_L2_dc) .or. &
@@ -346,6 +383,29 @@ contains
         end if
         print *, ''
     end subroutine cross_check
+
+    subroutine write_curve_data(path, r, phi_global, phi_periodic, &
+                                phi_global_dc, phi_periodic_dc)
+        character(len=*), intent(in) :: path
+        real(dp), intent(in) :: r(:)
+        complex(dp), intent(in) :: phi_global(:), phi_periodic(:)
+        complex(dp), intent(in) :: phi_global_dc(:), phi_periodic_dc(:)
+        integer :: i, io_unit
+
+        open(newunit=io_unit, file=path, status='replace', action='write')
+        write(io_unit, '(A)') &
+            '# r_cm global_re global_im periodic_re periodic_im ' // &
+            'global_dc_re global_dc_im periodic_dc_re periodic_dc_im'
+        do i = 1, size(r)
+            write(io_unit, '(9(ES24.16,1X))') r(i), &
+                real(phi_global(i), dp), aimag(phi_global(i)), &
+                real(phi_periodic(i), dp), aimag(phi_periodic(i)), &
+                real(phi_global_dc(i), dp), aimag(phi_global_dc(i)), &
+                real(phi_periodic_dc(i), dp), aimag(phi_periodic_dc(i))
+        end do
+        close(io_unit)
+        print *, '  curve data                  = ', path
+    end subroutine write_curve_data
 
     real(dp) function safe_ratio(num, den) result(ratio)
         ! num/den, guarding against a zero (or tiny) denominator so an all-zero
@@ -420,28 +480,6 @@ contains
             end if
         end do
     end subroutine assert_finite
-
-    real(dp) function interp_rho_L(x) result(rhoLx)
-        ! 4-point Lagrange interpolation of the global electron Larmor radius
-        ! plasma%spec(0)%rho_L at radius x -- same stencil as the periodic
-        ! run-type uses to size its window, so rm/Delta match the solver.
-        use species_m, only: plasma
-        real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
-
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr / 2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
-        end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-    end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)


### PR DESCRIPTION
## Summary

- periodize every active species without overwriting ion state with electron profiles
- preserve true-background caches across repeated convergence solves
- add multispecies identity, transition, periodicity, and cache-invalidation tests

## Why

Periodic FP kernels receive species-correct density, temperature, collision, and derived background data.

## Validation

Validated cumulatively at the stack head:

- `cmake --build build -j2`
- `ctest --test-dir build -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global' --output-on-failure` — 35/35 passed

Known red gates are intentionally excluded from that command: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation acceptance gate, and the unresolved periodic-vs-global 5% agreement gate.

## Stack

Base: `fix/kim-fp-01-ion-scale-window`
Head: `fix/kim-fp-02-multispecies-background`

Closes #186

