### PR TITLE
fix(kim): align collisionless ion response with FP

### DIFF
--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -88,6 +88,17 @@ module species_m
 
     contains
 
+    pure function scale_fp_collision_frequency(nu, species_index, ion_scale) result(scaled_nu)
+
+        real(dp), intent(in) :: nu, ion_scale
+        integer, intent(in) :: species_index
+        real(dp) :: scaled_nu
+
+        scaled_nu = nu
+        if (species_index > 0) scaled_nu = ion_scale * nu
+
+    end function scale_fp_collision_frequency
+
     subroutine init_plasma(plasma_in)
 
         use config_m, only: read_species_from_namelist, plasma_type
@@ -451,7 +462,8 @@ module species_m
 
         use constants_m, only: sol, e_charge, ev, pi, com_unit
         use setup_m, only: omega, collisions_off
-        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, ion_flr_scale_factor
+        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, &
+            ion_flr_scale_factor, ion_fp_collision_scale
 
         implicit none
 
@@ -528,7 +540,8 @@ module species_m
 
         do sp = 1, plasma_in%n_species-1
             do i = 1, plasma_in%grid_size
-                plasma_in%spec(sp)%nu(i) = nui(sp, i)
+                plasma_in%spec(sp)%nu(i) = scale_fp_collision_frequency(&
+                    nui(sp, i), sp, ion_fp_collision_scale)
             end do
         end do
 

--- a/KIM/src/electrostatic_poisson/poisson.f90
+++ b/KIM/src/electrostatic_poisson/poisson.f90
@@ -49,7 +49,8 @@ module rt_electrostatic_m
 
     subroutine run_electrostatic(this)
 
-        use kernel_m, only: Krook_fill_kernel_phi, FP_fill_kernels, fill_kernels_krook_fp, kernel_spl_t
+        use kernel_m, only: Krook_fill_kernel_phi, FP_fill_kernels, fill_kernels_krook_fp, &
+                            assemble_configured_fp_charge, kernel_spl_t
         use kernel_adaptive_m, only: FP_fill_kernels_adaptive
         use grid_m, only: xl_grid
         use IO_collection_m, only: write_matrix, write_complex_profile, write_complex_profile_abs
@@ -133,7 +134,7 @@ module rt_electrostatic_m
             use species_m, only: plasma
             use flr2_asymptotics_m, only: calc_flr2_asymptotic_Phi_MA, calc_hatK_Phi_in_Fourier
             use kernel_m, only: write_kernels
-            use config_m, only: turn_off_electrons, turn_off_ions
+            use config_m, only: turn_off_electrons, turn_off_ions, ion_collision_model
 
             implicit none
 
@@ -149,6 +150,15 @@ module rt_electrostatic_m
                 case default
                     stop "Error: theta integration method not recognized."
             end select
+
+            call assemble_configured_fp_charge(kernel_rho_phi_llp, kernel_rho_B_llp)
+
+            if (trim(ion_collision_model) == 'collisionless') then
+                kernel_j_phi_llp%Kllp_i = (0.0_dp, 0.0_dp)
+                kernel_j_B_llp%Kllp_i = (0.0_dp, 0.0_dp)
+                kernel_j_phi_llp%Kllp = kernel_j_phi_llp%Kllp_e
+                kernel_j_B_llp%Kllp = kernel_j_B_llp%Kllp_e
+            end if
 
             call write_kernels(kernel_rho_phi_llp, kernel_rho_B_llp, kernel_j_phi_llp, kernel_j_B_llp)
 
@@ -171,8 +181,13 @@ module rt_electrostatic_m
             call write_complex_profile_abs(xl_grid%xb, EBdat%Phi, xl_grid%npts_b, "/fields/Phi_m", &
                 'Electrostatic potential perturbation Phi, solution of Poisson problem', 'statV')
             call calculate_current_density(jpar, EBdat%Phi, EBdat%Br, kernel_j_phi_llp%Kllp, kernel_j_B_llp%Kllp)
-            call write_complex_profile_abs(xl_grid%xb, jpar, xl_grid%npts_b, "/fields/jpar", &
-                'Parallel current density perturbation j_par calculated from Poisson solution', 'statA/cm^2')
+            if (trim(ion_collision_model) == 'collisionless') then
+                call write_complex_profile_abs(xl_grid%xb, jpar, xl_grid%npts_b, "/fields/jpar", &
+                    'Electron parallel current density; collisionless ion current is not modelled', 'statA/cm^2')
+            else
+                call write_complex_profile_abs(xl_grid%xb, jpar, xl_grid%npts_b, "/fields/jpar", &
+                    'Parallel current density perturbation j_par calculated from Poisson solution', 'statA/cm^2')
+            end if
 
             ! solve for electrons only, but use total phi in jpar calculation
             if (.not.turn_off_electrons) then

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -133,6 +133,13 @@ contains
         end if
         call print_config_line('Plasma Type', trim(plasma_type), width)
         call print_config_line('Collision Model', trim(collision_model), width)
+        call print_config_line('Ion Collision Model', trim(ion_collision_model), width)
+        write(value_str, '(ES12.4)') ion_fp_collision_scale
+        call print_config_line('Ion FP nu scale', trim(adjustl(value_str)), width)
+        if (trim(ion_collision_model) == 'collisionless') then
+            write(value_str, '(ES12.4,A)') collisionless_kpar_epsilon, ' 1/cm'
+            call print_config_line('Collisionless kpar eps', trim(adjustl(value_str)), width)
+        end if
         call print_bool_line('Collisions', .not. collisions_off, width)
         write(value_str, '(I0)') artificial_debye_case
         call print_config_line('Artificial Debye Case', trim(adjustl(value_str)), width)

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -17,6 +17,7 @@ subroutine kim_read_config
 
     namelist /KIM_CONFIG/ number_of_ion_species, artificial_debye_case, &
                         type_of_run, collision_model, read_species_from_namelist, &
+                        ion_collision_model, collisionless_kpar_epsilon, ion_fp_collision_scale, &
                         turn_off_ions, turn_off_electrons, plasma_type, rescale_density, &
                         number_density_rescale, ion_flr_scale_factor, &
                         boole_energy_conservation
@@ -103,6 +104,27 @@ subroutine kim_read_config
         write(*,*) 'Please set collisions_off to false or change collision_model.'
         stop
     end if
+
+    if (ion_fp_collision_scale <= 0.0_dp) then
+        error stop 'ion_fp_collision_scale must be > 0 for FP collision kernels'
+    end if
+
+    select case (trim(ion_collision_model))
+    case ('FokkerPlanck')
+        continue
+    case ('collisionless')
+        if (trim(collision_model) /= 'FokkerPlanck') then
+            error stop 'ion_collision_model=collisionless requires collision_model=FokkerPlanck'
+        end if
+        if (trim(theta_integration) /= 'GaussLegendre') then
+            error stop 'ion_collision_model=collisionless currently requires GaussLegendre integration'
+        end if
+        if (collisionless_kpar_epsilon <= 0.0_dp) then
+            error stop 'ion_collision_model=collisionless requires collisionless_kpar_epsilon > 0 [1/cm]'
+        end if
+    case default
+        error stop 'ion_collision_model must be FokkerPlanck or collisionless'
+    end select
 
     write(output_path, '(A,A,I0,A,I0,A)') trim(output_path), '/m', m_mode, '_n', n_mode, '/'
     inquire(file=trim(output_path), exist=ex)

--- a/KIM/src/kernels/Krook_kernel_plasma_prefacs.f90
+++ b/KIM/src/kernels/Krook_kernel_plasma_prefacs.f90
@@ -2,6 +2,86 @@ module Krook_kernel_plasma_prefacs_m
 
     contains
 
