### PR TITLE
Recompute z0 after interpolation and add collision-frequency scale

### DIFF
--- a/KIM/nmls/KIM_config.nml
+++ b/KIM/nmls/KIM_config.nml
@@ -12,6 +12,7 @@
     rescale_density = .false.
     number_density_rescale = 1d-6
     ion_flr_scale_factor = 1.0
+    collision_frequency_scale = 1.0
 /
 
 &wkb_dispersion

--- a/KIM/nmls/README.md
+++ b/KIM/nmls/README.md
@@ -6,6 +6,7 @@ KIM is configured via the namelist file KIM_config.nml containing multiple namel
 - read_species_from_namelist ... boolean, if false, initialize deuterium plasma
 - type_of_run ... string, specifies the type of run, options are: 'electrostatic', 'electromagnetic', 'WKB_dispersion', 'flr2_benchmark'
 - collision_model ... string, collision model to use, options are: 'Krook', 'FokkerPlanck'
+- collision_frequency_scale ... real, positive multiplier applied to the calculated electron and ion collision frequencies before the Krook argument z0 and the Fokker-Planck susceptibility inputs are assembled; default 1.0 leaves the collision formulas unchanged
 - artificial_debye_case ... integer, if 0: full calculation of kernel, if 1: Debye case, if 2: exclude Debye case
 
 ## KIM_IO

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -459,7 +459,8 @@ module species_m
 
         use constants_m, only: sol, e_charge, ev, pi, com_unit
         use setup_m, only: omega, collisions_off
-        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, ion_flr_scale_factor
+        use config_m, only: number_of_ion_species, rescale_density, number_density_rescale, &
+                            ion_flr_scale_factor, collision_frequency_scale
 
         implicit none
 
@@ -538,6 +539,13 @@ module species_m
             do i = 1, plasma_in%grid_size
                 plasma_in%spec(sp)%nu(i) = nui(sp, i)
             end do
+        end do
+
+        ! Sensitivity knob: scales the calculated frequencies before z0 and the
+        ! FP susceptibility inputs are assembled. The default 1.0 leaves the
+        ! Coulomb-logarithm formulas above untouched.
+        do sp = 0, plasma_in%n_species-1
+            plasma_in%spec(sp)%nu = plasma_in%spec(sp)%nu * collision_frequency_scale
         end do
 
         do sp =0, plasma_in%n_species-1
@@ -740,8 +748,15 @@ module species_m
     end subroutine
 
     subroutine interpolate_plasma_backs(plasma_in, grid)
+        ! Primitive quantities are interpolated; the derived Krook argument z0
+        ! is recomputed from them afterwards. z0 carries a 1/|k_parallel|
+        ! singularity at the resonance, so a Lagrange stencil spanning
+        ! k_parallel=0 produces values that violate its defining formula by
+        ! many orders of magnitude.
 
         use KIM_kinds_m, only: dp
+        use constants_m, only: com_unit
+        use setup_m, only: omega
         use IO_collection_m, only: plot_profile
 
         implicit none
@@ -787,7 +802,6 @@ module species_m
                 plasma_temp%spec(sp)%omega_c(i)  = sum(coef(0,:) * plasma_in%spec(sp)%omega_c(ibeg:iend))
                 plasma_temp%spec(sp)%lambda_D(i) = sum(coef(0,:) * plasma_in%spec(sp)%lambda_D(ibeg:iend))
                 plasma_temp%spec(sp)%rho_L(i)    = sum(coef(0,:) * plasma_in%spec(sp)%rho_L(ibeg:iend))
-                plasma_temp%spec(sp)%z0(i)       = sum(coef(0,:) * plasma_in%spec(sp)%z0(ibeg:iend))
             end do
 
             plasma_temp%B0(i)   = sum(coef(0,:) * plasma_in%B0(ibeg:iend))