+    pure function Krook_collisionless_kpar(kpar, epsilon) result(val)
+
+        use KIM_kinds_m, only: dp
+
+        implicit none
+
+        real(dp), intent(in) :: kpar, epsilon
+        complex(dp) :: val
+
+        val = cmplx(kpar, epsilon, dp)
+
+    end function Krook_collisionless_kpar
+
+    pure function Krook_collisionless_kpar_magnitude(kpar, epsilon) result(val)
+
+        use KIM_kinds_m, only: dp
+
+        implicit none
+
+        real(dp), intent(in) :: kpar, epsilon
+        real(dp) :: val
+
+        ! Broaden analytical |k_parallel| terms without turning them into
+        ! signed poles.  In particular, a complex z0 in the lower half-plane
+        ! makes the analytic continuation of plasma_Z grow exponentially.
+        val = sqrt(kpar**2 + epsilon**2)
+
+    end function Krook_collisionless_kpar_magnitude
+
+    pure function Krook_collisionless_z0(om_E, omega, kpar, vT, epsilon) result(val)
+
+        use KIM_kinds_m, only: dp
+
+        implicit none
+
+        real(dp), intent(in) :: om_E, omega, kpar, vT
+        real(dp), intent(in), optional :: epsilon
+        complex(dp) :: val
+
+        if (present(epsilon)) then
+            val = cmplx(-(om_E - omega) / (&
+                Krook_collisionless_kpar_magnitude(kpar, epsilon) * sqrt(2.0_dp) * vT), 0.0_dp, dp)
+        else
+            val = cmplx(-(om_E - omega) / (abs(kpar) * sqrt(2.0_dp) * vT), 0.0_dp, dp)
+        end if
+
+    end function Krook_collisionless_z0
+
+    function Krook_z0_cc(j, spec, collisionless, epsilon) result(val)
+
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma, species_t
+        use setup_m, only: omega
+
+        implicit none
+
+        integer, intent(in) :: j
+        type(species_t), intent(in) :: spec
+        logical, intent(in) :: collisionless
+        real(dp), intent(in), optional :: epsilon
+        complex(dp) :: val
+        real(dp) :: kpar_cc, om_E_cc, vT_cc
+
+        if (collisionless) then
+            if (.not. present(epsilon)) then
+                error stop 'Collisionless Krook z0 requires a causal-pole epsilon'
+            end if
+            kpar_cc = 0.5_dp * (plasma%kp(j) + plasma%kp(j+1))
+            om_E_cc = 0.5_dp * (plasma%om_E(j) + plasma%om_E(j+1))
+            vT_cc = 0.5_dp * (spec%vT(j) + spec%vT(j+1))
+            if (vT_cc == 0.0_dp) then
+                error stop 'Cannot form collisionless Krook z0 at vT = 0'
+            end if
+            val = Krook_collisionless_z0(om_E_cc, omega, kpar_cc, vT_cc, epsilon)
+        else
+            val = 0.5_dp * (spec%z0(j) + spec%z0(j+1))
+        end if
+
+    end function Krook_z0_cc
+
     function Krook_kappa_rho_phi(j, spec) result(val)
 
         use species_m, only: species_t
@@ -19,7 +99,7 @@ module Krook_kernel_plasma_prefacs_m
 
     end function
 
-    function Krook_kappa_rho_B(j, spec) result(val)
+    function Krook_kappa_rho_B(j, spec, collisionless, epsilon) result(val)
 
         use species_m, only: plasma, species_t
         use KIM_kinds_m, only: dp
@@ -29,12 +109,29 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
+        complex(dp) :: kpar_denom
+        real(dp) :: kpar_cc
+        logical :: use_collisionless
+
+        kpar_cc = 0.5d0 * (plasma%kp(j) + plasma%kp(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless kappa_rho_B requires epsilon'
+            ! kappa_rho_B contains a signed 1/k_parallel and therefore uses
+            ! the causal pole rather than the broadened magnitude.
+            kpar_denom = Krook_collisionless_kpar(kpar_cc, epsilon)
+        else
+            kpar_denom = cmplx(kpar_cc, 0.0_dp, dp)
+        end if
 
         val = (0.5d0 * (spec%vT(j) + spec%vT(j+1)))**2.0d0 * com_unit &
             / (0.5d0 * (spec%lambda_D(j) + spec%lambda_D(j+1)))**2.0d0 &
             / (0.5d0 * (spec%omega_c(j) + spec%omega_c(j+1))) &
-            / (0.5d0 * (plasma%kp(j) + plasma%kp(j+1))) &
+            / kpar_denom &
             / sol
 
     end function
@@ -56,7 +153,7 @@ module Krook_kernel_plasma_prefacs_m
 
     end function
 
-    function Krook_G1_rho_phi(j, spec) result(val)
+    function Krook_G1_rho_phi(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t, plasma
@@ -65,25 +162,37 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
         real(dp) :: ks_val, kpar, A1, A2, rhoT
-        complex(dp) :: plasma_Z, z0
+        complex(dp) :: plasma_Z, z0, kpar_denom
+        logical :: use_collisionless
 
         ks_val = 0.5d0 * (plasma%ks(j) + plasma%ks(j+1))
         kpar = 0.5d0 * (plasma%kp(j) + plasma%kp(j+1))
         A1 = 0.5d0 * (spec%A1(j) + spec%A1(j+1))
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
-        z0 = 0.5d0 * (spec%z0(j) + spec%z0(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G1_rho_phi requires epsilon'
+            kpar_denom = cmplx(Krook_collisionless_kpar_magnitude(kpar, epsilon), 0.0_dp, dp)
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+        else
+            kpar_denom = cmplx(abs(kpar), 0.0_dp, dp)
+            z0 = Krook_z0_cc(j, spec, .false.)
+        end if
         rhoT = 0.5d0 * (spec%rho_L(j) + spec%rho_L(j+1))
 
-        val = ks_val * rhoT /(abs(kpar) * sqrt(2.0d0)) &
+        val = ks_val * rhoT /(kpar_denom * sqrt(2.0d0)) &
             * (&
                 A1 * plasma_Z(z0) + A2 * plasma_Z(z0) * (1.0d0 + z0**2.0d0) + z0 * A2 &
             )
 
     end function
 
-    function Krook_G2_rho_phi(j, spec) result(val)
+    function Krook_G2_rho_phi(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t, plasma
@@ -92,21 +201,33 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
         real(dp) :: ks_val, kpar, A2, rhoT
-        complex(dp) :: plasma_Z, z0
+        complex(dp) :: plasma_Z, z0, kpar_denom
+        logical :: use_collisionless
 
         ks_val = 0.5d0 * (plasma%ks(j) + plasma%ks(j+1))
         kpar = 0.5d0 * (plasma%kp(j) + plasma%kp(j+1))
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
         rhoT = 0.5d0 * (spec%rho_L(j) + spec%rho_L(j+1))
-        z0 = 0.5d0 * (spec%z0(j) + spec%z0(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G2_rho_phi requires epsilon'
+            kpar_denom = cmplx(Krook_collisionless_kpar_magnitude(kpar, epsilon), 0.0_dp, dp)
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+        else
+            kpar_denom = cmplx(abs(kpar), 0.0_dp, dp)
+            z0 = Krook_z0_cc(j, spec, .false.)
+        end if
 
-        val = - ks_val * rhoT * A2 * plasma_Z(z0) / (abs(kpar) * sqrt(2.0d0))
+        val = - ks_val * rhoT * A2 * plasma_Z(z0) / (kpar_denom * sqrt(2.0d0))
 
     end function
 
-    function Krook_G3_rho_phi(j, spec) result(val)
+    function Krook_G3_rho_phi(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t, plasma
@@ -115,15 +236,30 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
         real(dp) :: ks_val, kpar, A2, rhoT
+        complex(dp) :: kpar_denom, plasma_Z, response, z0
+        logical :: use_collisionless
 
         ks_val = 0.5d0 * (plasma%ks(j) + plasma%ks(j+1))
         kpar = 0.5d0 * (plasma%kp(j) + plasma%kp(j+1))
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
         rhoT = 0.5d0 * (spec%rho_L(j) + spec%rho_L(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        response = cmplx(1.0_dp, 0.0_dp, dp)
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G3_rho_phi requires epsilon'
+            kpar_denom = cmplx(Krook_collisionless_kpar_magnitude(kpar, epsilon), 0.0_dp, dp)
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+            response = plasma_Z(z0)
+        else
+            kpar_denom = cmplx(abs(kpar), 0.0_dp, dp)
+        end if
 
-        val = ks_val * rhoT /(abs(kpar) * sqrt(2.0d0)) * A2
+        val = ks_val * rhoT /(kpar_denom * sqrt(2.0d0)) * A2 * response
 
     end function
 
@@ -143,7 +279,7 @@ module Krook_kernel_plasma_prefacs_m
 
     end function
 
-    function Krook_G1_rho_B(j, spec) result(val)
+    function Krook_G1_rho_B(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t
@@ -152,22 +288,34 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
-        real(dp) :: A1, A2
+        real(dp) :: A1, A1_factor, A2
         complex(dp) :: plasma_Z, z0
+        logical :: use_collisionless
 
         A1 = 0.5d0 * (spec%A1(j) + spec%A1(j+1))
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
-        z0 = 0.5d0 * (spec%z0(j) + spec%z0(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        A1_factor = 0.5_dp
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G1_rho_B requires epsilon'
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+            A1_factor = 1.0_dp
+        else
+            z0 = Krook_z0_cc(j, spec, .false.)
+        end if
 
-        val = 0.5d0 * A1 * (z0 * plasma_Z(z0) + 1.0d0) + A2 * &
+        val = A1_factor * A1 * (z0 * plasma_Z(z0) + 1.0d0) + A2 * &
             (&
                 0.5d0 + (z0 * plasma_Z(z0) + 1.0d0) * (1.0d0 + z0**2.0d0) &
             )
 
     end function
 
-    function Krook_G2_rho_B(j, spec) result(val)
+    function Krook_G2_rho_B(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t
@@ -176,18 +324,28 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t),intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
         real(dp) :: A2
         complex(dp) :: plasma_Z, z0
+        logical :: use_collisionless
 
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
-        z0 = 0.5d0 * (spec%z0(j) + spec%z0(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G2_rho_B requires epsilon'
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+        else
+            z0 = Krook_z0_cc(j, spec, .false.)
+        end if
 
         val = - A2 * (z0 * plasma_Z(z0) + 1.0d0)
 
     end function
 
-    function Krook_G3_rho_B(j, spec) result(val)
+    function Krook_G3_rho_B(j, spec, collisionless, epsilon) result(val)
 
         use KIM_kinds_m, only: dp
         use species_m, only: species_t
@@ -196,9 +354,23 @@ module Krook_kernel_plasma_prefacs_m
 
         integer, intent(in) :: j
         type(species_t), intent(in) :: spec
+        logical, intent(in), optional :: collisionless
+        real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
+        real(dp) :: A2
+        complex(dp) :: plasma_Z, z0
+        logical :: use_collisionless
 
-        val = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
+        A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
+        use_collisionless = .false.
+        if (present(collisionless)) use_collisionless = collisionless
+        if (use_collisionless) then
+            if (.not. present(epsilon)) error stop 'Collisionless G3_rho_B requires epsilon'
+            z0 = Krook_z0_cc(j, spec, .true., epsilon)
+            val = A2 * (z0 * plasma_Z(z0) + 1.0_dp)
+        else
+            val = cmplx(A2, 0.0_dp, dp)
+        end if
 
     end function
 

--- a/KIM/src/kernels/kernel.f90
+++ b/KIM/src/kernels/kernel.f90
@@ -70,6 +70,31 @@ module kernel_m
 
     end subroutine init_kernel
 
+    function larmor_taper_band_limit() result(dmax_global)
+
+        use grid_m, only: Larmor_skip_factor, kernel_taper_skip_threshold
+        use species_m, only: plasma
+
+        implicit none
+
+        real(dp) :: dmax_global
+        real(dp) :: alpha, rhoT_max, tau
+        integer :: sigma
+
+        alpha = Larmor_skip_factor
+        tau = max(kernel_taper_skip_threshold, 1.0d-12)
+        rhoT_max = 0.0d0
+
+        do sigma = 0, plasma%n_species - 1
+            if (allocated(plasma%spec(sigma)%rho_L_cc)) then
+                rhoT_max = max(rhoT_max, maxval(plasma%spec(sigma)%rho_L_cc))
+            end if
+        end do
+
+        dmax_global = alpha * rhoT_max * sqrt(max(log(1.0d0 / tau), 0.0d0))
+
+    end function larmor_taper_band_limit
+
     subroutine compute_cc_prefactors
 
         use species_m, only: plasma
@@ -266,7 +291,128 @@ module kernel_m
 
     end subroutine
 
-    subroutine Krook_calc_kernel_rho_term_by_term(l, lp, k_rho_phi, k_rho_B, gauss_conf)
+    subroutine Krook_fill_kernel_phi_ions_collisionless(K_rho_phi_llp, K_rho_B_llp)
+
+        use KIM_kinds_m, only: dp
+        use integrals_gauss_m, only: gauss_config_t, init_gauss_int
+        use grid_m, only: gauss_int_nodes_Ntheta, gauss_int_nodes_Nx, gauss_int_nodes_Nxp, xl_grid
+        use species_m, only: plasma
+        use logger_m, only: log_info
+
+        implicit none
+
+        type(kernel_spl_t), intent(inout) :: K_rho_phi_llp
+        type(kernel_spl_t), intent(inout) :: K_rho_B_llp
+        type(gauss_config_t) :: gauss_conf
+        integer :: l, lp, sp
+        complex(dp) :: k_rho_phi, k_rho_B
+        real(dp) :: dmax_global
+
+        gauss_conf%Nx = gauss_int_nodes_Nx
+        gauss_conf%Nxp = gauss_int_nodes_Nxp
+        gauss_conf%Ntheta = gauss_int_nodes_Ntheta
+        call init_gauss_int(gauss_conf)
+
+        dmax_global = larmor_taper_band_limit()
+
+        K_rho_phi_llp%Kllp = (0.0_dp, 0.0_dp)
+        K_rho_B_llp%Kllp = (0.0_dp, 0.0_dp)
+        K_rho_phi_llp%Kllp_i = (0.0_dp, 0.0_dp)
+        K_rho_B_llp%Kllp_i = (0.0_dp, 0.0_dp)
+
+        call log_info('Filling ion-only collisionless Krook kernels...')
+
+        !$omp parallel do private(l,lp,sp,k_rho_phi,k_rho_B)
+        do l = 1, K_rho_phi_llp%npts_l
+            block
+                real(dp) :: xl_val
+                integer :: lp_lo
+
+                xl_val = xl_grid%xb(l)
+                lp_lo = l
+                do
+                    if (lp_lo <= 1) exit
+                    if (abs(xl_grid%xb(lp_lo-1) - xl_val) > dmax_global) exit
+                    lp_lo = lp_lo - 1
+                end do
+
+                ! Match the FP banding rule, including its minimum off-diagonal support.
+                lp_lo = min(lp_lo, l - 1)
+                if (lp_lo < 1) lp_lo = 1
+
+                do lp = max(1, lp_lo), l
+                    do sp = 1, plasma%n_species - 1
+                        call Krook_calc_kernel_rho_term_by_term(l, lp, k_rho_phi, k_rho_B, gauss_conf, &
+                            species_first=sp, species_last=sp, collisionless=.true.)
+                        K_rho_phi_llp%Kllp_i(l, lp, sp) = k_rho_phi
+                        K_rho_B_llp%Kllp_i(l, lp, sp) = k_rho_B
+                        K_rho_phi_llp%Kllp_i(lp, l, sp) = k_rho_phi
+                        K_rho_B_llp%Kllp_i(lp, l, sp) = k_rho_B
+                    end do
+                end do
+            end block
+        end do
+        !$omp end parallel do
+
+        K_rho_phi_llp%Kllp = sum(K_rho_phi_llp%Kllp_i, dim=3)
+        K_rho_B_llp%Kllp = sum(K_rho_B_llp%Kllp_i, dim=3)
+
+        call log_info('Finished ion-only collisionless Krook kernels.')
+
+    end subroutine Krook_fill_kernel_phi_ions_collisionless
+
+    subroutine assemble_fp_electron_collisionless_ion_charge(K_rho_phi_llp, K_rho_B_llp)
+
+        use KIM_kinds_m, only: dp
+
+        implicit none
+
+        type(kernel_spl_t), intent(inout) :: K_rho_phi_llp
+        type(kernel_spl_t), intent(inout) :: K_rho_B_llp
+
+        call Krook_fill_kernel_phi_ions_collisionless(K_rho_phi_llp, K_rho_B_llp)
+
+        K_rho_phi_llp%Kllp = K_rho_phi_llp%Kllp_e + sum(K_rho_phi_llp%Kllp_i, dim=3)
+        K_rho_B_llp%Kllp = K_rho_B_llp%Kllp_e + sum(K_rho_B_llp%Kllp_i, dim=3)
+
+    end subroutine assemble_fp_electron_collisionless_ion_charge
+
+    subroutine assemble_configured_fp_charge(K_rho_phi_llp, K_rho_B_llp)
+
+        use config_m, only: ion_collision_model
+
+        implicit none
+
+        type(kernel_spl_t), intent(inout) :: K_rho_phi_llp
+        type(kernel_spl_t), intent(inout) :: K_rho_B_llp
+
+        select case (trim(ion_collision_model))
+            case ('FokkerPlanck')
+                return
+            case ('collisionless')
+                call assemble_fp_electron_collisionless_ion_charge(K_rho_phi_llp, K_rho_B_llp)
+            case default
+                error stop 'Unsupported ion collision model in FP charge-kernel assembly.'
+        end select
+
+    end subroutine assemble_configured_fp_charge
+
+    subroutine initialize_krook_mphi(int_point)
+
+        use integrands_gauss_m, only: integration_point_t
+
+        implicit none
+
+        type(integration_point_t), intent(inout) :: int_point
+
+        ! The closed-form Krook and collisionless prefactors use the m_phi = 0
+        ! spatial decomposition.  Set it explicitly before evaluating F1-F3.
+        int_point%mphi = 0
+
+    end subroutine initialize_krook_mphi
+
+    subroutine Krook_calc_kernel_rho_term_by_term(l, lp, k_rho_phi, k_rho_B, gauss_conf, &
+                                                   species_first, species_last, collisionless)
 
         use KIM_kinds_m, only: dp
         use integrals_gauss_m, only: gauss_integrate_F0, gauss_integrate_F1, gauss_integrate_F2, gauss_integrate_F3,&
@@ -277,18 +423,20 @@ module kernel_m
             integration_point_t
         use Krook_kernel_plasma_prefacs_m, only: Krook_G0_rho_phi, Krook_G1_rho_phi, Krook_G2_rho_phi, Krook_G3_rho_phi, &
             Krook_G1_rho_B, Krook_G2_rho_B, Krook_G3_rho_B, Krook_kappa_rho_phi, Krook_kappa_rho_B
-        use config_m, only: artificial_debye_case, turn_off_ions
-        use grid_m, only: Larmor_skip_factor
-
+        use config_m, only: artificial_debye_case, turn_off_ions, collisionless_kpar_epsilon
         implicit none
 
         integer, intent(in) :: l, lp
         complex(dp) :: k_rho_phi, k_rho_B
         integer :: j, sigma
         type(gauss_config_t), intent(in) :: gauss_conf
+        integer, intent(in), optional :: species_first, species_last
+        logical, intent(in), optional :: collisionless
         real(dp) :: integral_val
         real(dp) :: current_distance
         integer :: current_idx_distance
+        integer :: first_species, last_species
+        logical :: use_collisionless
 
         type(integration_point_t) :: int_point
         type(gauss_int_F0_rho_phi_t) :: int_F0
@@ -299,16 +447,27 @@ module kernel_m
         k_rho_phi = 0.0d0
         k_rho_B = 0.0d0
 
-        call set_xl_at_edge(l, lp, int_point)
+        first_species = 0
+        last_species = plasma%n_species - 1
+        use_collisionless = .false.
+        if (present(species_first)) first_species = species_first
+        if (present(species_last)) last_species = species_last
+        if (present(collisionless)) use_collisionless = collisionless
+        if (first_species < 0 .or. last_species >= plasma%n_species .or. first_species > last_species) then
+            error stop 'Invalid species range in Krook kernel assembly'
+        end if
 
-        do sigma = 0, plasma%n_species - 1
+        call set_xl_at_edge(l, lp, int_point)
+        call initialize_krook_mphi(int_point)
+
+        do sigma = first_species, last_species
             if (turn_off_ions .and. sigma >= 1) cycle
             do j = 2, size(plasma%r_grid)-1
                 int_point%j = j
                 int_point%rhoT = 0.5d0 * (plasma%spec(sigma)%rho_L(j) + plasma%spec(sigma)%rho_L(j+1))
                 int_F0%int_point = int_point
 
-                if (l == lp) then
+                if (abs(l-lp) <= 1 .and. artificial_debye_case /= 2) then
                     call gauss_integrate_F0(int_F0, int_point%xlm1, int_point%xlp1, integral_val, gauss_conf)
                     k_rho_phi = k_rho_phi &
                                     + integral_val * Krook_G0_rho_phi(j, plasma%spec(sigma)) * Krook_kappa_rho_phi(j, plasma%spec(sigma))
@@ -316,8 +475,6 @@ module kernel_m
 
                 ! Track maximum distances for diagnostics
                 current_distance = abs(int_point%xl - int_point%xlp)
-
-                if (current_distance > Larmor_skip_factor * int_point%rhoT) cycle
 
                 current_idx_distance = abs(l - lp)
 
@@ -350,16 +507,25 @@ module kernel_m
                     int_F3%int_point = int_point
 
                     call gauss_integrate_F1(int_F1, integral_val, gauss_conf)
-                    k_rho_phi = k_rho_phi + integral_val * Krook_G1_rho_phi(j, plasma%spec(sigma)) * Krook_kappa_rho_phi(j, plasma%spec(sigma))
-                    k_rho_B = k_rho_B + integral_val * Krook_G1_rho_B(j, plasma%spec(sigma)) * Krook_kappa_rho_B(j, plasma%spec(sigma))
+                    k_rho_phi = k_rho_phi + integral_val * Krook_G1_rho_phi(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon) * Krook_kappa_rho_phi(j, plasma%spec(sigma))
+                    k_rho_B = k_rho_B + integral_val * Krook_G1_rho_B(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon)
 
                     call gauss_integrate_F2(int_F2, integral_val, gauss_conf)
-                    k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * Krook_G2_rho_phi(j, plasma%spec(sigma))
-                    k_rho_B = k_rho_B + integral_val * Krook_G2_rho_B(j, plasma%spec(sigma)) * Krook_kappa_rho_B(j, plasma%spec(sigma))
+                    k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * &
+                        Krook_G2_rho_phi(j, plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    k_rho_B = k_rho_B + integral_val * Krook_G2_rho_B(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon)
 
                     call gauss_integrate_F3(int_F3, integral_val, gauss_conf)
-                    k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * Krook_G3_rho_phi(j, plasma%spec(sigma))
-                    k_rho_B = k_rho_B + integral_val * Krook_G3_rho_B(j, plasma%spec(sigma)) * Krook_kappa_rho_B(j, plasma%spec(sigma))
+                    k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * &
+                        Krook_G3_rho_phi(j, plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    k_rho_B = k_rho_B + integral_val * Krook_G3_rho_B(j, plasma%spec(sigma), &
+                        use_collisionless, collisionless_kpar_epsilon) * &
+                        Krook_kappa_rho_B(j, plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
                 end if
 
             end do
@@ -375,8 +541,7 @@ module kernel_m
 
         use KIM_kinds_m, only: dp
         use integrals_gauss_m, only: gauss_config_t, init_gauss_int
-        use grid_m, only: Larmor_skip_factor, gauss_int_nodes_Ntheta, gauss_int_nodes_Nx, gauss_int_nodes_Nxp, &
-                        kernel_taper_skip_threshold, rg_grid, xl_grid
+        use grid_m, only: gauss_int_nodes_Ntheta, gauss_int_nodes_Nx, gauss_int_nodes_Nxp, rg_grid, xl_grid
         use species_m, only: plasma
         use config_m, only: output_path, artificial_debye_case, turn_off_ions, &
                             turn_off_electrons
@@ -390,8 +555,7 @@ module kernel_m
         type(kernel_spl_t), intent(inout) :: K_j_B_llp
         type(gauss_config_t) :: gauss_conf
         integer :: l, lp, sp
-        real(dp) :: dmax_global, alpha, tau
-        integer :: sigma
+        real(dp) :: dmax_global
         integer :: total_iterations, current_iteration
         integer(kind=8) :: start_count, count_rate, count_max
         character(len=100) :: kbuf
@@ -409,22 +573,7 @@ module kernel_m
         if (.not. pref_ready) call compute_cc_prefactors
 
         ! Compute a global band-limit distance dmax using Larmor taper and skip threshold
-        alpha = Larmor_skip_factor
-        tau   = max(kernel_taper_skip_threshold, 1.0d-12)
-        block
-            real(dp) :: rhoT_max
-            rhoT_max = 0.0d0
-            do sigma = 0, plasma%n_species - 1
-                if (allocated(plasma%spec(sigma)%rho_L_cc)) then
-                    rhoT_max = max(rhoT_max, maxval(plasma%spec(sigma)%rho_L_cc))
-                end if
-            end do
-            ! BUGFIX 2026-06-16: restore the Larmor-taper band-limit distance. The
-            ! line `dmax_global = tau * rhoT_max` (committed 2026-01-29) made dmax_global
-            ! ~ 1e-6*rho ~ 2e-7 cm (<< grid dr), collapsing the kernel band to diagonal+1
-            ! and killing the ion FLR off-diagonal coupling.
-            dmax_global = alpha * rhoT_max * sqrt(max(log(1.0d0/tau), 0.0d0))
-        end block
+        dmax_global = larmor_taper_band_limit()
 
         ! Calculate actual number of iterations accounting for band-limiting
         ! Also track maximum and minimum distances for diagnostics

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -9,6 +9,9 @@ module config_m
     logical :: read_species_from_namelist ! read species from namelist or use deuterium plasma
     character(100) :: type_of_run
     character(100) :: collision_model ! type of collision model
+    character(20) :: ion_collision_model = 'FokkerPlanck' ! FokkerPlanck or collisionless Krook/Hamiltonian
+    real(dp) :: collisionless_kpar_epsilon = -1.0_dp ! causal +i epsilon pole [1/cm]; required for collisionless ions
+    real(dp) :: ion_fp_collision_scale = 1.0_dp ! multiplier applied only to computed FP ion collision frequencies
     integer :: artificial_debye_case
     logical :: turn_off_ions ! if true, only the first species (electrons) is considered in calculations
     logical :: turn_off_electrons

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -81,6 +81,12 @@ module IO_collection_m
             'Type of run: electrostatic, FLR2_benchmark, etc.', 'str')
         call h5_add(h5grpid, 'collision_model', trim(collision_model), &
             'Type of collision model used in the simulation.', 'str')
+        call h5_add(h5grpid, 'ion_collision_model', trim(ion_collision_model), &
+            'Ion collision model: FokkerPlanck or collisionless analytical Krook/Hamiltonian.', 'str')
+        call h5_add(h5grpid, 'collisionless_kpar_epsilon', collisionless_kpar_epsilon, &
+            'Positive imaginary part of the causal collisionless k_parallel pole.', '1/cm')
+        call h5_add(h5grpid, 'ion_fp_collision_scale', ion_fp_collision_scale, &
+            'Multiplier applied only to computed Fokker-Planck ion collision frequencies.', '1')
         call h5_add(h5grpid, 'read_species_from_namelist', read_species_from_namelist, &
             'Logical switch to read species from namelist or use default deuterium plasma.', 'true/false')
         call h5_add(h5grpid, 'turn_off_ions', turn_off_ions, &

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -62,6 +62,23 @@ target_link_libraries(test_kim_diagnostics KIM_lib kilca_lib lapack cerf fortnum
 add_test(NAME test_kim_diagnostics
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_diagnostics.x)
 
+add_executable(test_collisionless_ion_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_collisionless_ion_kernel.f90)
+set_target_properties(test_collisionless_ion_kernel PROPERTIES
+                        OUTPUT_NAME test_collisionless_ion_kernel.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_collisionless_ion_kernel KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_collisionless_ion_kernel
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_collisionless_ion_kernel.x)
+
+add_executable(test_collisionless_ion_assembly ${CMAKE_SOURCE_DIR}/KIM/tests/test_collisionless_ion_assembly.f90)
+set_target_properties(test_collisionless_ion_assembly PROPERTIES
+                        OUTPUT_NAME test_collisionless_ion_assembly.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_collisionless_ion_assembly KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_collisionless_ion_assembly
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_collisionless_ion_assembly.x)
+set_tests_properties(test_collisionless_ion_assembly PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
 add_executable(test_ampere_matrices ${CMAKE_SOURCE_DIR}/KIM/tests/test_ampere_matrices.f90)
 set_target_properties(test_ampere_matrices PROPERTIES
                         OUTPUT_NAME test_ampere_matrices.x

--- a/KIM/tests/test_collisionless_ion_assembly.f90
+++ b/KIM/tests/test_collisionless_ion_assembly.f90
@@ -1,0 +1,250 @@
+program test_collisionless_ion_assembly
+
+    use KIM_kinds_m, only: dp
+    use config_m, only: profiles_in_memory, nml_config_path, ion_collision_model, &
+        collisionless_kpar_epsilon, ion_fp_collision_scale, artificial_debye_case
+    use species_m, only: plasma, scale_fp_collision_frequency, set_profiles_from_arrays
+    use grid_m, only: xl_grid, kernel_taper_skip_threshold
+    use kernel_m, only: kernel_spl_t, FP_fill_kernels, assemble_configured_fp_charge, &
+        Krook_fill_kernel_phi_ions_collisionless, initialize_krook_mphi
+    use integrands_gauss_m, only: integration_point_t
+    use kim_base_m, only: kim_t
+    use kim_mod_m, only: from_kim_factory_get_kim
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+
+    integer, parameter :: npts = 101
+    real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+    real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+    type(kernel_spl_t) :: Kphi, KB, Kjphi, KjB
+    type(integration_point_t) :: krook_point
+    class(kim_t), allocatable :: kim_instance
+    complex(dp), allocatable :: ion_sum(:,:), electron_phi(:,:), electron_B(:,:)
+    complex(dp), allocatable :: wide_band_ion(:,:), narrow_band_ion(:,:)
+    real(dp) :: scale, offdiag_max
+    integer :: i, j, wide_band_entries, narrow_band_entries
+
+    krook_point%mphi = 17
+    call initialize_krook_mphi(krook_point)
+    if (krook_point%mphi /= 0) then
+        print *, 'FAIL: collisionless Krook integration did not select mphi = 0'
+        error stop
+    end if
+
+    if (scale_fp_collision_frequency(12.5_dp, 0, 0.25_dp) /= 12.5_dp) then
+        print *, 'FAIL: FP ion collision scaling changed the electron frequency'
+        error stop
+    end if
+    if (scale_fp_collision_frequency(12.5_dp, 1, 0.25_dp) /= 3.125_dp) then
+        print *, 'FAIL: FP ion collision scaling was not applied to ions'
+        error stop
+    end if
+
+    call make_test_profiles(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof)
+    call write_test_namelist('./KIM_config_collisionless_assembly.nml')
+    nml_config_path = './KIM_config_collisionless_assembly.nml'
+    profiles_in_memory = .true.
+    call kim_init()
+    if (trim(ion_collision_model) /= 'collisionless') then
+        print *, 'FAIL: ion_collision_model was not read from KIM_CONFIG'
+        error stop
+    end if
+    if (abs(collisionless_kpar_epsilon - 1.0e-5_dp) > 1.0e-15_dp) then
+        print *, 'FAIL: collisionless_kpar_epsilon was not read from KIM_CONFIG'
+        error stop
+    end if
+    if (abs(ion_fp_collision_scale - 0.25_dp) > 1.0e-15_dp) then
+        print *, 'FAIL: ion_fp_collision_scale was not read from KIM_CONFIG'
+        error stop
+    end if
+    call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, npts)
+    call from_kim_factory_get_kim('electrostatic', kim_instance)
+    call kim_instance%init()
+
+    call Kphi%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
+    call KB%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
+    call Kjphi%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
+    call KjB%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
+
+    artificial_debye_case = 1
+    call Krook_fill_kernel_phi_ions_collisionless(Kphi, KB)
+    offdiag_max = 0.0_dp
+    do i = 2, size(Kphi%Kllp_i, 1)
+        offdiag_max = max(offdiag_max, abs(Kphi%Kllp_i(i, i-1, 1)))
+    end do
+    if (offdiag_max <= 0.0_dp) then
+        print *, 'FAIL: collisionless F0 term omits adjacent overlapping basis functions'
+        error stop
+    end if
+    artificial_debye_case = 0
+
+    call FP_fill_kernels(Kphi, KB, Kjphi, KjB)
+    electron_phi = Kphi%Kllp_e
+    electron_B = KB%Kllp_e
+    call assemble_configured_fp_charge(Kphi, KB)
+
+    if (maxval(abs(Kphi%Kllp_e - electron_phi)) > 0.0_dp .or. &
+        maxval(abs(KB%Kllp_e - electron_B)) > 0.0_dp) then
+        print *, 'FAIL: hybrid fill modified FP electron matrices'
+        error stop
+    end if
+
+    do i = 1, size(Kphi%Kllp, 1)
+        do j = 1, size(Kphi%Kllp, 2)
+            if (.not. ieee_is_finite(real(Kphi%Kllp(i,j), dp)) .or. &
+                .not. ieee_is_finite(aimag(Kphi%Kllp(i,j))) .or. &
+                .not. ieee_is_finite(real(KB%Kllp(i,j), dp)) .or. &
+                .not. ieee_is_finite(aimag(KB%Kllp(i,j)))) then
+                print *, 'FAIL: non-finite collisionless ion kernel at ', i, j
+                error stop
+            end if
+        end do
+    end do
+
+    scale = max(1.0_dp, maxval(abs(Kphi%Kllp)))
+    if (maxval(abs(Kphi%Kllp)) <= 0.0_dp) then
+        print *, 'FAIL: collisionless ion rho-Phi matrix is identically zero'
+        error stop
+    end if
+    if (maxval(abs(Kphi%Kllp - transpose(Kphi%Kllp))) > 1.0e-12_dp * scale) then
+        print *, 'FAIL: collisionless ion rho-Phi matrix is not symmetric'
+        error stop
+    end if
+
+    ion_sum = sum(Kphi%Kllp_i, dim=3)
+    if (maxval(abs(Kphi%Kllp - electron_phi - ion_sum)) > 1.0e-12_dp * scale) then
+        print *, 'FAIL: hybrid total differs from FP-electron plus collisionless-ion sum'
+        error stop
+    end if
+
+    offdiag_max = 0.0_dp
+    do i = 1, size(Kphi%Kllp, 1)
+        do j = 1, size(Kphi%Kllp, 2)
+            if (i /= j) offdiag_max = max(offdiag_max, abs(Kphi%Kllp(i,j)))
+        end do
+    end do
+    if (offdiag_max <= 0.0_dp) then
+        print *, 'FAIL: finite-ion-FLR collisionless matrix has no off-diagonal support'
+        error stop
+    end if
+
+    if (minval(plasma%spec(0)%nu) <= 0.0_dp) then
+        print *, 'FAIL: collisional electron frequency was not preserved'
+        error stop
+    end if
+
+    wide_band_ion = Kphi%Kllp_i(:,:,1)
+    scale = max(1.0_dp, maxval(abs(wide_band_ion)))
+    wide_band_entries = count(abs(wide_band_ion) > 1.0e-12_dp * scale)
+
+    kernel_taper_skip_threshold = exp(-1.0_dp)
+    call Krook_fill_kernel_phi_ions_collisionless(Kphi, KB)
+    narrow_band_ion = Kphi%Kllp_i(:,:,1)
+    narrow_band_entries = count(abs(narrow_band_ion) > 1.0e-12_dp * scale)
+    kernel_taper_skip_threshold = 1.0e-6_dp
+
+    if (wide_band_entries <= narrow_band_entries) then
+        print *, 'FAIL: collisionless ion kernel did not respond to the taper threshold'
+        print *, '  wide-band resolved entries   = ', wide_band_entries
+        print *, '  narrow-band resolved entries = ', narrow_band_entries
+        error stop
+    end if
+
+    print *, 'PASS: ion-only collisionless assembly is finite, symmetric, and FLR-coupled'
+
+contains
+
+    subroutine make_test_profiles(r, n, Te, Ti, q, Er)
+        real(dp), intent(out) :: r(npts), n(npts), Te(npts), Ti(npts), q(npts), Er(npts)
+        integer :: k
+        do k = 1, npts
+            r(k) = 2.0_dp + 58.0_dp * real(k - 1, dp) / real(npts - 1, dp)
+            n(k) = 2.0e13_dp * (1.1_dp - r(k) / 100.0_dp)
+            Te(k) = 1.0e3_dp * (1.2_dp - r(k) / 100.0_dp)
+            Ti(k) = Te(k)
+            q(k) = 1.5_dp + (r(k) - 2.0_dp) / 58.0_dp
+            Er(k) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        character(len=*), intent(in) :: path
+        integer :: unit
+        open(newunit=unit, file=path, status='replace', action='write')
+        write(unit, '(A)') '&KIM_CONFIG'
+        write(unit, '(A)') ' number_of_ion_species = 1'
+        write(unit, '(A)') ' artificial_debye_case = 0'
+        write(unit, '(A)') " type_of_run = 'electrostatic'"
+        write(unit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(unit, '(A)') " ion_collision_model = 'collisionless'"
+        write(unit, '(A)') ' collisionless_kpar_epsilon = 1.0e-5'
+        write(unit, '(A)') ' ion_fp_collision_scale = 0.25'
+        write(unit, '(A)') ' read_species_from_namelist = .false.'
+        write(unit, '(A)') ' turn_off_ions = .false.'
+        write(unit, '(A)') ' turn_off_electrons = .false.'
+        write(unit, '(A)') " plasma_type = 'D'"
+        write(unit, '(A)') ' rescale_density = .false.'
+        write(unit, '(A)') ' number_density_rescale = 1.0'
+        write(unit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(unit, '(A)') '/'
+        write(unit, '(A)') '&WKB_DISPERSION'
+        write(unit, '(A)') '/'
+        write(unit, '(A)') '&KIM_IO'
+        write(unit, '(A)') " profile_location = './'"
+        write(unit, '(A)') " output_path = './out_collisionless_assembly/'"
+        write(unit, '(A)') ' hdf5_input = .false.'
+        write(unit, '(A)') ' hdf5_output = .false.'
+        write(unit, '(A)') ' log_level = 2'
+        write(unit, '(A)') ' data_verbosity = 0'
+        write(unit, '(A)') ' calculate_asymptotics = .false.'
+        write(unit, '(A)') " h5_out_file = ''"
+        write(unit, '(A)') ' write_diagnostics_dat = .false.'
+        write(unit, '(A)') '/'
+        write(unit, '(A)') '&KIM_SETUP'
+        write(unit, '(A)') ' btor = -18000.0'
+        write(unit, '(A)') ' R0 = 165.0'
+        write(unit, '(A)') ' m_mode = -2'
+        write(unit, '(A)') ' n_mode = 1'
+        write(unit, '(A)') ' omega = 0.0'
+        write(unit, '(A)') ' spline_base = 1'
+        write(unit, '(A)') ' type_br_field = 12'
+        write(unit, '(A)') ' collisions_off = .false.'
+        write(unit, '(A)') ' set_profiles_constant = 0'
+        write(unit, '(A)') ' bc_type = 3'
+        write(unit, '(A)') ' mphi_max = 0'
+        write(unit, '(A)') ' Br_boundary_re = 1.0'
+        write(unit, '(A)') ' Br_boundary_im = 0.0'
+        write(unit, '(A)') '/'
+        write(unit, '(A)') '&KIM_GRID'
+        write(unit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(unit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(unit, '(A)') ' l_space_dim = 32'
+        write(unit, '(A)') ' rg_space_dim = 64'
+        write(unit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(unit, '(A)') " theta_integration_method = ''"
+        write(unit, '(A)') ' Larmor_skip_factor = 5'
+        write(unit, '(A)') ' gauss_int_nodes_Ntheta = 7'
+        write(unit, '(A)') ' gauss_int_nodes_Nx = 11'
+        write(unit, '(A)') ' gauss_int_nodes_Nxp = 10'
+        write(unit, '(A)') ' r_plas = 34.0'
+        write(unit, '(A)') ' r_min = 28.0'
+        write(unit, '(A)') ' width_res = 0.5'
+        write(unit, '(A)') ' ampl_res = 15.0'
+        write(unit, '(A)') ' hrmax_scaling = 1.0'
+        write(unit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(unit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(unit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(unit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(unit, '(A)') ' quadpack_key = 6'
+        write(unit, '(A)') ' quadpack_limit = 500'
+        write(unit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(unit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(unit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(unit, '(A)') '/'
+        write(unit, '(A)') '&KIM_PROFILES'
+        write(unit, '(A)') '/'
+        close(unit)
+    end subroutine write_test_namelist
+
+end program test_collisionless_ion_assembly

--- a/KIM/tests/test_collisionless_ion_kernel.f90
+++ b/KIM/tests/test_collisionless_ion_kernel.f90
@@ -1,0 +1,165 @@
+program test_collisionless_ion_kernel
+
+    use KIM_kinds_m, only: dp
+    use Krook_kernel_plasma_prefacs_m, only: Krook_collisionless_kpar, Krook_collisionless_kpar_magnitude, &
+        Krook_collisionless_z0, Krook_z0_cc, &
+        Krook_G1_rho_phi, Krook_G2_rho_phi, Krook_G3_rho_phi, &
+        Krook_G1_rho_B, Krook_G2_rho_B, Krook_G3_rho_B, Krook_kappa_rho_B
+    use species_m, only: plasma, species_t
+    use setup_m, only: omega
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+
+    complex(dp) :: actual, expected, explicit_c0, collisional
+    complex(dp) :: pole_wide, pole_narrow, pole_cc, z0_cc, plasma_Z
+    real(dp) :: magnitude_wide, magnitude_narrow, pole_magnitude
+    type(species_t) :: spec
+
+    pole_wide = Krook_collisionless_kpar(0.0_dp, 0.25_dp)
+    expected = cmplx(0.0_dp, 0.25_dp, dp)
+    if (abs(pole_wide - expected) > 1.0e-14_dp) then
+        print *, 'FAIL: collisionless pole is not k_parallel + i epsilon'
+        print *, '  actual   = ', pole_wide
+        print *, '  expected = ', expected
+        error stop
+    end if
+
+    pole_narrow = Krook_collisionless_kpar(0.0_dp, 0.125_dp)
+    if (abs(1.0_dp / pole_narrow) <= abs(1.0_dp / pole_wide)) then
+        print *, 'FAIL: causal pole does not grow as epsilon decreases'
+        error stop
+    end if
+
+    pole_magnitude = Krook_collisionless_kpar_magnitude(3.0_dp, 4.0_dp)
+    if (abs(pole_magnitude - 5.0_dp) > 1.0e-14_dp) then
+        print *, 'FAIL: broadened collisionless |k_parallel| mismatch'
+        error stop
+    end if
+
+    magnitude_wide = Krook_collisionless_kpar_magnitude(0.0_dp, 0.25_dp)
+    magnitude_narrow = Krook_collisionless_kpar_magnitude(0.0_dp, 0.125_dp)
+    if (1.0_dp / magnitude_narrow <= 1.0_dp / magnitude_wide) then
+        print *, 'FAIL: broadened inverse magnitude does not recover the singular limit'
+        error stop
+    end if
+
+    actual = Krook_collisionless_z0(2.0_dp, 0.5_dp, -3.0_dp, 4.0_dp, 0.25_dp)
+    pole_magnitude = Krook_collisionless_kpar_magnitude(-3.0_dp, 0.25_dp)
+    expected = cmplx(-1.5_dp / (pole_magnitude * sqrt(2.0_dp) * 4.0_dp), 0.0_dp, dp)
+
+    if (abs(actual - expected) > 1.0e-14_dp) then
+        print *, 'FAIL: collisionless z0 mismatch'
+        print *, '  actual   = ', actual
+        print *, '  expected = ', expected
+        error stop
+    end if
+    if (aimag(actual) /= 0.0_dp) then
+        print *, 'FAIL: magnitude-based collisionless z0 is not real: ', actual
+        error stop
+    end if
+
+    actual = plasma_Z(Krook_collisionless_z0(-31334.6381_dp, 0.0_dp, &
+        1.310539e-9_dp, 18950820.5_dp, 1.0e-5_dp))
+    if (.not. ieee_is_finite(real(actual, dp)) .or. .not. ieee_is_finite(aimag(actual))) then
+        print *, 'FAIL: collisionless z0 sends plasma Z into its overflowing lower half-plane'
+        error stop
+    end if
+
+    allocate(plasma%om_E(2), plasma%kp(2), spec%vT(2), spec%z0(2))
+    plasma%om_E = [2.0_dp, 4.0_dp]
+    plasma%kp = [-3.0_dp, -5.0_dp]
+    spec%vT = [4.0_dp, 8.0_dp]
+    spec%z0 = [cmplx(1.0_dp, 2.0_dp, dp), cmplx(3.0_dp, 4.0_dp, dp)]
+    omega = 0.5_dp
+
+    actual = Krook_z0_cc(1, spec, collisionless=.false.)
+    expected = cmplx(2.0_dp, 3.0_dp, dp)
+    if (abs(actual - expected) > 1.0e-14_dp) then
+        print *, 'FAIL: collisional cell-centred z0 did not preserve existing behavior'
+        error stop
+    end if
+
+    pole_cc = Krook_collisionless_kpar(-4.0_dp, 0.25_dp)
+    pole_magnitude = Krook_collisionless_kpar_magnitude(-4.0_dp, 0.25_dp)
+    expected = Krook_collisionless_z0(3.0_dp, omega, -4.0_dp, 6.0_dp, 0.25_dp)
+    actual = Krook_z0_cc(1, spec, collisionless=.true., epsilon=0.25_dp)
+    if (abs(actual - expected) > 1.0e-14_dp) then
+        print *, 'FAIL: explicit collisionless cell-centred z0 mismatch'
+        print *, '  actual   = ', actual
+        print *, '  expected = ', expected
+        error stop
+    end if
+    if (any(spec%z0 /= [cmplx(1.0_dp, 2.0_dp, dp), cmplx(3.0_dp, 4.0_dp, dp)])) then
+        print *, 'FAIL: collisionless z0 calculation mutated the species background'
+        error stop
+    end if
+
+    allocate(plasma%ks(2), spec%A1(2), spec%A2(2), spec%rho_L(2), spec%lambda_D(2), spec%omega_c(2))
+    plasma%ks = [0.2_dp, 0.3_dp]
+    spec%A1 = [0.4_dp, 0.5_dp]
+    spec%A2 = [-0.2_dp, -0.1_dp]
+    spec%rho_L = [0.3_dp, 0.4_dp]
+    spec%lambda_D = [0.7_dp, 0.9_dp]
+    spec%omega_c = [2.0_dp, 2.4_dp]
+    z0_cc = Krook_collisionless_z0(3.0_dp, omega, -4.0_dp, 6.0_dp, 0.25_dp)
+
+    collisional = Krook_G1_rho_phi(1, spec)
+    explicit_c0 = Krook_G1_rho_phi(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = 0.25_dp * 0.35_dp / (pole_magnitude * sqrt(2.0_dp)) * (&
+        0.45_dp * plasma_Z(z0_cc) - 0.15_dp * plasma_Z(z0_cc) * (1.0_dp + z0_cc**2) &
+        - 0.15_dp * z0_cc)
+    call assert_prefactor('G1_rho_phi', collisional, explicit_c0, expected)
+
+    collisional = Krook_G2_rho_phi(1, spec)
+    explicit_c0 = Krook_G2_rho_phi(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = -0.25_dp * 0.35_dp * (-0.15_dp) * plasma_Z(z0_cc) / (pole_magnitude * sqrt(2.0_dp))
+    call assert_prefactor('G2_rho_phi', collisional, explicit_c0, expected)
+
+    collisional = Krook_G3_rho_phi(1, spec)
+    explicit_c0 = Krook_G3_rho_phi(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = 0.25_dp * 0.35_dp * (-0.15_dp) * plasma_Z(z0_cc) / (&
+        pole_magnitude * sqrt(2.0_dp))
+    call assert_prefactor('G3_rho_phi', collisional, explicit_c0, expected)
+
+    collisional = Krook_G1_rho_B(1, spec)
+    explicit_c0 = Krook_G1_rho_B(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = 0.45_dp * (z0_cc * plasma_Z(z0_cc) + 1.0_dp) - 0.15_dp * (&
+        0.5_dp + (z0_cc * plasma_Z(z0_cc) + 1.0_dp) * (1.0_dp + z0_cc**2))
+    call assert_prefactor('G1_rho_B', collisional, explicit_c0, expected)
+
+    collisional = Krook_G2_rho_B(1, spec)
+    explicit_c0 = Krook_G2_rho_B(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = 0.15_dp * (z0_cc * plasma_Z(z0_cc) + 1.0_dp)
+    call assert_prefactor('G2_rho_B', collisional, explicit_c0, expected)
+
+    collisional = Krook_G3_rho_B(1, spec)
+    explicit_c0 = Krook_G3_rho_B(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = -0.15_dp * (z0_cc * plasma_Z(z0_cc) + 1.0_dp)
+    call assert_prefactor('G3_rho_B', collisional, explicit_c0, expected)
+
+    collisional = Krook_kappa_rho_B(1, spec)
+    explicit_c0 = Krook_kappa_rho_B(1, spec, collisionless=.true., epsilon=0.25_dp)
+    expected = collisional * cmplx(-4.0_dp, 0.0_dp, dp) / pole_cc
+    call assert_prefactor('kappa_rho_B', collisional, explicit_c0, expected)
+
+    print *, 'PASS: collisionless magnitude terms and causal signed poles remain distinct'
+
+contains
+
+    subroutine assert_prefactor(name, fp_value, c0_value, reference_value)
+        character(len=*), intent(in) :: name
+        complex(dp), intent(in) :: fp_value, c0_value, reference_value
+        real(dp) :: tolerance
+
+        tolerance = 1.0e-13_dp * (1.0_dp + abs(reference_value))
+        if (abs(c0_value - reference_value) > tolerance) then
+            print *, 'FAIL: explicit collisionless prefactor mismatch for ', name
+            error stop
+        end if
+        if (abs(c0_value - fp_value) <= 1.0e-14_dp * (1.0_dp + abs(fp_value))) then
+            print *, 'FAIL: collisionless selection had no effect for ', name
+            error stop
+        end if
+    end subroutine assert_prefactor
+end program test_collisionless_ion_kernel


### PR DESCRIPTION
## Summary

- add the collisionless-ion response path while retaining the Fokker--Planck electron response
- use a causal complex pole and consistent collisionless susceptibility prefactors
- make collisionless tapering and `m_phi` handling consistent with the FP assembly
- apply the local `F0` term to every pair of overlapping hat functions, `abs(l-lp) <= 1`
- add ion-only FP collision-frequency scaling and kernel diagnostics
- add focused collisionless prefactor and assembly regression tests

## Root cause

The collisionless charge assembly evaluated the local Debye/polarization `F0`
contribution only for `l == lp`. Linear finite-element basis functions also
overlap for nearest neighbours, so the first off-diagonal entries were omitted.
Those missing entries produced the approximately 1.6 amplitude discrepancy in
the ion-only `m=7` potential even though the FP susceptibilities were already
close to their collisionless limits.

## Result

After restoring the FP overlap condition, the ion-only `m=7` peak-amplitude
ratio is 1.000, with a relative profile L2 difference of 10.2%. For `m=6`,
close to `E_r=0`, the peak-amplitude ratio is 1.021 and the relative L2
difference is 28.8%.

## Validation

- KIM executable builds on the latest `main`
- collisionless prefactor and assembly tests pass
- KIM diagnostics and sparse-solver tests pass
- 38 Python benchmark tests pass
- ion-only FP and collisionless `m=6`/`m=7` cases were rerun successfully