@@ -798,6 +812,12 @@ module species_m
             plasma_temp%dqdr(i) = sum(coef(0,:) * plasma_in%dqdr(ibeg:iend))
             plasma_temp%Er(i)   = sum(coef(0,:) * plasma_in%Er(ibeg:iend))
 
+        end do
+
+        do sp = 0, plasma_temp%n_species-1
+            plasma_temp%spec(sp)%z0 = -(plasma_temp%om_E - omega &
+                - com_unit * plasma_temp%spec(sp)%nu) &
+                / (abs(plasma_temp%kp) * sqrt(2d0) * plasma_temp%spec(sp)%vT)
         end do
 
         plasma_in = plasma_temp

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -134,6 +134,10 @@ contains
         call print_config_line('Plasma Type', trim(plasma_type), width)
         call print_config_line('Collision Model', trim(collision_model), width)
         call print_bool_line('Collisions', .not. collisions_off, width)
+        if (collision_frequency_scale /= 1.0d0) then
+            write(value_str, '(ES12.3)') collision_frequency_scale
+            call print_config_line('Collision Frequency Scale', trim(adjustl(value_str)), width)
+        end if
         write(value_str, '(I0)') artificial_debye_case
         call print_config_line('Artificial Debye Case', trim(adjustl(value_str)), width)
         call print_bool_line('Turn Off Ions', turn_off_ions, width)

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -19,7 +19,7 @@ subroutine kim_read_config
                         type_of_run, collision_model, read_species_from_namelist, &
                         turn_off_ions, turn_off_electrons, plasma_type, rescale_density, &
                         number_density_rescale, ion_flr_scale_factor, &
-                        boole_energy_conservation
+                        collision_frequency_scale, boole_energy_conservation
 
     namelist /WKB_DISPERSION/ WKB_dispersion_mode, WKB_dispersion_solver, &
                         WKB_solve_for_kr_squared, &
@@ -114,6 +114,11 @@ subroutine kim_read_config
     if (collisions_off .and. collision_model == "FokkerPlanck") then
         write(*,*) 'Error: collision_model is set to "FokkerPlanck" but collisions_off is true.'
         write(*,*) 'Please set collisions_off to false or change collision_model.'
+        stop
+    end if
+
+    if (collision_frequency_scale <= 0.0_dp) then
+        write(*,*) 'Error: collision_frequency_scale must be positive. Got: ', collision_frequency_scale
         stop
     end if
 

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -59,6 +59,7 @@ module config_m
     logical :: rescale_density
     real(dp) :: number_density_rescale
     real(dp) :: ion_flr_scale_factor
+    real(dp) :: collision_frequency_scale = 1.0_dp
 
     ! KIM_PROFILES namelist variables
     character(20) :: coord_type = 'auto'           ! 'auto', 'sqrt_psiN', or 'r_eff'

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -196,6 +196,7 @@ module IO_collection_m
     subroutine write_setup_namelist_to_hdf5()
 
         use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_obj_exists, h5_add, h5_close_group
+        use config_m, only: collision_frequency_scale
         use setup_m
 
         implicit none
@@ -226,6 +227,8 @@ module IO_collection_m
             'Integer type of delta Br.', '1')
         call h5_add(h5grpid, 'collisions_off', collisions_off, &
             'Logical switch to turn off collisions.', 'true/false')
+        call h5_add(h5grpid, 'collision_frequency_scale', collision_frequency_scale, &
+            'Multiplier applied to calculated collision frequencies.', '1')
         call h5_add(h5grpid, 'set_profiles_constant', set_profiles_constant, &
             'Integer switch for setting (some) profiles constant.', '1')
         call h5_add(h5grpid, 'bc_type', bc_type, &

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -115,6 +115,15 @@ target_link_libraries(test_periodization KIM_lib kilca_lib lapack cerf ddeabm sl
 add_test(NAME test_periodization
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodization.x)
 
+# Derived Krook argument z0 recompute + collision-frequency scale (ex-wp5 #182/#183).
+add_executable(test_collision_scale_z0 ${CMAKE_SOURCE_DIR}/KIM/tests/test_collision_scale_z0.f90)
+set_target_properties(test_collision_scale_z0 PROPERTIES
+                        OUTPUT_NAME test_collision_scale_z0.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_collision_scale_z0 KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_collision_scale_z0
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_collision_scale_z0.x)
+
 # Periodic sampling of KIM background primitives (aperfuns callback + wrapper).
 add_executable(test_periodic_background ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_background.f90)
 set_target_properties(test_periodic_background PROPERTIES

--- a/KIM/tests/test_collision_scale_z0.f90
+++ b/KIM/tests/test_collision_scale_z0.f90
@@ -15,16 +15,23 @@ program test_collision_scale_z0
     !       frequencies, and the default 1.0 leaves them untouched. The scaled
     !       nu must reach z0, since z0 is assembled after the scaling.
 
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use KIM_kinds_m, only: dp
-    use constants_m, only: com_unit, e_mass
-    use species_m, only: plasma_t, init_electron_species, interpolate_plasma_backs
-    use setup_m, only: omega
+    use constants_m, only: com_unit
+    use species_m, only: plasma, plasma_t, init_electron_species, &
+                         init_deuterium_species, calculate_plasma_backs, &
+                         interpolate_plasma_backs, compute_rg_cell_centers, &
+                         calculate_thermodynamic_forces_and_susc
+    use config_m, only: number_of_ion_species, collision_frequency_scale, &
+                        rescale_density, ion_flr_scale_factor
+    use grid_m, only: rg_grid
+    use setup_m, only: omega, collisions_off, mphi_max
 
     implicit none
 
     call test_z0_recomputed_across_resonance()
     call test_z0_matches_formula_off_resonance()
-    call test_collision_scale_reaches_z0()
+    call test_collision_scale_reaches_production_paths()
 
     print *, 'All tests PASSED'
     stop 0
@@ -92,6 +99,17 @@ contains
 
         want = z0_formula(p, i)
         err = abs(p%spec(0)%z0(i) - want)/max(abs(want), 1.0d0)
+        if (.not. ieee_is_finite(real(p%spec(0)%z0(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(p%spec(0)%z0(i))) .or. &
+                .not. ieee_is_finite(real(want, dp)) .or. &
+                .not. ieee_is_finite(aimag(want)) .or. &
+                .not. ieee_is_finite(err)) then
+            print *, 'FAIL: ', label
+            print *, '  k_par   = ', p%kp(i)
+            print *, '  z0 got  = ', p%spec(0)%z0(i)
+            print *, '  z0 want = ', want
+            error stop 'z0 comparison contains a non-finite value'
+        end if
         if (err > 1.0d-12) then
             print *, 'FAIL: ', label
             print *, '  r        = ', p%r_grid(i)
@@ -107,11 +125,14 @@ contains
         ! Target grid point sits where k_parallel is near zero, so the old
         ! interpolated-z0 path blew up while the recomputed one stays exact.
         type(plasma_t) :: p
-        real(dp) :: fine_grid(3)
+        real(dp) :: fine_grid(4)
         integer :: i
 
         call build_coarse_plasma(p, 1.0d0)
-        fine_grid = [24.0d0, 25.0d0, 26.0d0]
+        ! Sample finite points on both sides of the singular surface. The exact
+        ! k_parallel=0 point is mathematically singular and is not a valid
+        ! finite-value invariant check.
+        fine_grid = [24.0d0, 24.9d0, 25.1d0, 26.0d0]
         call interpolate_plasma_backs(p, fine_grid)
 
         do i = 1, size(fine_grid)
@@ -135,39 +156,126 @@ contains
         print *, 'PASS: z0 obeys its formula away from the resonance'
     end subroutine test_z0_matches_formula_off_resonance
 
-    subroutine test_collision_scale_reaches_z0()
-        ! calculate_plasma_backs applies collision_frequency_scale before z0 is
-        ! assembled; check the scaled nu propagates and that scale 1 is a no-op.
-        type(plasma_t) :: unscaled, scaled
-        real(dp), parameter :: scale = 3.0d0
-        real(dp) :: fine_grid(2)
-        complex(dp) :: want
-        integer :: i
+    subroutine require_close(got, want, label)
+        real(dp), intent(in) :: got, want
+        character(*), intent(in) :: label
 
-        call build_coarse_plasma(unscaled, 1.0d0)
-        call build_coarse_plasma(scaled, scale)
-        fine_grid = [12.0d0, 14.0d0]
-        call interpolate_plasma_backs(unscaled, fine_grid)
-        call interpolate_plasma_backs(scaled, fine_grid)
+        if (abs(got - want) > 1.0d-12*max(abs(want), 1.0d0)) then
+            print *, 'FAIL: ', label
+            print *, '  got  = ', got
+            print *, '  want = ', want
+            error stop 'scaled production quantity has the wrong value'
+        end if
+    end subroutine require_close
 
-        do i = 1, size(fine_grid)
-            if (abs(scaled%spec(0)%nu(i) - scale*unscaled%spec(0)%nu(i)) &
-                    > 1.0d-12*abs(scale*unscaled%spec(0)%nu(i))) then
-                print *, 'FAIL: scaled nu = ', scaled%spec(0)%nu(i), &
-                         ' expected ', scale*unscaled%spec(0)%nu(i)
-                error stop 'collision frequency scale did not reach the background'
-            end if
-            want = z0_formula(scaled, i)
-            if (abs(scaled%spec(0)%z0(i) - want) > 1.0d-12*max(abs(want), 1.0d0)) then
-                print *, 'FAIL: z0 = ', scaled%spec(0)%z0(i), ' expected ', want
-                error stop 'scaled collision frequency did not reach z0'
-            end if
-            if (abs(aimag(scaled%spec(0)%z0(i)) - scale*aimag(unscaled%spec(0)%z0(i))) &
-                    > 1.0d-12*abs(scale*aimag(unscaled%spec(0)%z0(i)))) then
-                error stop 'z0 imaginary part does not track the collision scale'
-            end if
+    subroutine build_collision_plasma(template)
+        type(plasma_t), intent(out) :: template
+        integer, parameter :: n = 4
+        integer :: sp
+
+        template%n_species = 2
+        template%grid_size = n
+        allocate(template%spec(0:1))
+        call init_electron_species(template%spec(0))
+        call init_deuterium_species(template%spec(1))
+        allocate(template%r_grid(n), template%ks(n), template%kp(n), &
+                 template%om_E(n), template%B0(n), template%q(n), &
+                 template%dqdr(n), template%Er(n))
+        do sp = 0, 1
+            allocate(template%spec(sp)%n(n), template%spec(sp)%dndr(n), &
+                     template%spec(sp)%T(n), template%spec(sp)%dTdr(n))
         end do
-        print *, 'PASS: collision frequency scale reaches nu and z0'
-    end subroutine test_collision_scale_reaches_z0
+
+        template%r_grid = [10.0d0, 20.0d0, 30.0d0, 40.0d0]
+        template%kp = [3.0d-3, 2.0d-3, 1.0d-3, 5.0d-4]
+        template%om_E = [9.3d4, 8.0d4, 7.0d4, 6.0d4]
+        template%ks = 1.0d-2
+        template%B0 = 2.0d4
+        template%q = 1.5d0
+        template%dqdr = 1.0d-2
+        template%Er = 0.0d0
+        template%spec(0)%n = 1.0d13
+        template%spec(1)%n = 1.0d13
+        template%spec(0)%T = 1.0d3
+        template%spec(1)%T = 8.0d2
+        do sp = 0, 1
+            template%spec(sp)%dndr = -1.0d11
+            template%spec(sp)%dTdr = -1.0d1
+        end do
+
+        rg_grid%npts_b = n
+        rg_grid%npts_c = n - 1
+        if (allocated(rg_grid%xb)) deallocate(rg_grid%xb)
+        if (allocated(rg_grid%xc)) deallocate(rg_grid%xc)
+        allocate(rg_grid%xb(n), rg_grid%xc(n - 1))
+        rg_grid%xb = template%r_grid
+        rg_grid%xc = 0.5d0*(rg_grid%xb(:n - 1) + rg_grid%xb(2:))
+    end subroutine build_collision_plasma
+
+    subroutine run_collision_scale_case(template, scale, nu, z0, x1, x2)
+        type(plasma_t), intent(in) :: template
+        real(dp), intent(in) :: scale
+        real(dp), intent(out) :: nu(0:1), x1(0:1), x2(0:1)
+        complex(dp), intent(out) :: z0(0:1)
+        integer :: sp
+
+        plasma = template
+        collision_frequency_scale = scale
+        call calculate_plasma_backs(plasma)
+        call compute_rg_cell_centers(plasma)
+        call calculate_thermodynamic_forces_and_susc(plasma)
+
+        do sp = 0, 1
+            nu(sp) = plasma%spec(sp)%nu(2)
+            z0(sp) = plasma%spec(sp)%z0(2)
+            x1(sp) = plasma%spec(sp)%x1(2)
+            x2(sp) = plasma%spec(sp)%x2(2, 0)
+        end do
+    end subroutine run_collision_scale_case
+
+    subroutine test_collision_scale_reaches_production_paths()
+        type(plasma_t) :: template
+        real(dp), parameter :: scale = 3.0d0
+        real(dp) :: nu_base(0:1), nu_scaled(0:1)
+        real(dp) :: x1_base(0:1), x1_scaled(0:1)
+        real(dp) :: x2_base(0:1), x2_scaled(0:1)
+        real(dp) :: lee, lei, expected_nue
+        complex(dp) :: z0_base(0:1), z0_scaled(0:1)
+        integer :: sp
+
+        number_of_ion_species = 1
+        rescale_density = .false.
+        ion_flr_scale_factor = 1.0d0
+        collisions_off = .false.
+        mphi_max = 0
+        omega = 1.0d5
+        call build_collision_plasma(template)
+        call run_collision_scale_case(template, 1.0d0, nu_base, z0_base, &
+                                      x1_base, x2_base)
+        call run_collision_scale_case(template, scale, nu_scaled, z0_scaled, &
+                                      x1_scaled, x2_scaled)
+
+        lee = 23.5d0 - log(sqrt(1.0d13)/1.0d3**1.25d0) &
+            - sqrt(1.0d-5 + (log(1.0d3) - 2.0d0)**2/16.0d0)
+        lei = 24.0d0 - log(sqrt(1.0d13)/1.0d3)
+        expected_nue = real(5.8e-6, dp)*1.0d13*lee/1.0d3**1.5d0 &
+            + 7.7d-6*1.0d13*lei/1.0d3**1.5d0
+        call require_close(nu_base(0), expected_nue, &
+                           'default scale preserves the electron collision formula')
+
+        do sp = 0, 1
+            call require_close(nu_scaled(sp), scale*nu_base(sp), &
+                               'collision scale reaches electron/ion nu')
+            call require_close(real(z0_scaled(sp), dp), real(z0_base(sp), dp), &
+                               'collision scale leaves real(z0) unchanged')
+            call require_close(aimag(z0_scaled(sp)), scale*aimag(z0_base(sp)), &
+                               'collision scale reaches imag(z0)')
+            call require_close(x1_scaled(sp), x1_base(sp)/scale, &
+                               'scaled nu reaches FP x1')
+            call require_close(x2_scaled(sp), x2_base(sp)/scale, &
+                               'scaled nu reaches FP x2')
+        end do
+        print *, 'PASS: collision scale reaches electron/ion nu, z0, and FP inputs'
+    end subroutine test_collision_scale_reaches_production_paths
 
 end program test_collision_scale_z0

--- a/KIM/tests/test_collision_scale_z0.f90
+++ b/KIM/tests/test_collision_scale_z0.f90
@@ -1,0 +1,173 @@
+program test_collision_scale_z0
+    ! Two background-quantity invariants, extracted from the retired wp5 stack
+    ! (PRs #182/#183) onto the forced-periodicity lineage:
+    !
+    !   (a) interpolate_plasma_backs recomputes the derived Krook argument z0
+    !       from interpolated primitives instead of interpolating z0 itself.
+    !       z0 carries a 1/|k_parallel| singularity at the resonance, so a
+    !       four-point Lagrange stencil spanning k_parallel=0 can return values
+    !       many orders of magnitude away from the defining formula
+    !         z0 = -(omega_E - omega - i nu)/(|k_parallel| sqrt(2) v_T).
+    !       Asserted both on a stencil that straddles the resonance (the
+    !       regression proper) and on a smooth off-resonance point.
+    !
+    !   (b) collision_frequency_scale multiplies the calculated collision
+    !       frequencies, and the default 1.0 leaves them untouched. The scaled
+    !       nu must reach z0, since z0 is assembled after the scaling.
+
+    use KIM_kinds_m, only: dp
+    use constants_m, only: com_unit, e_mass
+    use species_m, only: plasma_t, init_electron_species, interpolate_plasma_backs
+    use setup_m, only: omega
+
+    implicit none
+
+    call test_z0_recomputed_across_resonance()
+    call test_z0_matches_formula_off_resonance()
+    call test_collision_scale_reaches_z0()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine build_coarse_plasma(coarse, nu_scale)
+        ! Minimal single-species background whose k_parallel changes sign
+        ! between grid points 2 and 3, i.e. a resonance inside the stencil.
+        type(plasma_t), intent(out) :: coarse
+        real(dp), intent(in) :: nu_scale
+        integer :: n
+
+        n = 4
+        coarse%n_species = 1
+        coarse%grid_size = n
+        allocate(coarse%spec(0:0))
+        call init_electron_species(coarse%spec(0))
+        allocate(coarse%r_grid(n), coarse%ks(n), coarse%kp(n), coarse%om_E(n), &
+                 coarse%B0(n), coarse%q(n), coarse%dqdr(n), coarse%Er(n))
+        allocate(coarse%spec(0)%n(n), coarse%spec(0)%dndr(n), coarse%spec(0)%T(n), &
+                 coarse%spec(0)%dTdr(n), coarse%spec(0)%nu(n), coarse%spec(0)%vT(n), &
+                 coarse%spec(0)%omega_c(n), coarse%spec(0)%lambda_D(n), &
+                 coarse%spec(0)%rho_L(n), coarse%spec(0)%z0(n))
+
+        coarse%r_grid = [10.0d0, 20.0d0, 30.0d0, 40.0d0]
+        coarse%kp     = [3.0d-3, 1.0d-3, -1.0d-3, -3.0d-3]
+        coarse%om_E   = [9.3d4, 8.0d4, 7.0d4, 6.0d4]
+        coarse%ks     = 1.0d-2
+        coarse%B0     = 2.0d4
+        coarse%q      = 1.5d0
+        coarse%dqdr   = 1.0d-2
+        coarse%Er     = 1.0d0
+
+        coarse%spec(0)%n       = 1.0d13
+        coarse%spec(0)%dndr    = -1.0d11
+        coarse%spec(0)%T       = 1.0d3
+        coarse%spec(0)%dTdr    = -1.0d1
+        coarse%spec(0)%vT      = 5.9d8
+        coarse%spec(0)%omega_c = -3.5d11
+        coarse%spec(0)%lambda_D = 7.4d-3
+        coarse%spec(0)%rho_L   = 1.7d-3
+        coarse%spec(0)%nu      = 1.0d4 * nu_scale
+
+        ! z0 consistent with the coarse primitives; the point of the fix is
+        ! that this array is NOT carried through the interpolation.
+        coarse%spec(0)%z0 = -(coarse%om_E - omega - com_unit*coarse%spec(0)%nu) &
+                            /(abs(coarse%kp)*sqrt(2d0)*coarse%spec(0)%vT)
+    end subroutine build_coarse_plasma
+
+    complex(dp) function z0_formula(p, i) result(z0)
+        type(plasma_t), intent(in) :: p
+        integer, intent(in) :: i
+
+        z0 = -(p%om_E(i) - omega - com_unit*p%spec(0)%nu(i)) &
+             /(abs(p%kp(i))*sqrt(2d0)*p%spec(0)%vT(i))
+    end function z0_formula
+
+    subroutine require_z0_matches_formula(p, i, label)
+        type(plasma_t), intent(in) :: p
+        integer, intent(in) :: i
+        character(*), intent(in) :: label
+        complex(dp) :: want
+        real(dp) :: err
+
+        want = z0_formula(p, i)
+        err = abs(p%spec(0)%z0(i) - want)/max(abs(want), 1.0d0)
+        if (err > 1.0d-12) then
+            print *, 'FAIL: ', label
+            print *, '  r        = ', p%r_grid(i)
+            print *, '  k_par    = ', p%kp(i)
+            print *, '  z0 got   = ', p%spec(0)%z0(i)
+            print *, '  z0 want  = ', want
+            print *, '  rel err  = ', err
+            error stop 'z0 violates its defining formula after interpolation'
+        end if
+    end subroutine require_z0_matches_formula
+
+    subroutine test_z0_recomputed_across_resonance()
+        ! Target grid point sits where k_parallel is near zero, so the old
+        ! interpolated-z0 path blew up while the recomputed one stays exact.
+        type(plasma_t) :: p
+        real(dp) :: fine_grid(3)
+        integer :: i
+
+        call build_coarse_plasma(p, 1.0d0)
+        fine_grid = [24.0d0, 25.0d0, 26.0d0]
+        call interpolate_plasma_backs(p, fine_grid)
+
+        do i = 1, size(fine_grid)
+            call require_z0_matches_formula(p, i, 'z0 across the resonance')
+        end do
+        print *, 'PASS: z0 recomputed from primitives across k_parallel = 0'
+    end subroutine test_z0_recomputed_across_resonance
+
+    subroutine test_z0_matches_formula_off_resonance()
+        type(plasma_t) :: p
+        real(dp) :: fine_grid(2)
+        integer :: i
+
+        call build_coarse_plasma(p, 1.0d0)
+        fine_grid = [12.0d0, 14.0d0]
+        call interpolate_plasma_backs(p, fine_grid)
+
+        do i = 1, size(fine_grid)
+            call require_z0_matches_formula(p, i, 'z0 away from the resonance')
+        end do
+        print *, 'PASS: z0 obeys its formula away from the resonance'
+    end subroutine test_z0_matches_formula_off_resonance
+
+    subroutine test_collision_scale_reaches_z0()
+        ! calculate_plasma_backs applies collision_frequency_scale before z0 is
+        ! assembled; check the scaled nu propagates and that scale 1 is a no-op.
+        type(plasma_t) :: unscaled, scaled
+        real(dp), parameter :: scale = 3.0d0
+        real(dp) :: fine_grid(2)
+        complex(dp) :: want
+        integer :: i
+
+        call build_coarse_plasma(unscaled, 1.0d0)
+        call build_coarse_plasma(scaled, scale)
+        fine_grid = [12.0d0, 14.0d0]
+        call interpolate_plasma_backs(unscaled, fine_grid)
+        call interpolate_plasma_backs(scaled, fine_grid)
+
+        do i = 1, size(fine_grid)
+            if (abs(scaled%spec(0)%nu(i) - scale*unscaled%spec(0)%nu(i)) &
+                    > 1.0d-12*abs(scale*unscaled%spec(0)%nu(i))) then
+                print *, 'FAIL: scaled nu = ', scaled%spec(0)%nu(i), &
+                         ' expected ', scale*unscaled%spec(0)%nu(i)
+                error stop 'collision frequency scale did not reach the background'
+            end if
+            want = z0_formula(scaled, i)
+            if (abs(scaled%spec(0)%z0(i) - want) > 1.0d-12*max(abs(want), 1.0d0)) then
+                print *, 'FAIL: z0 = ', scaled%spec(0)%z0(i), ' expected ', want
+                error stop 'scaled collision frequency did not reach z0'
+            end if
+            if (abs(aimag(scaled%spec(0)%z0(i)) - scale*aimag(unscaled%spec(0)%z0(i))) &
+                    > 1.0d-12*abs(scale*aimag(unscaled%spec(0)%z0(i)))) then
+                error stop 'z0 imaginary part does not track the collision scale'
+            end if
+        end do
+        print *, 'PASS: collision frequency scale reaches nu and z0'
+    end subroutine test_collision_scale_reaches_z0
+
+end program test_collision_scale_z0


### PR DESCRIPTION
## Summary

Extracts the two salvageable pieces of the retired wp5 flux-pumping stack onto the forced-periodicity lineage. The rest of that stack (#177–#181, #184) is closed as superseded.

## Krook argument `z0` (was #183)

`interpolate_plasma_backs` interpolated the **derived** `z0` alongside the primitives. `z0` carries a `1/|k_parallel|` singularity at the resonance, so a four-point Lagrange stencil spanning `k_parallel = 0` returns values that violate its own defining formula. The fix interpolates primitives only and recomputes

    z0 = -(omega_E - omega - i nu) / (|k_parallel| sqrt(2) v_T)

on the target grid — the same invariant the periodized-background path already follows.

**Scope:** `z0` is consumed only by `Krook_kernel_plasma_prefacs.f90`. The Fokker-Planck path recomputes `x1/x2/A1/A2/I^{kl}` after interpolation and never reads `z0`, so **FP results are bit-unchanged**. This repairs the Krook hat path, whose nml still marks it `(unstable)` — plausibly part of why.

## Collision-frequency scale (was #182)

New positive `&KIM_CONFIG` key `collision_frequency_scale` multiplying the calculated electron and ion collision frequencies before `z0` and the FP susceptibility inputs are assembled. Default `1.0` leaves every collision formula, profile, unit, and output unchanged. Non-positive values are rejected at startup; the value is displayed when it differs from 1.0 and stored in HDF5 provenance. Same shape as the existing `ion_flr_scale_factor` knob. No benchmark-acceptance claim — it is a sensitivity parameter.

## Tests

`test_collision_scale_z0` (new) asserts the `z0` invariant on a stencil straddling `k_parallel = 0` and away from it, and that the scale reaches both `nu` and `z0` (including the imaginary part of `z0` tracking it).

Developed red-first: against the pre-fix code the test fails with a **36% relative `z0` error at k_par = 2e-4** (`got (-0.0983, 0.0129)` vs `want (-0.4543, 0.0599)`), growing without bound toward the resonance.

## Validation

- `make` — clean build
- `ctest -E 'test_rhs_balance|test_periodic_convergence|test_periodic_vs_global'` — **32/32 passed**

Known red gates excluded as usual: the pre-existing `test_rhs_balance` baseline failure, the periodization-deformation gate, and the periodic-vs-global 5% gate — none touched by this change.

Supersedes #182, #183.