### PR TITLE
Add forced-periodicity electrostatic solver

### DIFF
--- a/KIM/nmls/KIM_config.nml
+++ b/KIM/nmls/KIM_config.nml
@@ -122,3 +122,13 @@
     Er_file = 'Er.dat'
     q_file = 'q.dat'
 /
+
+&KIM_PERIODIC
+    periodic_dr_asis_scale = 5.0
+    periodic_dr_tr_scale = 10.0
+    periodic_kmax_scale = 5.0
+    periodic_n_rg = 96
+    ! Enable only when comparing against the approximated global FEM kernel:
+    ! omit k_s^2 from FLR arguments and use zero electron FLR.
+    periodic_match_global_kernel_approximations = .false.
+/

--- a/KIM/src/CMakeLists.txt
+++ b/KIM/src/CMakeLists.txt
@@ -40,25 +40,15 @@ if("${LAPACK_FOUND}")
     message("${LAPACK_INCLUDE_DIRS}")
 endif()
 
-find_package(SuiteSparse REQUIRED)
-if("${SuiteSparse_FOUND}")
-    message(" ====== SuiteSparse was found! ======")
-    target_link_libraries(KIM_lib PUBLIC "${SuiteSparse_LIBRARIES}")
-    message("SuiteSparse libraries: ${SUITESPARSE_LIBRARIES}")
-    target_include_directories(KIM_lib PUBLIC "${SuiteSparse_INCLUDE_DIRS}")
-    message("${SUITESPARSE_INCLUDE_DIRS}")
-endif()
-
-find_package(Umfpack REQUIRED)
-if("${UMFPACK_FOUND}")
-    message(" ====== Umfpack was found! ======")
-    target_link_libraries(KIM_lib PUBLIC "${UMFPACK_LIBRARIES}")
-    message("UMFPACK libraries: ${UMFPACK_LIBRARIES}")
-    target_include_directories(KIM_lib PUBLIC "${UMFPACK_INCLUDES}")
-    message("${UMFPACK_INCLUDES}")
-endif()
-
-find_library(UMFPACK_LIBRARY umfpack)
+# SuiteSparse/UMFPACK come SOLELY from the fetched-static SuiteSparse v7.8.3 via the
+# `sparse` target linked above (Dependencies.cmake -> SuiteSparse::umfpack{,_wrappers},
+# built with -DDLONG -DZLONG). Previously a find_package(SuiteSparse)+find_package(Umfpack)
+# here ALSO linked the system (Homebrew) UMFPACK, so the binary loaded two conflicting
+# UMFPACK builds at once (static 7.8.3 + dylib 6.3.7). The duplicate SuiteSparse_config
+# global state corrupted every complex sparse solve (umf4zsym -> UMFPACK_ERROR_invalid_matrix,
+# solutions Inf/0), which silently made the global electrostatic Poisson solve return Phi==0.
+# The umf4_f77*.c wrappers' umfpack.h and the UMFPACK symbols both propagate transitively from
+# SuiteSparse::umfpack via the `sparse` target, so no separate find_package is needed.
 
 find_package(SuperLU REQUIRED)
 if("${SUPERLU_FOUND}")

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -58,6 +58,7 @@ set(KIM_dispersion  dispersion/fun_input.f90
 )
 
 set(KIM_poisson electrostatic_poisson/poisson.f90
+                electrostatic_poisson/poisson_periodic.f90
                 electrostatic_poisson/flr2_benchmark.f90
                 electrostatic_poisson/solve_poisson.f90
                 electrostatic_poisson/periodic_assembly.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -49,6 +49,7 @@ set(KIM_background_equilibrium background_equilibrium/species_mod.f90
                             background_equilibrium/calculate_equil.f90
                             background_equilibrium/profile_input_m.f90
                             background_equilibrium/periodization.f90
+                            background_equilibrium/periodic_background.f90
 )
 
 set(KIM_dispersion  dispersion/fun_input.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -61,6 +61,7 @@ set(KIM_poisson electrostatic_poisson/poisson.f90
                 electrostatic_poisson/flr2_benchmark.f90
                 electrostatic_poisson/solve_poisson.f90
                 electrostatic_poisson/periodic_assembly.f90
+                electrostatic_poisson/periodic_solve.f90
                 kernels/kernel.f90
                 kernels/integrands.f90
                 electrostatic_poisson/fields_mod.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -12,9 +12,7 @@ set(KIM_general general/config_display.f90
 )
 
 
-set(KIM_math math/suitesparse/umf4_f77zwrapper.c
-            math/suitesparse/umf4_f77wrapper.c
-            math/superlu/c_fortran_dgssv.c
+set(KIM_math math/superlu/c_fortran_dgssv.c
             math/superlu/c_fortran_zgssv.c
             math/use_libcerf_mod.f90
             math/plasma_disp_func.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -60,6 +60,7 @@ set(KIM_dispersion  dispersion/fun_input.f90
 set(KIM_poisson electrostatic_poisson/poisson.f90
                 electrostatic_poisson/flr2_benchmark.f90
                 electrostatic_poisson/solve_poisson.f90
+                electrostatic_poisson/periodic_assembly.f90
                 kernels/kernel.f90
                 kernels/integrands.f90
                 electrostatic_poisson/fields_mod.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -48,6 +48,7 @@ set(KIM_util util/findIndex.f90
 set(KIM_background_equilibrium background_equilibrium/species_mod.f90
                             background_equilibrium/calculate_equil.f90
                             background_equilibrium/profile_input_m.f90
+                            background_equilibrium/periodization.f90
 )
 
 set(KIM_dispersion  dispersion/fun_input.f90

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -73,7 +73,9 @@ set(KIM_fokkerplanck ${CMAKE_SOURCE_DIR}/QL-Balance/src/base/getIfunc.f90
                      ${CMAKE_SOURCE_DIR}/QL-Balance/src/base/W2_arr.f90
 )
 
-set(KIM_asymptotics asymptotics/FLR2_asymptotics.f90)
+set(KIM_asymptotics asymptotics/FLR2_asymptotics.f90
+                    asymptotics/flr2_fourier_kernel.f90
+)
 
 set(KIM_diagnostics diagnostics/kim_diagnostics_mod.f90
                     diagnostics/kim_qldiff_mod.f90

--- a/KIM/src/asymptotics/FLR2_asymptotics.f90
+++ b/KIM/src/asymptotics/FLR2_asymptotics.f90
@@ -153,6 +153,7 @@ module flr2_asymptotics_m
         use config_m, only: output_path
         use fortnum_special, only: bessel_in
         use config_m, only: turn_off_ions, artificial_debye_case, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
 
         implicit none
 
@@ -187,10 +188,15 @@ module flr2_asymptotics_m
 
 
             do j = 1, size(rg_grid%xb)
-                kernel_phi_temp = 0.0d0
                 do sp = 0, plasma_in%n_species-1
                     if (turn_off_ions .and. sp >= 1) cycle
                     if (turn_off_electrons .and. sp == 0) cycle
+
+                    ! Reset per species: hatG_rho_phi_diag_sp returns the full
+                    ! per-species Debye + FP contribution, so accumulate it
+                    ! fresh for each species (the original reassigned the Debye
+                    ! term per species, then added the temp to kernel_phi(j)).
+                    kernel_phi_temp = 0.0d0
 
                     ! Don't Include full perpendicular wavenumber in FLR parameter: b = (k_r^2 + k_s^2) * rho_T^2
                     ! k_s diverges at r=0, which is problematic for gsl Bessel functions
@@ -198,30 +204,14 @@ module flr2_asymptotics_m
 
                     b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
 
-                    if (artificial_debye_case <= 1) then
-                        kernel_phi_temp = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0
-                    end if
+                    ! Diagonal rho-Phi (Debye + FP) and rho-B (signed FP)
+                    ! integrands now live in flr2_fourier_kernel_m so the
+                    ! diagonal math has a single home. Both functions apply the
+                    ! same artificial_debye_case gating internally.
+                    kernel_phi_temp = kernel_phi_temp + hatG_rho_phi_diag_sp(plasma_in, sp, kr, j)
 
                     if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
-                        kernel_phi_temp = kernel_phi_temp + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
-                            * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * plasma_in%ks(j) &
-                            / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-b) * &
-                            (&
-                                plasma_in%spec(sp)%I00(j, 0) * (&
-                                    bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
-                                    + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
-                                )&
-                                + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
-                            )
-                        kernel_B(j) = kernel_B(j) - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
-                            / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-b) * &
-                            (&
-                                plasma_in%spec(sp)%I01(j, 0) * (&
-                                    bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
-                                    + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
-                                )&
-                                + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
-                            )
+                        kernel_B(j) = kernel_B(j) + hatG_rho_B_diag_sp(plasma_in, sp, kr, j)
 
                         kernel_jphi(j) = kernel_jphi(j) + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * com_unit * plasma_in%spec(sp)%vT(j)**3.0d0 &
                             / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * ks * exp(-b) * &

--- a/KIM/src/asymptotics/FLR2_asymptotics.f90
+++ b/KIM/src/asymptotics/FLR2_asymptotics.f90
@@ -241,8 +241,8 @@ module flr2_asymptotics_m
 
             kernel_phi = kernel_phi / (4.0d0 * pi)
             kernel_B = kernel_B / (4.0d0 * pi)
-            kernel_jphi = kernel_jphi / (4.0d0 * pi)
-            kernel_jB = kernel_jB / (4.0d0 * pi)
+            kernel_jphi = kernel_jphi / (8.0d0 * pi**2)
+            kernel_jB = kernel_jB / (8.0d0 * pi**2)
 
             write(filename, '(A,I0)') "/fields/hatK_Phi_kr", int(kr)
             call write_complex_profile_abs(rg_grid%xb, kernel_phi, rg_grid%npts_b, filename, &

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -12,19 +12,36 @@ module flr2_fourier_kernel_m
     public :: core_rho_phi_sp, core_rho_B_sp
     public :: core_j_phi_sp, core_j_B_sp
     public :: scaled_bessel_pair
+    public :: flr_arg_pair_sp
+    public :: set_global_kernel_approximations
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
-    ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
+    ! the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
     ! the kernel depends only on the radial wavenumbers k_r, k'_r and collapses
     ! exactly to the diagonal source-of-truth calc_hatK_Phi_in_Fourier. The
-    ! .true. path reintroduces k_s^2 via kperp = sqrt(k_s^2 + k_r^2) (see
-    ! hatG_rho_phi) — the canonical form of the recovered kernel_mod.f90.
-    logical, save, public :: kern_include_ks2 = .false.
+    ! optional full form reintroduces k_s^2 via kperp = sqrt(k_s^2 + k_r^2).
+    ! The global FEM kernel drops this contribution before its analytical
+    ! inverse Fourier transform. The full periodic kernel retains it by default.
+    logical, save, public :: kern_include_ks2 = .true.
+
+    ! The global FEM implementation evaluates electron kernels in the zero-FLR
+    ! limit but retains ion FLR. Keep the same approximation in the periodic
+    ! solver only when the optional global-comparison approximation is enabled.
+    logical, save, public :: kern_zero_flr_electrons = .false.
 contains
+    subroutine set_global_kernel_approximations(enabled)
+        ! Select between the full periodic Fourier kernel and the simplified
+        ! kernel used by the global FEM implementation.
+        logical, intent(in) :: enabled
+
+        kern_include_ks2 = .not. enabled
+        kern_zero_flr_electrons = enabled
+    end subroutine set_global_kernel_approximations
+
     subroutine flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
         ! Shared FLR argument pair (b_+, b_x) for the two-wavenumber kernels.
         ! Single home for the kern_include_ks2 branch used by both hatG_rho_phi
-        ! and hatG_rho_B. When .false. (default) the perpendicular wavenumber
+        ! and hatG_rho_B. When .false. the perpendicular wavenumber
         ! k_s is dropped, so the pair depends only on the radial wavenumbers
         ! k_r, k'_r and collapses exactly to the diagonal source-of-truth. The
         ! .true. path reintroduces k_s^2 via kperp = sqrt(k_s^2 + k_r^2), giving
@@ -34,6 +51,12 @@ contains
         real(dp), intent(in) :: kr, krp
         real(dp), intent(out) :: bplus, bcross
         real(dp) :: rho_L2, ks
+
+        if (kern_zero_flr_electrons .and. sp == 0) then
+            bplus = 0.0_dp
+            bcross = 0.0_dp
+            return
+        end if
 
         rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
         if (kern_include_ks2) then
@@ -72,11 +95,10 @@ contains
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber rho-Phi kernel Ghat^{rho Phi}(k_r, k'_r, r_g):
         ! sum the per-species core over the non-turned-off species, then apply
-        ! the Fourier phase exp(i (k_r - k'_r) r_g) and the /(4*pi) source-of-
-        ! truth normalization. On the diagonal k_r = k'_r the FLR pair collapses
-        ! to a single b and the phase is unity, so this equals the diagonal
-        ! integrand summed over species and divided by 4*pi (collapse by
-        ! construction, since the diagonal shares this same core).
+        ! the Fourier phase exp(-i (k_r - k'_r) r_g) and the continuous-kernel
+        ! normalization 1/(8*pi^2). The latter follows directly from the
+        ! Fourier definition K_kk'=(1/2*pi) int dr dr' exp(-ikr) K(r,r')
+        ! exp(ik'r'): a local real-space core/(4*pi) becomes core/(8*pi^2).
         use grid_m, only: rg_grid
         use constants_m, only: pi, com_unit
         use config_m, only: turn_off_ions, turn_off_electrons
@@ -96,16 +118,14 @@ contains
             acc = acc + core_rho_phi_sp(plasma_in, sp, bplus, bcross, j)
         end do
 
-        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) / (4.0d0 * pi) * acc
+        G = exp(-com_unit * (kr - krp) * rg_grid%xb(j)) / (8.0_dp * pi**2) * acc
     end function hatG_rho_phi
 
     complex(dp) function hatG_rho_B(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber rho-B kernel Ghat^{rho B}(k_r, k'_r, r_g): sum the
         ! signed per-species core over the non-turned-off species, then apply the
-        ! Fourier phase exp(i (k_r - k'_r) r_g) and the /(4*pi) source-of-truth
-        ! normalization. On the diagonal k_r = k'_r the FLR pair collapses to a
-        ! single b and the phase is unity, so this equals the diagonal integrand
-        ! summed over species and divided by 4*pi (collapse by construction).
+        ! Fourier phase exp(-i (k_r - k'_r) r_g) and the same 1/(8*pi^2)
+        ! continuous-kernel normalization as rho-Phi.
         ! rho-B has no Debye term (handled inside core_rho_B_sp).
         use grid_m, only: rg_grid
         use constants_m, only: pi, com_unit
@@ -126,22 +146,22 @@ contains
             acc = acc + core_rho_B_sp(plasma_in, sp, bplus, bcross, j)
         end do
 
-        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) / (4.0d0 * pi) * acc
+        G = exp(-com_unit * (kr - krp) * rg_grid%xb(j)) / (8.0_dp * pi**2) * acc
     end function hatG_rho_B
 
     complex(dp) function hatG_j_phi(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber j-Phi kernel Ghat^{jPhi}(k_r, k'_r, r_g): sum the
         ! per-species core over the non-turned-off species, then apply the
-        ! Fourier phase exp(i (k_r - k'_r) r_g). On the diagonal k_r = k'_r the
+        ! Fourier phase exp(-i (k_r - k'_r) r_g). On the diagonal k_r = k'_r the
         ! FLR pair collapses to a single b and the phase is unity, so this equals
         ! the diagonal j-Phi expression of calc_hatK_Phi_in_Fourier summed over
         ! species (thesis 14.5).
         !
-        ! NO /(4*pi), unlike hatG_rho_*: that factor exists there only to cancel
-        ! solve_periodic's Poisson 4*pi. Thesis (11.7) defines
-        ! delta_j_par = K^{jPhi} delta_Phi + K^{jB} delta_Br with no such factor.
+        ! Equations (14.5) and (14.6) give the current kernels the Fourier
+        ! normalization 1/(2^3*pi^2). This factor belongs to the kinetic kernel,
+        ! independently of the 4*pi appearing in Poisson's equation.
         use grid_m, only: rg_grid
-        use constants_m, only: com_unit
+        use constants_m, only: pi, com_unit
         use config_m, only: turn_off_ions, turn_off_electrons
         type(plasma_t), intent(in) :: plasma_in
         real(dp), intent(in) :: kr, krp
@@ -159,19 +179,20 @@ contains
             acc = acc + core_j_phi_sp(plasma_in, sp, bplus, bcross, j)
         end do
 
-        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) * acc
+        G = exp(-com_unit * (kr - krp) * rg_grid%xb(j)) &
+            / (8.0_dp * pi**2) * acc
     end function hatG_j_phi
 
     complex(dp) function hatG_j_B(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber j-B kernel Ghat^{jB}(k_r, k'_r, r_g): sum the
         ! signed per-species core over the non-turned-off species, then apply the
-        ! Fourier phase exp(i (k_r - k'_r) r_g). On the diagonal k_r = k'_r this
+        ! Fourier phase exp(-i (k_r - k'_r) r_g). On the diagonal k_r = k'_r this
         ! equals the diagonal j-B expression of calc_hatK_Phi_in_Fourier summed
         ! over species (thesis 14.6, via I11 = I02 and I13 = I22).
         !
-        ! NO /(4*pi) -- see hatG_j_phi.
+        ! The same 1/(8*pi^2) normalization applies as in hatG_j_phi.
         use grid_m, only: rg_grid
-        use constants_m, only: com_unit
+        use constants_m, only: pi, com_unit
         use config_m, only: turn_off_ions, turn_off_electrons
         type(plasma_t), intent(in) :: plasma_in
         real(dp), intent(in) :: kr, krp
@@ -189,7 +210,8 @@ contains
             acc = acc + core_j_B_sp(plasma_in, sp, bplus, bcross, j)
         end do
 
-        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) * acc
+        G = exp(-com_unit * (kr - krp) * rg_grid%xb(j)) &
+            / (8.0_dp * pi**2) * acc
     end function hatG_j_B
 
     complex(dp) function core_j_phi_sp(plasma_in, sp, bplus, bcross, j) result(G)
@@ -205,7 +227,8 @@ contains
         ! (14.3)-(14.6) all print vT^2, and (14.4)'s was confirmed dimensionally
         ! to be a misprint. The code's powers follow vT^(2+s) throughout.
         !
-        ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
+        ! No phase or Fourier normalization; callers supply both after summing
+        ! species contributions.
         use config_m, only: artificial_debye_case
         use constants_m, only: com_unit
         type(plasma_t), intent(in) :: plasma_in
@@ -241,7 +264,8 @@ contains
         ! B-drive), hence the vT^(2+s) = vT^4 prefactor -- again not the vT^2
         ! printed in (14.6). See core_j_phi_sp.
         !
-        ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
+        ! No phase or Fourier normalization; callers supply both after summing
+        ! species contributions.
         use config_m, only: artificial_debye_case
         use constants_m, only: sol
         type(plasma_t), intent(in) :: plasma_in

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -7,6 +7,7 @@ module flr2_fourier_kernel_m
     implicit none
     private
     public :: hatG_rho_phi, hatG_rho_B
+    public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
 contains
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
         type(plasma_t), intent(in) :: plasma_in
@@ -21,4 +22,67 @@ contains
         integer, intent(in) :: j
         G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
     end function hatG_rho_B
+
+    complex(dp) function hatG_rho_phi_diag_sp(plasma_in, sp, kr, j) result(G)
+        ! Per-species DIAGONAL (single-wavenumber) rho-Phi integrand
+        ! contribution: returns Debye term + FP term = the full per-species
+        ! contribution to kernel_phi_temp. No phase, NO /(4*pi) — the caller
+        ! applies those. Species selection (turn_off_*) stays in the caller.
+        use config_m, only: artificial_debye_case
+        use constants_m, only: com_unit
+        use fortnum_special, only: bessel_in
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr
+        real(dp) :: b
+
+        G = (0.0_dp, 0.0_dp)
+        b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
+
+        if (artificial_debye_case <= 1) then
+            G = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0
+        end if
+
+        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            G = G + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
+                * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * plasma_in%ks(j) &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-b) * &
+                (&
+                    plasma_in%spec(sp)%I00(j, 0) * (&
+                        bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
+                        + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                    )&
+                    + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
+                )
+        end if
+    end function hatG_rho_phi_diag_sp
+
+    complex(dp) function hatG_rho_B_diag_sp(plasma_in, sp, kr, j) result(G)
+        ! Per-species DIAGONAL rho-B integrand contribution: returns the
+        ! SIGNED FP term (i.e. including the leading minus, so callers
+        ! accumulate with '+'). No phase, NO /(4*pi). Species selection
+        ! (turn_off_*) stays in the caller.
+        use config_m, only: artificial_debye_case
+        use constants_m, only: sol
+        use fortnum_special, only: bessel_in
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr
+        real(dp) :: b
+
+        G = (0.0_dp, 0.0_dp)
+        b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
+
+        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            G = G - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-b) * &
+                (&
+                    plasma_in%spec(sp)%I01(j, 0) * (&
+                        bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
+                        + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                    )&
+                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
+                )
+        end if
+    end function hatG_rho_B_diag_sp
 end module flr2_fourier_kernel_m

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -8,12 +8,48 @@ module flr2_fourier_kernel_m
     private
     public :: hatG_rho_phi, hatG_rho_B
     public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
+
+    ! FLR-parameter convention for the two-wavenumber kernel. When .false.
+    ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
+    ! the kernel depends only on the radial wavenumbers k_r, k'_r. The .true.
+    ! path (which reintroduces k_s^2) is implemented in a later task.
+    logical, save, public :: kern_include_ks2 = .false.
 contains
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
+        ! Fused two-wavenumber rho-Phi kernel Ghat^{rho Phi}(k_r, k'_r, r_g):
+        ! sum the per-species core over the non-turned-off species, then apply
+        ! the Fourier phase exp(i (k_r - k'_r) r_g) and the /(4*pi) source-of-
+        ! truth normalization. On the diagonal k_r = k'_r the FLR pair collapses
+        ! to a single b and the phase is unity, so this equals the diagonal
+        ! integrand summed over species and divided by 4*pi (collapse by
+        ! construction, since the diagonal shares this same core).
+        use grid_m, only: rg_grid
+        use constants_m, only: pi, com_unit
+        use config_m, only: turn_off_ions, turn_off_electrons
         type(plasma_t), intent(in) :: plasma_in
         real(dp), intent(in) :: kr, krp
         integer, intent(in) :: j
-        G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
+        integer :: sp
+        real(dp) :: rho_L2, bplus, bcross
+        complex(dp) :: acc
+
+        acc = (0.0_dp, 0.0_dp)
+        do sp = 0, plasma_in%n_species - 1
+            if (turn_off_ions .and. sp >= 1) cycle
+            if (turn_off_electrons .and. sp == 0) cycle
+
+            if (kern_include_ks2) then
+                error stop 'hatG_rho_phi: kern_include_ks2=.true. path not implemented yet (Task 3b)'
+            else
+                rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
+                bplus = rho_L2 * (kr**2.0d0 + krp**2.0d0) / 2.0d0
+                bcross = rho_L2 * abs(kr * krp)
+            end if
+
+            acc = acc + core_rho_phi_sp(plasma_in, sp, bplus, bcross, j)
+        end do
+
+        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) / (4.0d0 * pi) * acc
     end function hatG_rho_phi
 
     complex(dp) function hatG_rho_B(plasma_in, kr, krp, j) result(G)
@@ -23,21 +59,24 @@ contains
         G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
     end function hatG_rho_B
 
-    complex(dp) function hatG_rho_phi_diag_sp(plasma_in, sp, kr, j) result(G)
-        ! Per-species DIAGONAL (single-wavenumber) rho-Phi integrand
-        ! contribution: returns Debye term + FP term = the full per-species
-        ! contribution to kernel_phi_temp. No phase, NO /(4*pi) — the caller
-        ! applies those. Species selection (turn_off_*) stays in the caller.
+    complex(dp) function core_rho_phi_sp(plasma_in, sp, bplus, bcross, j) result(G)
+        ! Per-species rho-Phi core (Debye + FP) parameterized by the FLR
+        ! argument pair (b_+, b_x). This is the single home for the rho-Phi
+        ! integrand math: the diagonal integrand calls it with bplus=bcross=b,
+        ! and the fused two-wavenumber kernel calls it with the off-diagonal
+        ! pair. b_+ scales exp(-b) and the (1 - b) polynomial factor; b_x is the
+        ! argument (and the leading multiplier) of the modified Bessel terms.
+        ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
         use config_m, only: artificial_debye_case
         use constants_m, only: com_unit
         use fortnum_special, only: bessel_in
         type(plasma_t), intent(in) :: plasma_in
         integer, intent(in) :: sp, j
-        real(dp), intent(in) :: kr
-        real(dp) :: b
+        real(dp), intent(in) :: bplus, bcross
+        real(dp) :: ks
 
         G = (0.0_dp, 0.0_dp)
-        b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
+        ks = plasma_in%ks(j)
 
         if (artificial_debye_case <= 1) then
             G = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0
@@ -45,16 +84,32 @@ contains
 
         if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
             G = G + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
-                * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * plasma_in%ks(j) &
-                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-b) * &
+                * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * ks &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-bplus) * &
                 (&
                     plasma_in%spec(sp)%I00(j, 0) * (&
-                        bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
-                        + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                        bessel_in(0, bcross) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * bessel_in(-1, bcross) &
                     )&
-                    + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
+                    + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, bcross) &
                 )
         end if
+    end function core_rho_phi_sp
+
+    complex(dp) function hatG_rho_phi_diag_sp(plasma_in, sp, kr, j) result(G)
+        ! Per-species DIAGONAL (single-wavenumber) rho-Phi integrand
+        ! contribution: returns Debye term + FP term = the full per-species
+        ! contribution to kernel_phi_temp. No phase, NO /(4*pi) — the caller
+        ! applies those. Species selection (turn_off_*) stays in the caller.
+        ! Delegates to core_rho_phi_sp with b_+ = b_x = b so the diagonal math
+        ! is single-homed.
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr
+        real(dp) :: b
+
+        b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
+        G = core_rho_phi_sp(plasma_in, sp, b, b, j)
     end function hatG_rho_phi_diag_sp
 
     complex(dp) function hatG_rho_B_diag_sp(plasma_in, sp, kr, j) result(G)

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -7,8 +7,10 @@ module flr2_fourier_kernel_m
     implicit none
     private
     public :: hatG_rho_phi, hatG_rho_B
+    public :: hatG_j_phi, hatG_j_B
     public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
     public :: core_rho_phi_sp, core_rho_B_sp
+    public :: core_j_phi_sp, core_j_B_sp
     public :: scaled_bessel_pair
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
@@ -126,6 +128,143 @@ contains
 
         G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) / (4.0d0 * pi) * acc
     end function hatG_rho_B
+
+    complex(dp) function hatG_j_phi(plasma_in, kr, krp, j) result(G)
+        ! Fused two-wavenumber j-Phi kernel Ghat^{jPhi}(k_r, k'_r, r_g): sum the
+        ! per-species core over the non-turned-off species, then apply the
+        ! Fourier phase exp(i (k_r - k'_r) r_g). On the diagonal k_r = k'_r the
+        ! FLR pair collapses to a single b and the phase is unity, so this equals
+        ! the diagonal j-Phi expression of calc_hatK_Phi_in_Fourier summed over
+        ! species (thesis 14.5).
+        !
+        ! NO /(4*pi), unlike hatG_rho_*: that factor exists there only to cancel
+        ! solve_periodic's Poisson 4*pi. Thesis (11.7) defines
+        ! delta_j_par = K^{jPhi} delta_Phi + K^{jB} delta_Br with no such factor.
+        use grid_m, only: rg_grid
+        use constants_m, only: com_unit
+        use config_m, only: turn_off_ions, turn_off_electrons
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        integer :: sp
+        real(dp) :: bplus, bcross
+        complex(dp) :: acc
+
+        acc = (0.0_dp, 0.0_dp)
+        do sp = 0, plasma_in%n_species - 1
+            if (turn_off_ions .and. sp >= 1) cycle
+            if (turn_off_electrons .and. sp == 0) cycle
+
+            call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+            acc = acc + core_j_phi_sp(plasma_in, sp, bplus, bcross, j)
+        end do
+
+        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) * acc
+    end function hatG_j_phi
+
+    complex(dp) function hatG_j_B(plasma_in, kr, krp, j) result(G)
+        ! Fused two-wavenumber j-B kernel Ghat^{jB}(k_r, k'_r, r_g): sum the
+        ! signed per-species core over the non-turned-off species, then apply the
+        ! Fourier phase exp(i (k_r - k'_r) r_g). On the diagonal k_r = k'_r this
+        ! equals the diagonal j-B expression of calc_hatK_Phi_in_Fourier summed
+        ! over species (thesis 14.6, via I11 = I02 and I13 = I22).
+        !
+        ! NO /(4*pi) -- see hatG_j_phi.
+        use grid_m, only: rg_grid
+        use constants_m, only: com_unit
+        use config_m, only: turn_off_ions, turn_off_electrons
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        integer :: sp
+        real(dp) :: bplus, bcross
+        complex(dp) :: acc
+
+        acc = (0.0_dp, 0.0_dp)
+        do sp = 0, plasma_in%n_species - 1
+            if (turn_off_ions .and. sp >= 1) cycle
+            if (turn_off_electrons .and. sp == 0) cycle
+
+            call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+            acc = acc + core_j_B_sp(plasma_in, sp, bplus, bcross, j)
+        end do
+
+        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) * acc
+    end function hatG_j_B
+
+    complex(dp) function core_j_phi_sp(plasma_in, sp, bplus, bcross, j) result(G)
+        ! Per-species j-Phi core (FP only, NO Debye term) parameterized by the
+        ! FLR argument pair (b_+, b_x). Shares the skeleton of core_rho_phi_sp;
+        ! only the moment pair and the prefactor differ.
+        !
+        ! Moments (I01, I21) per thesis (14.5). j-Phi and rho-B legitimately
+        ! SHARE moments: the pair is (I^{0s}, I^{2s}) with s = moment power +
+        ! drive power, and both have s = 1. This is not a copy-paste artifact.
+        !
+        ! The prefactor carries vT^3 = vT^(2+s), not the vT^2 printed in (14.5):
+        ! (14.3)-(14.6) all print vT^2, and (14.4)'s was confirmed dimensionally
+        ! to be a misprint. The code's powers follow vT^(2+s) throughout.
+        !
+        ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
+        use config_m, only: artificial_debye_case
+        use constants_m, only: com_unit
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: bplus, bcross
+        real(dp) :: ks, sI0, sIm1
+
+        G = (0.0_dp, 0.0_dp)
+        ks = plasma_in%ks(j)
+
+        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
+            G = 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
+                * com_unit * plasma_in%spec(sp)%vT(j)**3.0d0 * ks &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * &
+                (&
+                    plasma_in%spec(sp)%I01(j, 0) * (&
+                        sI0 * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * sIm1 &
+                    )&
+                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * sI0 &
+                )
+        end if
+    end function core_j_phi_sp
+
+    complex(dp) function core_j_B_sp(plasma_in, sp, bplus, bcross, j) result(G)
+        ! Per-species j-B core (SIGNED FP term, NO Debye) parameterized by the
+        ! FLR argument pair (b_+, b_x). Carries the leading minus, so callers
+        ! accumulate with '+'.
+        !
+        ! Moments (I11, I13) = thesis (14.6)'s (I02, I22) via the susceptibility
+        ! identities I11 = I02 and I13 = I22. s = 2 here (first moment in u_par,
+        ! B-drive), hence the vT^(2+s) = vT^4 prefactor -- again not the vT^2
+        ! printed in (14.6). See core_j_phi_sp.
+        !
+        ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
+        use config_m, only: artificial_debye_case
+        use constants_m, only: sol
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: bplus, bcross
+        real(dp) :: sI0, sIm1
+
+        G = (0.0_dp, 0.0_dp)
+
+        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
+            G = - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
+                * plasma_in%spec(sp)%vT(j)**4.0d0 &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * &
+                (&
+                    plasma_in%spec(sp)%I11(j, 0) * (&
+                        sI0 * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * sIm1 &
+                    )&
+                    + 0.5d0 * plasma_in%spec(sp)%I13(j, 0) * plasma_in%spec(sp)%A2(j) * sI0 &
+                )
+        end if
+    end function core_j_B_sp
 
     complex(dp) function core_rho_phi_sp(plasma_in, sp, bplus, bcross, j) result(G)
         ! Per-species rho-Phi core (Debye + FP) parameterized by the FLR

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -1,0 +1,24 @@
+module flr2_fourier_kernel_m
+    ! Fused Fokker-Planck off-diagonal Fourier-space kernel integrand
+    ! G(k_r, k'_r, r_g) for the forced-periodicity solver. Collapses to the
+    ! diagonal source-of-truth calc_hatK_Phi_in_Fourier at k_r = k'_r.
+    use KIM_kinds_m, only: dp
+    use species_m, only: plasma_t
+    implicit none
+    private
+    public :: hatG_rho_phi, hatG_rho_B
+contains
+    complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
+    end function hatG_rho_phi
+
+    complex(dp) function hatG_rho_B(plasma_in, kr, krp, j) result(G)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
+    end function hatG_rho_B
+end module flr2_fourier_kernel_m

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -8,6 +8,7 @@ module flr2_fourier_kernel_m
     private
     public :: hatG_rho_phi, hatG_rho_B
     public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
+    public :: core_rho_phi_sp
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
     ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
@@ -30,7 +31,7 @@ contains
         real(dp), intent(in) :: kr, krp
         integer, intent(in) :: j
         integer :: sp
-        real(dp) :: rho_L2, bplus, bcross
+        real(dp) :: rho_L2, ks, bplus, bcross
         complex(dp) :: acc
 
         acc = (0.0_dp, 0.0_dp)
@@ -38,10 +39,15 @@ contains
             if (turn_off_ions .and. sp >= 1) cycle
             if (turn_off_electrons .and. sp == 0) cycle
 
+            rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
             if (kern_include_ks2) then
-                error stop 'hatG_rho_phi: kern_include_ks2=.true. path not implemented yet (Task 3b)'
+                ! k_s^2-inclusive FLR: the perpendicular wavenumbers are
+                ! kperp = sqrt(k_s^2 + k_r^2), kperpp = sqrt(k_s^2 + k'_r^2), so
+                ! b_+ = rho_L^2/2 (kperp^2 + kperpp^2) and b_x = rho_L^2 kperp kperpp.
+                ks = plasma_in%ks(j)
+                bplus = rho_L2 * (2.0d0 * ks**2 + kr**2 + krp**2) / 2.0d0
+                bcross = rho_L2 * sqrt(ks**2 + kr**2) * sqrt(ks**2 + krp**2)
             else
-                rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
                 bplus = rho_L2 * (kr**2.0d0 + krp**2.0d0) / 2.0d0
                 bcross = rho_L2 * abs(kr * krp)
             end if

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -12,8 +12,10 @@ module flr2_fourier_kernel_m
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
     ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
-    ! the kernel depends only on the radial wavenumbers k_r, k'_r. The .true.
-    ! path (which reintroduces k_s^2) is implemented in a later task.
+    ! the kernel depends only on the radial wavenumbers k_r, k'_r and collapses
+    ! exactly to the diagonal source-of-truth calc_hatK_Phi_in_Fourier. The
+    ! .true. path reintroduces k_s^2 via kperp = sqrt(k_s^2 + k_r^2) (see
+    ! hatG_rho_phi) — the canonical form of the recovered kernel_mod.f90.
     logical, save, public :: kern_include_ks2 = .false.
 contains
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -9,6 +9,7 @@ module flr2_fourier_kernel_m
     public :: hatG_rho_phi, hatG_rho_B
     public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
     public :: core_rho_phi_sp, core_rho_B_sp
+    public :: scaled_bessel_pair
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
     ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
@@ -42,6 +43,29 @@ contains
             bcross = rho_L2 * abs(kr * krp)
         end if
     end subroutine flr_arg_pair_sp
+
+    subroutine scaled_bessel_pair(bplus, bcross, sI0, sIm1)
+        ! Overflow-safe scaled modified Bessel products:
+        !   sI0  = exp(-bplus) * I_0(bcross)
+        !   sIm1 = exp(-bplus) * I_{-1}(bcross)
+        ! For large bcross the unscaled I_n(bcross) would overflow before the
+        ! exp(-bplus) damping (b_+ >= b_x by construction), so use the large-
+        ! argument asymptotics (lifted from the recovered kernel_mod.f90).
+        use fortnum_special, only: bessel_in
+        real(dp), intent(in) :: bplus, bcross
+        real(dp), intent(out) :: sI0, sIm1
+        real(dp), parameter :: asymptotic_threshold = 500.0d0  ! safely below the ~710 I_0 overflow
+        real(dp), parameter :: twopi = 6.283185307179586d0
+
+        if (bcross > asymptotic_threshold) then
+            sI0  = exp(bcross - bplus) / sqrt(twopi * bcross)
+            sIm1 = exp(-bplus + asinh(-1.0d0/bcross) + bcross*sqrt(1.0d0 + 1.0d0/bcross**2)) &
+                   / sqrt(twopi * bcross * sqrt(1.0d0 + 1.0d0/bcross**2))
+        else
+            sI0  = exp(-bplus) * bessel_in(0, bcross)
+            sIm1 = exp(-bplus) * bessel_in(-1, bcross)
+        end if
+    end subroutine scaled_bessel_pair
 
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber rho-Phi kernel Ghat^{rho Phi}(k_r, k'_r, r_g):
@@ -113,11 +137,10 @@ contains
         ! No phase, NO /(4*pi); species selection (turn_off_*) stays in callers.
         use config_m, only: artificial_debye_case
         use constants_m, only: com_unit
-        use fortnum_special, only: bessel_in
         type(plasma_t), intent(in) :: plasma_in
         integer, intent(in) :: sp, j
         real(dp), intent(in) :: bplus, bcross
-        real(dp) :: ks
+        real(dp) :: ks, sI0, sIm1
 
         G = (0.0_dp, 0.0_dp)
         ks = plasma_in%ks(j)
@@ -127,15 +150,16 @@ contains
         end if
 
         if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
             G = G + 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 &
                 * com_unit * plasma_in%spec(sp)%vT(j)**2.0d0 * ks &
-                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * exp(-bplus) * &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j)) * &
                 (&
                     plasma_in%spec(sp)%I00(j, 0) * (&
-                        bessel_in(0, bcross) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
-                        + plasma_in%spec(sp)%A2(j) * bcross * bessel_in(-1, bcross) &
+                        sI0 * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * sIm1 &
                     )&
-                    + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, bcross) &
+                    + 0.5d0 * plasma_in%spec(sp)%I20(j, 0) * plasma_in%spec(sp)%A2(j) * sI0 &
                 )
         end if
     end function core_rho_phi_sp
@@ -151,22 +175,23 @@ contains
         ! NO /(4*pi); species selection (turn_off_*) stays in callers.
         use config_m, only: artificial_debye_case
         use constants_m, only: sol
-        use fortnum_special, only: bessel_in
         type(plasma_t), intent(in) :: plasma_in
         integer, intent(in) :: sp, j
         real(dp), intent(in) :: bplus, bcross
+        real(dp) :: sI0, sIm1
 
         G = (0.0_dp, 0.0_dp)
 
         if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
             G = G - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
-                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-bplus) * &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * &
                 (&
                     plasma_in%spec(sp)%I01(j, 0) * (&
-                        bessel_in(0, bcross) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
-                        + plasma_in%spec(sp)%A2(j) * bcross * bessel_in(-1, bcross) &
+                        sI0 * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * sIm1 &
                     )&
-                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, bcross) &
+                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * sI0 &
                 )
         end if
     end function core_rho_B_sp

--- a/KIM/src/asymptotics/flr2_fourier_kernel.f90
+++ b/KIM/src/asymptotics/flr2_fourier_kernel.f90
@@ -8,7 +8,7 @@ module flr2_fourier_kernel_m
     private
     public :: hatG_rho_phi, hatG_rho_B
     public :: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
-    public :: core_rho_phi_sp
+    public :: core_rho_phi_sp, core_rho_B_sp
 
     ! FLR-parameter convention for the two-wavenumber kernel. When .false.
     ! (default) the perpendicular wavenumber k_s is dropped from b_+ / b_x, so
@@ -18,6 +18,31 @@ module flr2_fourier_kernel_m
     ! hatG_rho_phi) — the canonical form of the recovered kernel_mod.f90.
     logical, save, public :: kern_include_ks2 = .false.
 contains
+    subroutine flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+        ! Shared FLR argument pair (b_+, b_x) for the two-wavenumber kernels.
+        ! Single home for the kern_include_ks2 branch used by both hatG_rho_phi
+        ! and hatG_rho_B. When .false. (default) the perpendicular wavenumber
+        ! k_s is dropped, so the pair depends only on the radial wavenumbers
+        ! k_r, k'_r and collapses exactly to the diagonal source-of-truth. The
+        ! .true. path reintroduces k_s^2 via kperp = sqrt(k_s^2 + k_r^2), giving
+        ! b_+ = rho_L^2/2 (kperp^2 + kperpp^2) and b_x = rho_L^2 kperp kperpp.
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr, krp
+        real(dp), intent(out) :: bplus, bcross
+        real(dp) :: rho_L2, ks
+
+        rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
+        if (kern_include_ks2) then
+            ks = plasma_in%ks(j)
+            bplus = rho_L2 * (2.0d0 * ks**2 + kr**2 + krp**2) / 2.0d0
+            bcross = rho_L2 * sqrt(ks**2 + kr**2) * sqrt(ks**2 + krp**2)
+        else
+            bplus = rho_L2 * (kr**2 + krp**2) / 2.0d0
+            bcross = rho_L2 * abs(kr * krp)
+        end if
+    end subroutine flr_arg_pair_sp
+
     complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
         ! Fused two-wavenumber rho-Phi kernel Ghat^{rho Phi}(k_r, k'_r, r_g):
         ! sum the per-species core over the non-turned-off species, then apply
@@ -33,7 +58,7 @@ contains
         real(dp), intent(in) :: kr, krp
         integer, intent(in) :: j
         integer :: sp
-        real(dp) :: rho_L2, ks, bplus, bcross
+        real(dp) :: bplus, bcross
         complex(dp) :: acc
 
         acc = (0.0_dp, 0.0_dp)
@@ -41,19 +66,7 @@ contains
             if (turn_off_ions .and. sp >= 1) cycle
             if (turn_off_electrons .and. sp == 0) cycle
 
-            rho_L2 = plasma_in%spec(sp)%rho_L(j)**2.0d0
-            if (kern_include_ks2) then
-                ! k_s^2-inclusive FLR: the perpendicular wavenumbers are
-                ! kperp = sqrt(k_s^2 + k_r^2), kperpp = sqrt(k_s^2 + k'_r^2), so
-                ! b_+ = rho_L^2/2 (kperp^2 + kperpp^2) and b_x = rho_L^2 kperp kperpp.
-                ks = plasma_in%ks(j)
-                bplus = rho_L2 * (2.0d0 * ks**2 + kr**2 + krp**2) / 2.0d0
-                bcross = rho_L2 * sqrt(ks**2 + kr**2) * sqrt(ks**2 + krp**2)
-            else
-                bplus = rho_L2 * (kr**2.0d0 + krp**2.0d0) / 2.0d0
-                bcross = rho_L2 * abs(kr * krp)
-            end if
-
+            call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
             acc = acc + core_rho_phi_sp(plasma_in, sp, bplus, bcross, j)
         end do
 
@@ -61,10 +74,33 @@ contains
     end function hatG_rho_phi
 
     complex(dp) function hatG_rho_B(plasma_in, kr, krp, j) result(G)
+        ! Fused two-wavenumber rho-B kernel Ghat^{rho B}(k_r, k'_r, r_g): sum the
+        ! signed per-species core over the non-turned-off species, then apply the
+        ! Fourier phase exp(i (k_r - k'_r) r_g) and the /(4*pi) source-of-truth
+        ! normalization. On the diagonal k_r = k'_r the FLR pair collapses to a
+        ! single b and the phase is unity, so this equals the diagonal integrand
+        ! summed over species and divided by 4*pi (collapse by construction).
+        ! rho-B has no Debye term (handled inside core_rho_B_sp).
+        use grid_m, only: rg_grid
+        use constants_m, only: pi, com_unit
+        use config_m, only: turn_off_ions, turn_off_electrons
         type(plasma_t), intent(in) :: plasma_in
         real(dp), intent(in) :: kr, krp
         integer, intent(in) :: j
-        G = (0.0_dp, 0.0_dp)   ! stub — replaced in a later task
+        integer :: sp
+        real(dp) :: bplus, bcross
+        complex(dp) :: acc
+
+        acc = (0.0_dp, 0.0_dp)
+        do sp = 0, plasma_in%n_species - 1
+            if (turn_off_ions .and. sp >= 1) cycle
+            if (turn_off_electrons .and. sp == 0) cycle
+
+            call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+            acc = acc + core_rho_B_sp(plasma_in, sp, bplus, bcross, j)
+        end do
+
+        G = exp(com_unit * (kr - krp) * rg_grid%xb(j)) / (4.0d0 * pi) * acc
     end function hatG_rho_B
 
     complex(dp) function core_rho_phi_sp(plasma_in, sp, bplus, bcross, j) result(G)
@@ -104,6 +140,37 @@ contains
         end if
     end function core_rho_phi_sp
 
+    complex(dp) function core_rho_B_sp(plasma_in, sp, bplus, bcross, j) result(G)
+        ! Per-species rho-B core (SIGNED FP term) parameterized by the FLR
+        ! argument pair (b_+, b_x). Single home for the rho-B integrand math:
+        ! the diagonal integrand calls it with bplus=bcross=b, and the fused
+        ! two-wavenumber kernel calls it with the off-diagonal pair. b_+ scales
+        ! exp(-b) and the (1 - b) polynomial factor; b_x is the argument (and the
+        ! leading multiplier) of the modified Bessel terms. rho-B carries the
+        ! leading minus, so callers accumulate with '+'. NO Debye term, no phase,
+        ! NO /(4*pi); species selection (turn_off_*) stays in callers.
+        use config_m, only: artificial_debye_case
+        use constants_m, only: sol
+        use fortnum_special, only: bessel_in
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: bplus, bcross
+
+        G = (0.0_dp, 0.0_dp)
+
+        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+            G = G - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
+                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-bplus) * &
+                (&
+                    plasma_in%spec(sp)%I01(j, 0) * (&
+                        bessel_in(0, bcross) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-bplus)) &
+                        + plasma_in%spec(sp)%A2(j) * bcross * bessel_in(-1, bcross) &
+                    )&
+                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, bcross) &
+                )
+        end if
+    end function core_rho_B_sp
+
     complex(dp) function hatG_rho_phi_diag_sp(plasma_in, sp, kr, j) result(G)
         ! Per-species DIAGONAL (single-wavenumber) rho-Phi integrand
         ! contribution: returns Debye term + FP term = the full per-species
@@ -124,28 +191,14 @@ contains
         ! Per-species DIAGONAL rho-B integrand contribution: returns the
         ! SIGNED FP term (i.e. including the leading minus, so callers
         ! accumulate with '+'). No phase, NO /(4*pi). Species selection
-        ! (turn_off_*) stays in the caller.
-        use config_m, only: artificial_debye_case
-        use constants_m, only: sol
-        use fortnum_special, only: bessel_in
+        ! (turn_off_*) stays in the caller. Delegates to core_rho_B_sp with
+        ! b_+ = b_x = b so the diagonal math is single-homed.
         type(plasma_t), intent(in) :: plasma_in
         integer, intent(in) :: sp, j
         real(dp), intent(in) :: kr
         real(dp) :: b
 
-        G = (0.0_dp, 0.0_dp)
         b = (kr**2.0d0) * plasma_in%spec(sp)%rho_L(j)**2.0d0
-
-        if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
-            G = G - 1.0d0 / plasma_in%spec(sp)%lambda_D(j)**2.0d0 * plasma_in%spec(sp)%vT(j)**3.0d0 &
-                / (plasma_in%spec(sp)%omega_c(j) * plasma_in%spec(sp)%nu(j) * sol) * exp(-b) * &
-                (&
-                    plasma_in%spec(sp)%I01(j, 0) * (&
-                        bessel_in(0, b) * (plasma_in%spec(sp)%A1(j) + plasma_in%spec(sp)%A2(j) * (1-b)) &
-                        + plasma_in%spec(sp)%A2(j) * b * bessel_in(-1, b) &
-                    )&
-                    + 0.5d0 * plasma_in%spec(sp)%I21(j, 0) * plasma_in%spec(sp)%A2(j) * bessel_in(0, b) &
-                )
-        end if
+        G = core_rho_B_sp(plasma_in, sp, b, b, j)
     end function hatG_rho_B_diag_sp
 end module flr2_fourier_kernel_m

--- a/KIM/src/background_equilibrium/calculate_equil.f90
+++ b/KIM/src/background_equilibrium/calculate_equil.f90
@@ -26,7 +26,7 @@ module equilibrium_m
 
     contains
 
-        subroutine calculate_equil(write_out)
+        subroutine calculate_equil(write_out, u0_seed)
         ! Calculate the magnetic field and current equilibrium from the input profiles.
         ! The force-balance equation for B0z is a scalar first-order ODE du/dr;
         ! it is integrated over the monotone radial grid with the fortnum
@@ -36,6 +36,15 @@ module equilibrium_m
         ! state to r_grid(i) (the SLATEC INFO(1)=1 restart), with the integration
         ! barred from stepping past r_grid(end) (the SLATEC RWORK(1)/INFO(4)=1
         ! tstop bound).
+        !
+        ! u0_seed (optional): initial value u(r_grid(1)) = B0(r_grid(1))**2 for the
+        ! force-balance ODE. When absent, the pressureless (vacuum) approximation
+        ! u0 = btor**2*(1 + r0**2/(R0**2 q0**2)) is used, which is accurate only
+        ! when r_grid(1) is near the axis. Callers that redirect the solve onto a
+        ! sub-window far from the axis (e.g. build_periodic_plasma) must pass the
+        ! true B0(r_grid(1))**2 so the accumulated pressure work from the global
+        ! domain is not lost and the absolute B0 level (hence omega_c, rho_L)
+        ! matches the global solve.
 
             use species_m, only: plasma, calc_plasma_parameter_derivs
             use constants_m, only: ev, pi, sol
@@ -49,6 +58,7 @@ module equilibrium_m
             implicit none
 
             logical, intent(in) :: write_out
+            real(dp), intent(in), optional :: u0_seed
 
             real(dp), allocatable :: u_seg(:)
             real(dp) :: rstop
@@ -91,7 +101,11 @@ module equilibrium_m
             dpress_prof = dpress_prof * ev
 
             radius0 = plasma%r_grid(1)
-            u0 = btor**2.0d0 * (1.0d0 + radius0**2.0d0 / (R0**2.0d0 * plasma%q(1)**2.0d0)) ! initial value
+            if (present(u0_seed)) then
+                u0 = u0_seed ! u = B0**2; caller supplies true B0(r_grid(1))**2
+            else
+                u0 = btor**2.0d0 * (1.0d0 + radius0**2.0d0 / (R0**2.0d0 * plasma%q(1)**2.0d0)) ! vacuum initial value
+            end if
             u(1) = u0
 
             ! Seed the re-entrant integrator at the inner grid point, then carry

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -41,36 +41,50 @@ module periodic_background_m
     !> (kim_geom_aperfuns) read the cache, makes repeated calls exactly correct:
     !> every call periodizes the SAME true background.
     !>
+    !> AUTO-INVALIDATION: the cache records the species_m::profiles_generation it
+    !> was captured at (cached_generation). set_profiles_from_arrays bumps that
+    !> counter on every profile swap (new case / time step / parameter-scan point),
+    !> so capture_true_background re-captures whenever the generations differ. This
+    !> means a second case in the same process gets a FRESH capture of ITS true
+    !> background -- no silent staleness -- without species_m having to know about
+    !> this cache (which would create a circular module dependency). No manual
+    !> reset is needed after set_profiles_from_arrays.
+    !>
     !> Order in cache_prim: [ n_e, Te, Ti, q, Er ]  (matches kim_aperfuns).
     !> Order in cache_geom: [ B0, ks, kp, om_E ]     (matches kim_geom_aperfuns).
-    logical, save :: cache_ready = .false.
+    integer, save :: cached_generation = -1
     real(dp), allocatable, save :: cache_r(:)
     real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, n_primitives)
     real(dp), allocatable, save :: cache_geom(:, :)   ! (grid_size, n_geom)
 
 contains
 
-    !> Clear the cached true background so the NEXT build_periodic_plasma call
-    !> re-captures it from the current global plasma. Call this whenever the
-    !> global profiles change (e.g. a new time step / a fresh set_profiles_from_
-    !> arrays) so the periodic window tracks the updated background.
+    !> Force the cached true background to be re-captured on the next
+    !> capture_true_background call. Not needed for correctness -- invalidation is
+    !> automatic via species_m::profiles_generation (see the cache header) -- but
+    !> kept for callers that want to drop the snapshot explicitly.
     subroutine reset_true_background_cache()
-        cache_ready = .false.
+        cached_generation = -1
         if (allocated(cache_r))    deallocate(cache_r)
         if (allocated(cache_prim)) deallocate(cache_prim)
         if (allocated(cache_geom)) deallocate(cache_geom)
     end subroutine reset_true_background_cache
 
     !> Capture the TRUE background (r-grid, primitives, geometry) from the global
-    !> plasma into the module cache, ONCE. No-op if already cached. Must be called
-    !> while `plasma` still holds the true global-grid background (i.e. at the top
-    !> of build_periodic_plasma, before the redirect).
+    !> plasma into the module cache. Self-guarding: a no-op while the cache matches
+    !> the current species_m::profiles_generation, and a (re)capture otherwise.
+    !> Must be called while `plasma` still holds the true global-grid background
+    !> (i.e. at the top of build_periodic_plasma, before the redirect).
     subroutine capture_true_background()
-        use species_m, only: plasma
+        use species_m, only: plasma, profiles_generation
 
         integer :: gs, i
 
-        if (cache_ready) return
+        if (cached_generation == profiles_generation) return
+
+        if (allocated(cache_r))    deallocate(cache_r)
+        if (allocated(cache_prim)) deallocate(cache_prim)
+        if (allocated(cache_geom)) deallocate(cache_geom)
 
         gs = plasma%grid_size
         allocate(cache_r(gs), cache_prim(gs, n_primitives), cache_geom(gs, n_geom))
@@ -89,7 +103,7 @@ contains
             cache_geom(i, 4) = plasma%om_E(i)        ! ExB rotation frequency
         end do
 
-        cache_ready = .true.
+        cached_generation = profiles_generation
     end subroutine capture_true_background
 
     !> 4-point Lagrange interpolation of ALL columns of a cached-background table
@@ -141,14 +155,15 @@ contains
         real(dp), intent(in) :: x
         real(dp), intent(out) :: funs(nfuns)
 
-        ! Lazy capture: if this callback is invoked directly (e.g. a unit test
-        ! exercising kim_aperfuns / sample_periodic_primitives without going
-        ! through build_periodic_plasma), populate the cache from the current
-        ! global plasma on first use. MUST happen before cache_prim is passed as
-        ! an argument (passing an unallocated allocatable to an assumed-shape
-        ! dummy is illegal). build_periodic_plasma captures explicitly at its top
-        ! before the redirect, so this is a no-op in the normal solver path.
-        if (.not. cache_ready) call capture_true_background()
+        ! Ensure the cache is fresh for the current profile generation. If this
+        ! callback is invoked directly (e.g. a unit test exercising kim_aperfuns /
+        ! sample_periodic_primitives without going through build_periodic_plasma),
+        ! this captures on first use; it also re-captures if the profiles changed.
+        ! MUST happen before cache_prim is passed as an argument (passing an
+        ! unallocated allocatable to an assumed-shape dummy is illegal).
+        ! capture_true_background self-guards on generation, so it is a cheap
+        ! no-op in the normal solver path (build_periodic_plasma already captured).
+        call capture_true_background()
 
         call interp_cache_row(cache_prim, nfuns, x, funs)
     end subroutine kim_aperfuns
@@ -172,8 +187,8 @@ contains
         real(dp), intent(in) :: x
         real(dp), intent(out) :: funs(nfuns)
 
-        ! Lazy capture before passing cache_geom (see kim_aperfuns note).
-        if (.not. cache_ready) call capture_true_background()
+        ! Ensure a fresh cache before passing cache_geom (see kim_aperfuns note).
+        call capture_true_background()
 
         call interp_cache_row(cache_geom, nfuns, x, funs)
     end subroutine kim_geom_aperfuns

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -103,6 +103,11 @@ contains
     !>
     !> NOTE: this MUTATES the module-global rg_grid and plasma. It is meant to be
     !> called once per forced-periodicity assembly on an independent process.
+    !>
+    !> SIDE EFFECT: not filesystem-side-effect-free. set_plasma_quantities
+    !> unconditionally calls write_species_backs / write_plasma_backs, which
+    !> create output_path//backs/ and write the background profile .dat files
+    !> (rho_L, lambda_D, kp, om_E, ...) for the window plasma.
     subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
         use species_m, only: plasma, set_plasma_quantities, reallocate, &
                              deallocate_plasma_derived
@@ -114,7 +119,7 @@ contains
         real(dp), intent(in) :: rm, dx_asis, dx_tr
         integer, intent(in) :: n_rg
 
-        real(dp) :: L, r_lo, r_hi
+        real(dp) :: L, r_lo, r_hi, u0_seed
         real(dp) :: funs(n_primitives)
         real(dp), allocatable :: r_win(:)
         real(dp), allocatable :: n_win(:), Te_win(:), Ti_win(:), q_win(:), Er_win(:)
@@ -147,6 +152,14 @@ contains
             q_win(j)  = funs(4)
             Er_win(j) = funs(5)
         end do
+
+        ! Capture the TRUE B0 at the window's left edge (still on the global grid
+        ! here) as the force-balance ODE seed u0 = B0(r_lo)**2. Without this the
+        ! window solve restarts from the pressureless vacuum initial condition
+        ! and loses the pressure work accumulated over [r_min, r_lo], offsetting
+        ! the absolute B0 level (hence omega_c, rho_L) by ~O(0.5%). See
+        ! calculate_equil's u0_seed argument.
+        u0_seed = interp_global_B0(r_lo)**2
 
         ! ---- 3. Redirect the plasma onto the window grid. ---------------------
         ! Clear ALL derived state so the recompute chain reallocates cleanly at
@@ -200,18 +213,44 @@ contains
         ! ---- 4./5. Recompute derivatives + all derived quantities. ------------
         ! calculate_equil: recomputes dndr/dTdr/dqdr (via calc_plasma_parameter_
         ! derivs on the equidistant window) and B0, ks, kp, om_E from the
-        ! periodized q/Er and btor/R0/m_mode/n_mode. write_out=.false. keeps this
-        ! side-effect-free (no equilibrium files).
-        call calculate_equil(.false.)
+        ! periodized q/Er and btor/R0/m_mode/n_mode. write_out=.false. suppresses
+        ! only the equilibrium (B0z/B0th/...) file dump; the profile .dat writes
+        ! below (via set_plasma_quantities) still happen -- see SIDE EFFECT note.
+        ! u0_seed carries the true B0(r_lo)**2 so the window B0 level matches the
+        ! global solve (see the capture above).
+        call calculate_equil(.false., u0_seed=u0_seed)
 
         ! set_plasma_quantities: calculate_plasma_backs (vT, nu, omega_c, rho_L,
         ! lambda_D, z0), interpolate_plasma_backs(rg_grid%xb) -- the IDENTITY
-        ! here because plasma%r_grid == rg_grid%xb -- cell centres, and
+        ! here because plasma%r_grid == rg_grid%xb -- cell centres,
         ! calculate_thermodynamic_forces_and_susc (A1, A2, x1, x2, I00..I21) on
-        ! rg_grid%npts_b == the window.
+        ! rg_grid%npts_b == the window, and write_species_backs /
+        ! write_plasma_backs (writes background profile .dat files to
+        ! output_path//backs/).
         call set_plasma_quantities(plasma)
 
     contains
+
+        !> 4-point Lagrange interpolation of the global plasma%B0 at radius x,
+        !> using the same binsrc + plag_coeff stencil as the rest of KIM. Called
+        !> while `plasma` still holds the TRUE global-grid B0 (before redirect).
+        real(dp) function interp_global_B0(x) result(b0x)
+            real(dp), intent(in) :: x
+            integer, parameter :: nlagr = 4, nder = 0
+            real(dp) :: coef(0:nder, nlagr)
+            integer :: gs, ir, ibeg, iend
+
+            gs = plasma%grid_size
+            call binsrc(plasma%r_grid, 1, gs, x, ir)
+            ibeg = max(1, ir - nlagr/2)
+            iend = ibeg + nlagr - 1
+            if (iend > gs) then
+                iend = gs
+                ibeg = iend - nlagr + 1
+            end if
+            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+            b0x = sum(coef(0, :) * plasma%B0(ibeg:iend))
+        end function interp_global_B0
 
         subroutine set_ion_density_quasineutral()
             integer :: total_Z, sp, jj

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -1,0 +1,87 @@
+module periodic_background_m
+    !> Bridges KIM's real background primitives to the vendored forced-periodicity
+    !> utility (periodization_m::make_periodic). Provides:
+    !>   - kim_aperfuns:  an aperfuns_i-conforming callback that samples the TRUE
+    !>                    (aperiodic) primitive profiles of the global `plasma` at
+    !>                    an arbitrary radius,
+    !>   - sample_periodic_primitives: a thin wrapper that returns the PERIODIZED
+    !>                    primitives at a query radius by driving make_periodic.
+    !>
+    !> ORDER CONTRACT (relied upon by Phase-2.3): the five sampled functions are
+    !> returned in the FIXED order
+    !>     funs = [ n_e, Te, Ti, q, Er ].
+    !> Do not reorder without updating every consumer.
+
+    use KIM_kinds_m, only: dp
+    use periodization_m, only: make_periodic
+
+    implicit none
+    private
+
+    public :: kim_aperfuns, sample_periodic_primitives
+
+    !> Number of primitive functions sampled, and their FIXED order.
+    integer, parameter :: n_primitives = 5
+
+contains
+
+    !> Aperiodic sample callback conforming to periodization_m::aperfuns_i.
+    !> Evaluates the TRUE primitive profiles of the global `plasma` at radius x
+    !> via 4-point Lagrange interpolation, in the FIXED order
+    !>     funs = [ n_e(x), Te(x), Ti(x), q(x), Er(x) ].
+    !>
+    !> Clamping: x is clamped to [r_grid(1), r_grid(grid_size)] before
+    !> interpolation, returning the endpoint value for out-of-range x. This is
+    !> required because make_periodic queries x_inperiod +- L, which can fall
+    !> outside the raw profile domain. In the deep as-is / periodic-image regions
+    !> the far images are weighted 0 by the localizer, so clamping is harmless
+    !> there; it only matters inside the transition region.
+    subroutine kim_aperfuns(nfuns, x, funs)
+        use species_m, only: plasma
+
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        real(dp) :: xc
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+
+        ! Clamp query point to the raw profile domain (see header note).
+        xc = max(plasma%r_grid(1), min(x, plasma%r_grid(gs)))
+
+        ! 4-point Lagrange stencil selection (mirrors calculate_equil.f90).
+        call binsrc(plasma%r_grid, 1, gs, xc, ir)
+        ibeg = max(1, ir - nlagr/2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+
+        call plag_coeff(nlagr, nder, xc, plasma%r_grid(ibeg:iend), coef)
+
+        ! FIXED order: [ n_e, Te, Ti, q, Er ] (contract with Phase-2.3).
+        funs(1) = sum(coef(0, :) * plasma%spec(0)%n(ibeg:iend))   ! electron density
+        funs(2) = sum(coef(0, :) * plasma%spec(0)%T(ibeg:iend))   ! electron temperature
+        funs(3) = sum(coef(0, :) * plasma%spec(1)%T(ibeg:iend))   ! ion temperature
+        funs(4) = sum(coef(0, :) * plasma%q(ibeg:iend))           ! safety factor
+        funs(5) = sum(coef(0, :) * plasma%Er(ibeg:iend))          ! radial electric field
+    end subroutine kim_aperfuns
+
+    !> Return the PERIODIZED primitives at query radius x, driving make_periodic
+    !> with kim_aperfuns. Layout: half_period = dx_asis + dx_tr, period
+    !> L = 2*half_period, an as-is core of half-width dx_asis centred on x_mid,
+    !> flanked by transition bands of width dx_tr. Output order matches
+    !> kim_aperfuns: funs_per = [ n_e, Te, Ti, q, Er ].
+    subroutine sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
+        real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
+        real(dp), intent(out) :: funs_per(n_primitives)
+
+        call make_periodic(kim_aperfuns, n_primitives, x_mid, dx_asis, dx_tr, x, funs_per)
+    end subroutine sample_periodic_primitives
+
+end module periodic_background_m

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -19,58 +19,164 @@ module periodic_background_m
     private
 
     public :: kim_aperfuns, sample_periodic_primitives, build_periodic_plasma
+    public :: reset_true_background_cache
 
     !> Number of primitive functions sampled, and their FIXED order.
     integer, parameter :: n_primitives = 5
 
+    !> Number of GEOMETRY functions periodized, and their FIXED order.
+    !>     geom = [ B0, ks, kp, om_E ].
+    integer, parameter :: n_geom = 4
+
+    !> Cached TRUE (aperiodic) background, captured ONCE from the global plasma on
+    !> the FIRST build_periodic_plasma call and reused on every later call.
+    !>
+    !> WHY A CACHE: build_periodic_plasma REDIRECTS the module-global `plasma`
+    !> onto the window on its first call, destroying the true global-grid
+    !> primitives and geometry. The convergence harness then calls it AGAIN (once
+    !> per n_rg) with `plasma` already pointing at the previous window, so a naive
+    !> re-sample of `plasma` would periodize an already-periodized profile. Caching
+    !> the true background r-grid + primitives + geometry on the first call, and
+    !> having BOTH the primitive callback (kim_aperfuns) and the geometry callback
+    !> (kim_geom_aperfuns) read the cache, makes repeated calls exactly correct:
+    !> every call periodizes the SAME true background.
+    !>
+    !> Order in cache_prim: [ n_e, Te, Ti, q, Er ]  (matches kim_aperfuns).
+    !> Order in cache_geom: [ B0, ks, kp, om_E ]     (matches kim_geom_aperfuns).
+    logical, save :: cache_ready = .false.
+    real(dp), allocatable, save :: cache_r(:)
+    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, n_primitives)
+    real(dp), allocatable, save :: cache_geom(:, :)   ! (grid_size, n_geom)
+
 contains
 
-    !> Aperiodic sample callback conforming to periodization_m::aperfuns_i.
-    !> Evaluates the TRUE primitive profiles of the global `plasma` at radius x
-    !> via 4-point Lagrange interpolation, in the FIXED order
-    !>     funs = [ n_e(x), Te(x), Ti(x), q(x), Er(x) ].
-    !>
-    !> Clamping: x is clamped to [r_grid(1), r_grid(grid_size)] before
-    !> interpolation, returning the endpoint value for out-of-range x. This is
-    !> required because make_periodic queries x_inperiod +- L, which can fall
-    !> outside the raw profile domain. In the deep as-is / periodic-image regions
-    !> the far images are weighted 0 by the localizer, so clamping is harmless
-    !> there; it only matters inside the transition region.
-    subroutine kim_aperfuns(nfuns, x, funs)
+    !> Clear the cached true background so the NEXT build_periodic_plasma call
+    !> re-captures it from the current global plasma. Call this whenever the
+    !> global profiles change (e.g. a new time step / a fresh set_profiles_from_
+    !> arrays) so the periodic window tracks the updated background.
+    subroutine reset_true_background_cache()
+        cache_ready = .false.
+        if (allocated(cache_r))    deallocate(cache_r)
+        if (allocated(cache_prim)) deallocate(cache_prim)
+        if (allocated(cache_geom)) deallocate(cache_geom)
+    end subroutine reset_true_background_cache
+
+    !> Capture the TRUE background (r-grid, primitives, geometry) from the global
+    !> plasma into the module cache, ONCE. No-op if already cached. Must be called
+    !> while `plasma` still holds the true global-grid background (i.e. at the top
+    !> of build_periodic_plasma, before the redirect).
+    subroutine capture_true_background()
         use species_m, only: plasma
 
-        integer, intent(in) :: nfuns
-        real(dp), intent(in) :: x
-        real(dp), intent(out) :: funs(nfuns)
+        integer :: gs, i
 
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        real(dp) :: xc
-        integer :: gs, ir, ibeg, iend
+        if (cache_ready) return
 
         gs = plasma%grid_size
+        allocate(cache_r(gs), cache_prim(gs, n_primitives), cache_geom(gs, n_geom))
 
-        ! Clamp query point to the raw profile domain (see header note).
-        xc = max(plasma%r_grid(1), min(x, plasma%r_grid(gs)))
+        cache_r = plasma%r_grid(1:gs)
+        do i = 1, gs
+            cache_prim(i, 1) = plasma%spec(0)%n(i)   ! electron density
+            cache_prim(i, 2) = plasma%spec(0)%T(i)   ! electron temperature
+            cache_prim(i, 3) = plasma%spec(1)%T(i)   ! ion temperature
+            cache_prim(i, 4) = plasma%q(i)           ! safety factor
+            cache_prim(i, 5) = plasma%Er(i)          ! radial electric field
 
-        ! 4-point Lagrange stencil selection (mirrors calculate_equil.f90).
-        call binsrc(plasma%r_grid, 1, gs, xc, ir)
+            cache_geom(i, 1) = plasma%B0(i)          ! equilibrium field magnitude
+            cache_geom(i, 2) = plasma%ks(i)          ! perpendicular wavenumber
+            cache_geom(i, 3) = plasma%kp(i)          ! parallel wavenumber
+            cache_geom(i, 4) = plasma%om_E(i)        ! ExB rotation frequency
+        end do
+
+        cache_ready = .true.
+    end subroutine capture_true_background
+
+    !> 4-point Lagrange interpolation of ALL columns of a cached-background table
+    !> at radius x, using the same binsrc + plag_coeff stencil as the rest of KIM,
+    !> with the query clamped to the cached r-grid domain (see kim_aperfuns header
+    !> note on why clamping is needed and harmless).
+    subroutine interp_cache_row(col_table, ncols, x, out)
+        real(dp), intent(in) :: col_table(:, :)
+        integer, intent(in) :: ncols
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: out(ncols)
+
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr), xc
+        integer :: gs, ir, ibeg, iend, c
+
+        gs = size(cache_r)
+        xc = max(cache_r(1), min(x, cache_r(gs)))
+        call binsrc(cache_r, 1, gs, xc, ir)
         ibeg = max(1, ir - nlagr/2)
         iend = ibeg + nlagr - 1
         if (iend > gs) then
             iend = gs
             ibeg = iend - nlagr + 1
         end if
+        call plag_coeff(nlagr, nder, xc, cache_r(ibeg:iend), coef)
+        do c = 1, ncols
+            out(c) = sum(coef(0, :) * col_table(ibeg:iend, c))
+        end do
+    end subroutine interp_cache_row
 
-        call plag_coeff(nlagr, nder, xc, plasma%r_grid(ibeg:iend), coef)
+    !> Aperiodic sample callback conforming to periodization_m::aperfuns_i.
+    !> Evaluates the TRUE primitive profiles at radius x via 4-point Lagrange
+    !> interpolation of the CACHED true background, in the FIXED order
+    !>     funs = [ n_e(x), Te(x), Ti(x), q(x), Er(x) ].
+    !>
+    !> Reads the module cache (captured once from the global plasma) rather than
+    !> the live `plasma`, so repeated build_periodic_plasma calls (which redirect
+    !> `plasma` onto the window) still periodize the SAME true background.
+    !>
+    !> Clamping: x is clamped to [cache_r(1), cache_r(end)] before interpolation,
+    !> returning the endpoint value for out-of-range x. This is required because
+    !> make_periodic queries x_inperiod +- L, which can fall outside the raw
+    !> profile domain. In the deep as-is / periodic-image regions the far images
+    !> are weighted 0 by the localizer, so clamping is harmless there; it only
+    !> matters inside the transition region.
+    subroutine kim_aperfuns(nfuns, x, funs)
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
 
-        ! FIXED order: [ n_e, Te, Ti, q, Er ] (contract with Phase-2.3).
-        funs(1) = sum(coef(0, :) * plasma%spec(0)%n(ibeg:iend))   ! electron density
-        funs(2) = sum(coef(0, :) * plasma%spec(0)%T(ibeg:iend))   ! electron temperature
-        funs(3) = sum(coef(0, :) * plasma%spec(1)%T(ibeg:iend))   ! ion temperature
-        funs(4) = sum(coef(0, :) * plasma%q(ibeg:iend))           ! safety factor
-        funs(5) = sum(coef(0, :) * plasma%Er(ibeg:iend))          ! radial electric field
+        ! Lazy capture: if this callback is invoked directly (e.g. a unit test
+        ! exercising kim_aperfuns / sample_periodic_primitives without going
+        ! through build_periodic_plasma), populate the cache from the current
+        ! global plasma on first use. MUST happen before cache_prim is passed as
+        ! an argument (passing an unallocated allocatable to an assumed-shape
+        ! dummy is illegal). build_periodic_plasma captures explicitly at its top
+        ! before the redirect, so this is a no-op in the normal solver path.
+        if (.not. cache_ready) call capture_true_background()
+
+        call interp_cache_row(cache_prim, nfuns, x, funs)
     end subroutine kim_aperfuns
+
+    !> Aperiodic sample callback for the equilibrium GEOMETRY, conforming to
+    !> periodization_m::aperfuns_i. Evaluates the TRUE geometry at radius x via
+    !> 4-point Lagrange interpolation of the CACHED true background, in the FIXED
+    !> order
+    !>     funs = [ B0(x), ks(x), kp(x), om_E(x) ].
+    !>
+    !> These carry the explicit 1/r geometric factors (ks, kp, om_E) and the
+    !> force-balance-integrated field (B0), which make_periodic did NOT touch when
+    !> only the primitives n,T,q,Er were periodized. Their true radial variation
+    !> (including 1/r) drifts ~0.3% across one period, so the raw window integrand
+    !> is NOT L-periodic and the periodic-trapezoidal r_g quadrature plateaus.
+    !> Periodizing them here (faithfully: the localizer blends the TRUE profile
+    !> into a C-infinity-periodic window function, keeping the true variation in
+    !> the as-is core) restores integrand periodicity and spectral convergence.
+    subroutine kim_geom_aperfuns(nfuns, x, funs)
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+
+        ! Lazy capture before passing cache_geom (see kim_aperfuns note).
+        if (.not. cache_ready) call capture_true_background()
+
+        call interp_cache_row(cache_geom, nfuns, x, funs)
+    end subroutine kim_geom_aperfuns
 
     !> Return the PERIODIZED primitives at query radius x, driving make_periodic
     !> with kim_aperfuns. Layout: half_period = dx_asis + dx_tr, period
@@ -83,6 +189,16 @@ contains
 
         call make_periodic(kim_aperfuns, n_primitives, x_mid, dx_asis, dx_tr, x, funs_per)
     end subroutine sample_periodic_primitives
+
+    !> Return the PERIODIZED geometry [ B0, ks, kp, om_E ] at query radius x,
+    !> driving make_periodic with kim_geom_aperfuns. Same window layout as
+    !> sample_periodic_primitives.
+    subroutine sample_periodic_geometry(x_mid, dx_asis, dx_tr, x, geom_per)
+        real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
+        real(dp), intent(out) :: geom_per(n_geom)
+
+        call make_periodic(kim_geom_aperfuns, n_geom, x_mid, dx_asis, dx_tr, x, geom_per)
+    end subroutine sample_periodic_geometry
 
     !> Build a fully-populated PERIODIC `plasma` on an equidistant window grid
     !> centred on rm. The window
@@ -109,8 +225,12 @@ contains
     !> create output_path//backs/ and write the background profile .dat files
     !> (rho_L, lambda_D, kp, om_E, ...) for the window plasma.
     subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
-        use species_m, only: plasma, set_plasma_quantities, reallocate, &
-                             deallocate_plasma_derived
+        use species_m, only: plasma, reallocate, deallocate_plasma_derived, &
+                             calc_plasma_parameter_derivs, calculate_plasma_backs, &
+                             interpolate_plasma_backs, compute_rg_cell_centers, &
+                             calculate_thermodynamic_forces_and_susc, &
+                             write_species_backs, write_species_cc_quantities, &
+                             write_plasma_backs
         use equilibrium_m, only: calculate_equil, B0, B0z, B0th, hz, hth, &
                                  equil_grid, u, dpress_prof
         use grid_m, only: rg_grid
@@ -125,6 +245,12 @@ contains
         real(dp), allocatable :: n_win(:), Te_win(:), Ti_win(:), q_win(:), Er_win(:)
         integer :: j, sigma, npts
 
+        ! Capture the TRUE background (r-grid, primitives, geometry) from the
+        ! global plasma ONCE, before any redirect destroys it; all periodization
+        ! (primitives AND geometry) then reads this cache, so repeated calls stay
+        ! correct even though `plasma` is redirected onto the window after call 1.
+        call capture_true_background()
+
         ! ---- 1. Equidistant window grid, reused as the global rg_grid. --------
         L = 2.0_dp * (dx_asis + dx_tr)
         r_lo = rm - 0.5_dp * L
@@ -136,10 +262,9 @@ contains
         call rg_grid%grid_generate_equidistant()
 
         ! ---- 2. Sample the PERIODIZED primitives on the window FIRST. ----------
-        ! kim_aperfuns reads the TRUE (global-grid) primitives of `plasma`, so
-        ! this MUST happen before we redirect `plasma` onto the window (which
-        ! reallocates and thereby destroys those true profiles). Sample into
-        ! temporaries; write them onto the redirected plasma in step 3.
+        ! kim_aperfuns reads the CACHED true primitives (captured above), so this
+        ! is robust to the redirect and to repeated calls. Sample into temporaries;
+        ! write them onto the redirected plasma in step 3.
         ! FIXED order from sample_periodic_primitives: [ n_e, Te, Ti, q, Er ].
         allocate(r_win(rg_grid%npts_b), n_win(rg_grid%npts_b), Te_win(rg_grid%npts_b), &
                  Ti_win(rg_grid%npts_b), q_win(rg_grid%npts_b), Er_win(rg_grid%npts_b))
@@ -153,13 +278,13 @@ contains
             Er_win(j) = funs(5)
         end do
 
-        ! Capture the TRUE B0 at the window's left edge (still on the global grid
-        ! here) as the force-balance ODE seed u0 = B0(r_lo)**2. Without this the
-        ! window solve restarts from the pressureless vacuum initial condition
+        ! Capture the TRUE B0 at the window's left edge (from the cached true
+        ! geometry) as the force-balance ODE seed u0 = B0(r_lo)**2. Without this
+        ! the window solve restarts from the pressureless vacuum initial condition
         ! and loses the pressure work accumulated over [r_min, r_lo], offsetting
         ! the absolute B0 level (hence omega_c, rho_L) by ~O(0.5%). See
         ! calculate_equil's u0_seed argument.
-        u0_seed = interp_global_B0(r_lo)**2
+        u0_seed = interp_cache_B0(r_lo)**2
 
         ! ---- 3. Redirect the plasma onto the window grid. ---------------------
         ! Clear ALL derived state so the recompute chain reallocates cleanly at
@@ -220,37 +345,120 @@ contains
         ! global solve (see the capture above).
         call calculate_equil(.false., u0_seed=u0_seed)
 
-        ! set_plasma_quantities: calculate_plasma_backs (vT, nu, omega_c, rho_L,
-        ! lambda_D, z0), interpolate_plasma_backs(rg_grid%xb) -- the IDENTITY
-        ! here because plasma%r_grid == rg_grid%xb -- cell centres,
-        ! calculate_thermodynamic_forces_and_susc (A1, A2, x1, x2, I00..I21) on
-        ! rg_grid%npts_b == the window, and write_species_backs /
-        ! write_plasma_backs (writes background profile .dat files to
-        ! output_path//backs/).
-        call set_plasma_quantities(plasma)
+        ! ---- 6. Periodize the equilibrium GEOMETRY on the window. --------------
+        ! calculate_equil just wrote B0/ks/kp/om_E on the window with their TRUE
+        ! radial variation -- but that variation (explicit 1/r in ks/kp/om_E, plus
+        ! the force-balance-integrated B0) is NOT L-periodic, so the raw window
+        ! integrand is non-periodic (seam jump ~3e-3 in ks/om_E) and the periodic-
+        ! trapezoidal r_g quadrature plateaus. Overwrite B0/ks/kp/om_E with their
+        ! FAITHFULLY periodized values (make_periodic blends the TRUE geometry into
+        ! a C-infinity-periodic window function; true variation kept in the as-is
+        ! core). Done BEFORE calculate_plasma_backs so omega_c/rho_L (from B0) and
+        ! the susceptibility (x1 from kp, x2 from om_E) inherit the periodicity.
+        call periodize_window_geometry()
+
+        ! Inlined set_plasma_quantities so the Fix-1 periodic-derivative overwrite
+        ! can be injected between calc_plasma_parameter_derivs (which writes dndr/
+        ! dTdr/dqdr with NON-periodic one-sided endpoint FD) and the A1/A2 forming
+        ! in calculate_thermodynamic_forces_and_susc. Steps mirror set_plasma_
+        ! quantities (species_mod.f90): calc_plasma_parameter_derivs -> [FIX 1:
+        ! periodic central-difference dndr/dTdr/dqdr] -> calculate_plasma_backs
+        ! (vT, nu, omega_c, rho_L, lambda_D, z0 -- omega_c/rho_L now from the
+        ! PERIODIZED B0) -> interpolate_plasma_backs(rg_grid%xb) (IDENTITY here
+        ! because plasma%r_grid == rg_grid%xb; Lagrange is exact at nodes so the
+        ! periodized geometry/derivatives survive) -> compute_rg_cell_centers ->
+        ! calculate_thermodynamic_forces_and_susc (A1, A2, x1, x2, I00..I21 from
+        ! the PERIODIZED kp/om_E) -> write_*_backs (profile .dat dumps).
+        call calc_plasma_parameter_derivs
+
+        call make_window_derivs_periodic()
+
+        call calculate_plasma_backs(plasma)
+        call interpolate_plasma_backs(plasma, rg_grid%xb)
+        call compute_rg_cell_centers(plasma)
+        call calculate_thermodynamic_forces_and_susc(plasma)
+
+        do sigma = 0, plasma%n_species - 1
+            call write_species_backs(plasma%spec(sigma), plasma%r_grid)
+            call write_species_cc_quantities(plasma%spec(sigma), rg_grid%xc)
+        end do
+        call write_plasma_backs(plasma, plasma%r_grid)
 
     contains
 
-        !> 4-point Lagrange interpolation of the global plasma%B0 at radius x,
-        !> using the same binsrc + plag_coeff stencil as the rest of KIM. Called
-        !> while `plasma` still holds the TRUE global-grid B0 (before redirect).
-        real(dp) function interp_global_B0(x) result(b0x)
+        !> 4-point Lagrange interpolation of the CACHED true B0 at radius x. Used
+        !> for the force-balance ODE seed u0 = B0(r_lo)**2; reads the cache so it
+        !> is robust to the redirect and to repeated calls.
+        real(dp) function interp_cache_B0(x) result(b0x)
             real(dp), intent(in) :: x
-            integer, parameter :: nlagr = 4, nder = 0
-            real(dp) :: coef(0:nder, nlagr)
-            integer :: gs, ir, ibeg, iend
+            real(dp) :: geom(n_geom)
+            call interp_cache_row(cache_geom, n_geom, x, geom)
+            b0x = geom(1)
+        end function interp_cache_B0
 
-            gs = plasma%grid_size
-            call binsrc(plasma%r_grid, 1, gs, x, ir)
-            ibeg = max(1, ir - nlagr/2)
-            iend = ibeg + nlagr - 1
-            if (iend > gs) then
-                iend = gs
-                ibeg = iend - nlagr + 1
-            end if
-            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-            b0x = sum(coef(0, :) * plasma%B0(ibeg:iend))
-        end function interp_global_B0
+        !> Overwrite the window B0/ks/kp/om_E (and the equilibrium_m B0 array, kept
+        !> consistent for interpolate_plasma_backs / any downstream reader) with
+        !> their make_periodic-periodized values, sampled per window node from the
+        !> cached true geometry. omega_c and rho_L are re-derived from the
+        !> periodized B0 inside calculate_plasma_backs, so periodizing B0 here
+        !> periodizes them too.
+        subroutine periodize_window_geometry()
+            real(dp) :: geom(n_geom)
+            integer :: i
+
+            do i = 1, rg_grid%npts_b
+                call sample_periodic_geometry(rm, dx_asis, dx_tr, rg_grid%xb(i), geom)
+                plasma%B0(i)   = geom(1)
+                plasma%ks(i)   = geom(2)
+                plasma%kp(i)   = geom(3)
+                plasma%om_E(i) = geom(4)
+                if (allocated(B0)) B0(i) = geom(1)
+            end do
+        end subroutine periodize_window_geometry
+
+        !> FIX 1: overwrite the window profile derivatives dndr/dTdr (all species)
+        !> and dqdr with PERIODIC central differences on the equidistant window
+        !> grid, replacing the non-periodic one-sided endpoint FD that
+        !> calc_plasma_parameter_derivs just wrote (without touching that shared
+        !> routine, which the global solver uses).
+        !>
+        !> The window grid rg_grid%xb is equidistant over exactly one period L,
+        !> endpoint-exclusive on the right (xb(i) = r_lo + (i-1)*h, h = L/n_rg, so
+        !> xb(n_rg) = r_hi - h). Because the periodized primitives are L-periodic,
+        !> the point one step left of xb(1) is xb(N) and one step right of xb(N) is
+        !> xb(1); the wrap-around central difference
+        !>     dfdr(i) = (f(i+1) - f(i-1)) / (2 h),  f(0) := f(N), f(N+1) := f(1)
+        !> is exact-to-O(h^2) AND seam-consistent.
+        subroutine make_window_derivs_periodic()
+            real(dp) :: h
+            integer :: sp, N
+
+            N = rg_grid%npts_b
+            if (N < 3) return
+            h = rg_grid%xb(2) - rg_grid%xb(1)   ! = L / n_rg
+
+            do sp = 0, number_of_ion_species
+                call periodic_central_diff(plasma%spec(sp)%n, plasma%spec(sp)%dndr, h, N)
+                call periodic_central_diff(plasma%spec(sp)%T, plasma%spec(sp)%dTdr, h, N)
+            end do
+            call periodic_central_diff(plasma%q, plasma%dqdr, h, N)
+        end subroutine make_window_derivs_periodic
+
+        !> Periodic central difference of an L-periodic array f sampled on an
+        !> equidistant, endpoint-exclusive one-period grid of N points, spacing h.
+        subroutine periodic_central_diff(f, dfdr, h, N)
+            real(dp), intent(in) :: f(:)
+            real(dp), intent(inout) :: dfdr(:)
+            real(dp), intent(in) :: h
+            integer, intent(in) :: N
+            integer :: i
+
+            dfdr(1) = (f(2) - f(N)) / (2.0_dp * h)
+            do i = 2, N - 1
+                dfdr(i) = (f(i+1) - f(i-1)) / (2.0_dp * h)
+            end do
+            dfdr(N) = (f(1) - f(N-1)) / (2.0_dp * h)
+        end subroutine periodic_central_diff
 
         subroutine set_ion_density_quasineutral()
             integer :: total_Z, sp, jj

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -18,7 +18,7 @@ module periodic_background_m
     implicit none
     private
 
-    public :: kim_aperfuns, sample_periodic_primitives
+    public :: kim_aperfuns, sample_periodic_primitives, build_periodic_plasma
 
     !> Number of primitive functions sampled, and their FIXED order.
     integer, parameter :: n_primitives = 5
@@ -83,5 +83,204 @@ contains
 
         call make_periodic(kim_aperfuns, n_primitives, x_mid, dx_asis, dx_tr, x, funs_per)
     end subroutine sample_periodic_primitives
+
+    !> Build a fully-populated PERIODIC `plasma` on an equidistant window grid
+    !> centred on rm. The window
+    !>     [rm - L/2, rm + L/2],   L = 2*(dx_asis + dx_tr),   n_rg boundary pts
+    !> serves as BOTH plasma%r_grid AND the global rg_grid, so the derived-
+    !> quantity recompute (calculate_equil -> set_plasma_quantities) runs on the
+    !> window with NO cross-grid interpolation (interpolate_plasma_backs becomes
+    !> the identity because plasma%r_grid == rg_grid%xb).
+    !>
+    !> On entry the global `plasma` must hold the TRUE (aperiodic) primitives on
+    !> the global grid (as after an electrostatic %init()): kim_aperfuns samples
+    !> them while the periodized primitives are laid down on the window.
+    !>
+    !> On exit plasma%{spec%n,T,dndr,dTdr,q,Er} are the PERIODIZED primitives on
+    !> the window and every derived quantity (B0, kp, om_E, vT, nu, omega_c,
+    !> rho_L, lambda_D, A1, A2, x1, x2 and the susceptibility functions I00..I21)
+    !> is recomputed from them and is therefore L-periodic.
+    !>
+    !> NOTE: this MUTATES the module-global rg_grid and plasma. It is meant to be
+    !> called once per forced-periodicity assembly on an independent process.
+    subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+        use species_m, only: plasma, set_plasma_quantities, reallocate, &
+                             deallocate_plasma_derived
+        use equilibrium_m, only: calculate_equil, B0, B0z, B0th, hz, hth, &
+                                 equil_grid, u, dpress_prof
+        use grid_m, only: rg_grid
+        use config_m, only: number_of_ion_species
+
+        real(dp), intent(in) :: rm, dx_asis, dx_tr
+        integer, intent(in) :: n_rg
+
+        real(dp) :: L, r_lo, r_hi
+        real(dp) :: funs(n_primitives)
+        real(dp), allocatable :: r_win(:)
+        real(dp), allocatable :: n_win(:), Te_win(:), Ti_win(:), q_win(:), Er_win(:)
+        integer :: j, sigma, npts
+
+        ! ---- 1. Equidistant window grid, reused as the global rg_grid. --------
+        L = 2.0_dp * (dx_asis + dx_tr)
+        r_lo = rm - 0.5_dp * L
+        r_hi = rm + 0.5_dp * L
+
+        ! grid_init_equidistant takes npts as intent(inout); pass a variable.
+        npts = n_rg
+        call rg_grid%grid_init_equidistant(npts, r_lo, r_hi, 'rg')
+        call rg_grid%grid_generate_equidistant()
+
+        ! ---- 2. Sample the PERIODIZED primitives on the window FIRST. ----------
+        ! kim_aperfuns reads the TRUE (global-grid) primitives of `plasma`, so
+        ! this MUST happen before we redirect `plasma` onto the window (which
+        ! reallocates and thereby destroys those true profiles). Sample into
+        ! temporaries; write them onto the redirected plasma in step 3.
+        ! FIXED order from sample_periodic_primitives: [ n_e, Te, Ti, q, Er ].
+        allocate(r_win(rg_grid%npts_b), n_win(rg_grid%npts_b), Te_win(rg_grid%npts_b), &
+                 Ti_win(rg_grid%npts_b), q_win(rg_grid%npts_b), Er_win(rg_grid%npts_b))
+        r_win = rg_grid%xb
+        do j = 1, rg_grid%npts_b
+            call sample_periodic_primitives(rm, dx_asis, dx_tr, r_win(j), funs)
+            n_win(j)  = funs(1)
+            Te_win(j) = funs(2)
+            Ti_win(j) = funs(3)
+            q_win(j)  = funs(4)
+            Er_win(j) = funs(5)
+        end do
+
+        ! ---- 3. Redirect the plasma onto the window grid. ---------------------
+        ! Clear ALL derived state so the recompute chain reallocates cleanly at
+        ! the new (window) size: equilibrium_m arrays, plasma-level derived
+        ! arrays (deallocate_plasma_derived), and the thermodynamic/
+        ! susceptibility arrays (guarded by `.not. allocated`, so a stale old
+        ! size would otherwise be kept).
+        if (allocated(B0))          deallocate(B0)
+        if (allocated(B0z))         deallocate(B0z)
+        if (allocated(B0th))        deallocate(B0th)
+        if (allocated(hz))          deallocate(hz)
+        if (allocated(hth))         deallocate(hth)
+        if (allocated(equil_grid))  deallocate(equil_grid)
+        if (allocated(u))           deallocate(u)
+        if (allocated(dpress_prof)) deallocate(dpress_prof)
+        call deallocate_plasma_derived()
+        call deallocate_thermo_and_susc()
+
+        plasma%grid_size = rg_grid%npts_b
+        call reallocate(plasma%r_grid, rg_grid%npts_b)
+        plasma%r_grid = r_win
+
+        ! Write the periodized primitives onto the redirected plasma. Ion
+        ! density follows from n_e by quasineutrality (as elsewhere in KIM).
+        call reallocate(plasma%q, rg_grid%npts_b)
+        call reallocate(plasma%Er, rg_grid%npts_b)
+        call reallocate(plasma%spec(0)%n, rg_grid%npts_b)
+        call reallocate(plasma%spec(0)%T, rg_grid%npts_b)
+        plasma%q  = q_win
+        plasma%Er = Er_win
+        plasma%spec(0)%n = n_win
+        plasma%spec(0)%T = Te_win
+        do sigma = 1, number_of_ion_species
+            call reallocate(plasma%spec(sigma)%n, rg_grid%npts_b)
+            call reallocate(plasma%spec(sigma)%T, rg_grid%npts_b)
+            plasma%spec(sigma)%T = Ti_win
+        end do
+        call set_ion_density_quasineutral()
+
+        ! Force calculate_equil / calc_plasma_parameter_derivs to recompute the
+        ! profile derivatives (dndr, dTdr, dqdr) on the window instead of reusing
+        ! stale global-grid values.
+        do sigma = 0, number_of_ion_species
+            if (allocated(plasma%spec(sigma)%dndr)) deallocate(plasma%spec(sigma)%dndr)
+            if (allocated(plasma%spec(sigma)%dTdr)) deallocate(plasma%spec(sigma)%dTdr)
+        end do
+        if (allocated(plasma%dqdr)) deallocate(plasma%dqdr)
+
+        deallocate(r_win, n_win, Te_win, Ti_win, q_win, Er_win)
+
+        ! ---- 4./5. Recompute derivatives + all derived quantities. ------------
+        ! calculate_equil: recomputes dndr/dTdr/dqdr (via calc_plasma_parameter_
+        ! derivs on the equidistant window) and B0, ks, kp, om_E from the
+        ! periodized q/Er and btor/R0/m_mode/n_mode. write_out=.false. keeps this
+        ! side-effect-free (no equilibrium files).
+        call calculate_equil(.false.)
+
+        ! set_plasma_quantities: calculate_plasma_backs (vT, nu, omega_c, rho_L,
+        ! lambda_D, z0), interpolate_plasma_backs(rg_grid%xb) -- the IDENTITY
+        ! here because plasma%r_grid == rg_grid%xb -- cell centres, and
+        ! calculate_thermodynamic_forces_and_susc (A1, A2, x1, x2, I00..I21) on
+        ! rg_grid%npts_b == the window.
+        call set_plasma_quantities(plasma)
+
+    contains
+
+        subroutine set_ion_density_quasineutral()
+            integer :: total_Z, sp, jj
+
+            total_Z = 0
+            do sp = 1, number_of_ion_species
+                total_Z = total_Z + plasma%spec(sp)%Zspec
+            end do
+            if (total_Z == 0) return
+            do sp = 1, number_of_ion_species
+                do jj = 1, rg_grid%npts_b
+                    plasma%spec(sp)%n(jj) = plasma%spec(0)%n(jj) * plasma%spec(sp)%Zspec / total_Z
+                end do
+            end do
+        end subroutine set_ion_density_quasineutral
+
+        !> Deallocate the thermodynamic-force and susceptibility arrays that
+        !> calculate_thermodynamic_forces_and_susc allocates behind a
+        !> `.not. allocated` guard. Without this the arrays keep their previous
+        !> (global-grid) size and the recompute silently skips reallocation.
+        subroutine deallocate_thermo_and_susc()
+            integer :: sp
+
+            do sp = 0, plasma%n_species - 1
+                if (allocated(plasma%spec(sp)%symbI)) deallocate(plasma%spec(sp)%symbI)
+
+                if (allocated(plasma%spec(sp)%A1)) deallocate(plasma%spec(sp)%A1)
+                if (allocated(plasma%spec(sp)%A2)) deallocate(plasma%spec(sp)%A2)
+                if (allocated(plasma%spec(sp)%x1)) deallocate(plasma%spec(sp)%x1)
+                if (allocated(plasma%spec(sp)%x2)) deallocate(plasma%spec(sp)%x2)
+                if (allocated(plasma%spec(sp)%I00)) deallocate(plasma%spec(sp)%I00)
+                if (allocated(plasma%spec(sp)%I01)) deallocate(plasma%spec(sp)%I01)
+                if (allocated(plasma%spec(sp)%I20)) deallocate(plasma%spec(sp)%I20)
+                if (allocated(plasma%spec(sp)%I21)) deallocate(plasma%spec(sp)%I21)
+                if (allocated(plasma%spec(sp)%I22)) deallocate(plasma%spec(sp)%I22)
+                if (allocated(plasma%spec(sp)%I02)) deallocate(plasma%spec(sp)%I02)
+                if (allocated(plasma%spec(sp)%I11)) deallocate(plasma%spec(sp)%I11)
+                if (allocated(plasma%spec(sp)%I13)) deallocate(plasma%spec(sp)%I13)
+
+                if (allocated(plasma%spec(sp)%n_cc)) deallocate(plasma%spec(sp)%n_cc)
+                if (allocated(plasma%spec(sp)%dndr_cc)) deallocate(plasma%spec(sp)%dndr_cc)
+                if (allocated(plasma%spec(sp)%T_cc)) deallocate(plasma%spec(sp)%T_cc)
+                if (allocated(plasma%spec(sp)%dTdr_cc)) deallocate(plasma%spec(sp)%dTdr_cc)
+                if (allocated(plasma%spec(sp)%nu_cc)) deallocate(plasma%spec(sp)%nu_cc)
+                if (allocated(plasma%spec(sp)%vT_cc)) deallocate(plasma%spec(sp)%vT_cc)
+                if (allocated(plasma%spec(sp)%omega_c_cc)) deallocate(plasma%spec(sp)%omega_c_cc)
+                if (allocated(plasma%spec(sp)%lambda_D_cc)) deallocate(plasma%spec(sp)%lambda_D_cc)
+                if (allocated(plasma%spec(sp)%rho_L_cc)) deallocate(plasma%spec(sp)%rho_L_cc)
+                if (allocated(plasma%spec(sp)%A1_cc)) deallocate(plasma%spec(sp)%A1_cc)
+                if (allocated(plasma%spec(sp)%A2_cc)) deallocate(plasma%spec(sp)%A2_cc)
+                if (allocated(plasma%spec(sp)%x1_cc)) deallocate(plasma%spec(sp)%x1_cc)
+                if (allocated(plasma%spec(sp)%x2_cc)) deallocate(plasma%spec(sp)%x2_cc)
+                if (allocated(plasma%spec(sp)%I00_cc)) deallocate(plasma%spec(sp)%I00_cc)
+                if (allocated(plasma%spec(sp)%I01_cc)) deallocate(plasma%spec(sp)%I01_cc)
+                if (allocated(plasma%spec(sp)%I10_cc)) deallocate(plasma%spec(sp)%I10_cc)
+                if (allocated(plasma%spec(sp)%I20_cc)) deallocate(plasma%spec(sp)%I20_cc)
+                if (allocated(plasma%spec(sp)%I21_cc)) deallocate(plasma%spec(sp)%I21_cc)
+                if (allocated(plasma%spec(sp)%I12_cc)) deallocate(plasma%spec(sp)%I12_cc)
+                if (allocated(plasma%spec(sp)%I22_cc)) deallocate(plasma%spec(sp)%I22_cc)
+                if (allocated(plasma%spec(sp)%I02_cc)) deallocate(plasma%spec(sp)%I02_cc)
+                if (allocated(plasma%spec(sp)%I13_cc)) deallocate(plasma%spec(sp)%I13_cc)
+                if (allocated(plasma%spec(sp)%I11_cc)) deallocate(plasma%spec(sp)%I11_cc)
+            end do
+
+            if (allocated(plasma%ks_cc)) deallocate(plasma%ks_cc)
+            if (allocated(plasma%Er_cc)) deallocate(plasma%Er_cc)
+            if (allocated(plasma%om_E_cc)) deallocate(plasma%om_E_cc)
+        end subroutine deallocate_thermo_and_susc
+
+    end subroutine build_periodic_plasma
 
 end module periodic_background_m

--- a/KIM/src/background_equilibrium/periodic_background.f90
+++ b/KIM/src/background_equilibrium/periodic_background.f90
@@ -7,10 +7,9 @@ module periodic_background_m
     !>   - sample_periodic_primitives: a thin wrapper that returns the PERIODIZED
     !>                    primitives at a query radius by driving make_periodic.
     !>
-    !> ORDER CONTRACT (relied upon by Phase-2.3): the five sampled functions are
-    !> returned in the FIXED order
+    !> LEGACY SAMPLING CONTRACT: the public five-value sampler returns
     !>     funs = [ n_e, Te, Ti, q, Er ].
-    !> Do not reorder without updating every consumer.
+    !> The full periodic build caches and samples n_s and T_s for every species.
 
     use KIM_kinds_m, only: dp
     use periodization_m, only: make_periodic
@@ -19,10 +18,15 @@ module periodic_background_m
     private
 
     public :: kim_aperfuns, sample_periodic_primitives, build_periodic_plasma
+    public :: sample_periodic_species_profiles
     public :: reset_true_background_cache
 
-    !> Number of primitive functions sampled, and their FIXED order.
-    integer, parameter :: n_primitives = 5
+    integer, parameter, public :: PERIODIC_BACKGROUND_OK = 0
+    integer, parameter, public :: PERIODIC_BACKGROUND_INVALID_MAIN_ION = 1
+    integer, parameter, public :: PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE = 2
+
+    !> Number of values in the legacy public primitive-sampling interface.
+    integer, parameter :: n_legacy_primitives = 5
 
     !> Number of GEOMETRY functions periodized, and their FIXED order.
     !>     geom = [ B0, ks, kp, om_E ].
@@ -50,11 +54,13 @@ module periodic_background_m
     !> this cache (which would create a circular module dependency). No manual
     !> reset is needed after set_profiles_from_arrays.
     !>
-    !> Order in cache_prim: [ n_e, Te, Ti, q, Er ]  (matches kim_aperfuns).
+    !> Order in cache_prim for S species:
+    !>   [ n_0..n_(S-1), T_0..T_(S-1), q, Er ].
     !> Order in cache_geom: [ B0, ks, kp, om_E ]     (matches kim_geom_aperfuns).
     integer, save :: cached_generation = -1
+    integer, save :: cached_n_species = 0
     real(dp), allocatable, save :: cache_r(:)
-    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, n_primitives)
+    real(dp), allocatable, save :: cache_prim(:, :)   ! (grid_size, 2*S + 2)
     real(dp), allocatable, save :: cache_geom(:, :)   ! (grid_size, n_geom)
 
 contains
@@ -65,6 +71,7 @@ contains
     !> kept for callers that want to drop the snapshot explicitly.
     subroutine reset_true_background_cache()
         cached_generation = -1
+        cached_n_species = 0
         if (allocated(cache_r))    deallocate(cache_r)
         if (allocated(cache_prim)) deallocate(cache_prim)
         if (allocated(cache_geom)) deallocate(cache_geom)
@@ -78,7 +85,7 @@ contains
     subroutine capture_true_background()
         use species_m, only: plasma, profiles_generation
 
-        integer :: gs, i
+        integer :: gs, i, sp, ncols
 
         if (cached_generation == profiles_generation) return
 
@@ -87,15 +94,18 @@ contains
         if (allocated(cache_geom)) deallocate(cache_geom)
 
         gs = plasma%grid_size
-        allocate(cache_r(gs), cache_prim(gs, n_primitives), cache_geom(gs, n_geom))
+        cached_n_species = plasma%n_species
+        ncols = 2*cached_n_species + 2
+        allocate(cache_r(gs), cache_prim(gs, ncols), cache_geom(gs, n_geom))
 
         cache_r = plasma%r_grid(1:gs)
         do i = 1, gs
-            cache_prim(i, 1) = plasma%spec(0)%n(i)   ! electron density
-            cache_prim(i, 2) = plasma%spec(0)%T(i)   ! electron temperature
-            cache_prim(i, 3) = plasma%spec(1)%T(i)   ! ion temperature
-            cache_prim(i, 4) = plasma%q(i)           ! safety factor
-            cache_prim(i, 5) = plasma%Er(i)          ! radial electric field
+            do sp = 0, cached_n_species - 1
+                cache_prim(i, sp + 1) = plasma%spec(sp)%n(i)
+                cache_prim(i, cached_n_species + sp + 1) = plasma%spec(sp)%T(i)
+            end do
+            cache_prim(i, 2*cached_n_species + 1) = plasma%q(i)
+            cache_prim(i, 2*cached_n_species + 2) = plasma%Er(i)
 
             cache_geom(i, 1) = plasma%B0(i)          ! equilibrium field magnitude
             cache_geom(i, 2) = plasma%ks(i)          ! perpendicular wavenumber
@@ -165,8 +175,29 @@ contains
         ! no-op in the normal solver path (build_periodic_plasma already captured).
         call capture_true_background()
 
-        call interp_cache_row(cache_prim, nfuns, x, funs)
+        block
+            real(dp) :: all_funs(2*cached_n_species + 2)
+
+            call interp_cache_row(cache_prim, size(all_funs), x, all_funs)
+            funs(1) = all_funs(1)
+            funs(2) = all_funs(cached_n_species + 1)
+            funs(3) = all_funs(cached_n_species + 2)
+            funs(4) = all_funs(2*cached_n_species + 1)
+            funs(5) = all_funs(2*cached_n_species + 2)
+        end block
     end subroutine kim_aperfuns
+
+    !> Internal callback used by build_periodic_plasma. Unlike the legacy public
+    !> sampler, this passes every species profile through make_periodic in the
+    !> cache order [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+    subroutine kim_all_profiles_aperfuns(nfuns, x, funs)
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+
+        call capture_true_background()
+        call interp_cache_row(cache_prim, nfuns, x, funs)
+    end subroutine kim_all_profiles_aperfuns
 
     !> Aperiodic sample callback for the equilibrium GEOMETRY, conforming to
     !> periodization_m::aperfuns_i. Evaluates the TRUE geometry at radius x via
@@ -200,10 +231,42 @@ contains
     !> kim_aperfuns: funs_per = [ n_e, Te, Ti, q, Er ].
     subroutine sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
         real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
-        real(dp), intent(out) :: funs_per(n_primitives)
+        real(dp), intent(out) :: funs_per(n_legacy_primitives)
 
-        call make_periodic(kim_aperfuns, n_primitives, x_mid, dx_asis, dx_tr, x, funs_per)
+        call make_periodic(kim_aperfuns, n_legacy_primitives, x_mid, dx_asis, dx_tr, &
+                           x, funs_per)
     end subroutine sample_periodic_primitives
+
+    !> Return independently periodized densities and temperatures for every
+    !> configured species, plus q and Er. Arrays use species indices 0:S-1.
+    subroutine sample_periodic_species_profiles(x_mid, dx_asis, dx_tr, x, &
+                                                n_per, T_per, q_per, Er_per)
+        real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
+        real(dp), intent(out) :: n_per(0:), T_per(0:)
+        real(dp), intent(out) :: q_per, Er_per
+
+        integer :: sp, n_profile_values
+
+        call capture_true_background()
+        if (size(n_per) /= cached_n_species .or. &
+            size(T_per) /= cached_n_species) then
+            error stop 'periodic species sampler received the wrong species count'
+        end if
+
+        n_profile_values = 2*cached_n_species + 2
+        block
+            real(dp) :: all_funs(n_profile_values)
+
+            call make_periodic(kim_all_profiles_aperfuns, n_profile_values, x_mid, &
+                               dx_asis, dx_tr, x, all_funs)
+            do sp = 0, cached_n_species - 1
+                n_per(sp) = all_funs(sp + 1)
+                T_per(sp) = all_funs(cached_n_species + sp + 1)
+            end do
+            q_per = all_funs(2*cached_n_species + 1)
+            Er_per = all_funs(2*cached_n_species + 2)
+        end block
+    end subroutine sample_periodic_species_profiles
 
     !> Return the PERIODIZED geometry [ B0, ks, kp, om_E ] at query radius x,
     !> driving make_periodic with kim_geom_aperfuns. Same window layout as
@@ -239,7 +302,7 @@ contains
     !> unconditionally calls write_species_backs / write_plasma_backs, which
     !> create output_path//backs/ and write the background profile .dat files
     !> (rho_L, lambda_D, kp, om_E, ...) for the window plasma.
-    subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+    subroutine build_periodic_plasma(rm, dx_asis, dx_tr, n_rg, info)
         use species_m, only: plasma, reallocate, deallocate_plasma_derived, &
                              calc_plasma_parameter_derivs, calculate_plasma_backs, &
                              interpolate_plasma_backs, compute_rg_cell_centers, &
@@ -253,45 +316,63 @@ contains
 
         real(dp), intent(in) :: rm, dx_asis, dx_tr
         integer, intent(in) :: n_rg
+        integer, intent(out), optional :: info
 
         real(dp) :: L, r_lo, r_hi, u0_seed
-        real(dp) :: funs(n_primitives)
         real(dp), allocatable :: r_win(:)
-        real(dp), allocatable :: n_win(:), Te_win(:), Ti_win(:), q_win(:), Er_win(:)
-        integer :: j, sigma, npts
+        real(dp), allocatable :: n_win(:, :), T_win(:, :), q_win(:), Er_win(:)
+        integer :: j, sigma, npts, n_species, profile_status
+
+        if (present(info)) info = PERIODIC_BACKGROUND_OK
 
         ! Capture the TRUE background (r-grid, primitives, geometry) from the
         ! global plasma ONCE, before any redirect destroys it; all periodization
         ! (primitives AND geometry) then reads this cache, so repeated calls stay
         ! correct even though `plasma` is redirected onto the window after call 1.
         call capture_true_background()
+        n_species = cached_n_species
 
-        ! ---- 1. Equidistant window grid, reused as the global rg_grid. --------
+        ! ---- 1. Construct an equidistant window without mutating globals. -----
         L = 2.0_dp * (dx_asis + dx_tr)
         r_lo = rm - 0.5_dp * L
         r_hi = rm + 0.5_dp * L
 
-        ! grid_init_equidistant takes npts as intent(inout); pass a variable.
+        ! ---- 2. Sample and validate PERIODIZED primitives before redirect. ----
+        ! kim_aperfuns reads the CACHED true primitives (captured above), so this
+        ! is robust to the redirect and to repeated calls. Sample into temporaries;
+        ! only a valid profile is allowed to mutate rg_grid or plasma below.
+        ! Dynamic order: [n_0..n_(S-1), T_0..T_(S-1), q, Er].
+        allocate(r_win(n_rg), n_win(n_rg, 0:n_species - 1), &
+                 T_win(n_rg, 0:n_species - 1), q_win(n_rg), Er_win(n_rg))
+        do j = 1, n_rg
+            r_win(j) = r_lo + L*real(j - 1, dp)/real(n_rg, dp)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, r_win(j), &
+                n_win(j, :), T_win(j, :), q_win(j), Er_win(j))
+        end do
+
+        ! Preserve independently periodized impurity densities and use the main
+        ! ion (species 1) as the dependent density. This documents one unique
+        ! quasineutrality policy and avoids changing impurity concentration
+        ! ratios merely because a species has a higher charge state.
+        call enforce_dependent_main_ion_density(n_win, T_win, profile_status)
+        if (profile_status /= PERIODIC_BACKGROUND_OK) then
+            deallocate(r_win, n_win, T_win, q_win, Er_win)
+            if (present(info)) then
+                info = profile_status
+                return
+            end if
+            if (profile_status == PERIODIC_BACKGROUND_INVALID_MAIN_ION) then
+                error stop 'periodic background requires a positive-Z main ion'
+            end if
+            error stop 'periodic background contains a nonphysical species profile'
+        end if
+
+        ! Validation succeeded. Redirect the global rg grid to the same
+        ! endpoint-exclusive equidistant window used for sampling.
         npts = n_rg
         call rg_grid%grid_init_equidistant(npts, r_lo, r_hi, 'rg')
         call rg_grid%grid_generate_equidistant()
-
-        ! ---- 2. Sample the PERIODIZED primitives on the window FIRST. ----------
-        ! kim_aperfuns reads the CACHED true primitives (captured above), so this
-        ! is robust to the redirect and to repeated calls. Sample into temporaries;
-        ! write them onto the redirected plasma in step 3.
-        ! FIXED order from sample_periodic_primitives: [ n_e, Te, Ti, q, Er ].
-        allocate(r_win(rg_grid%npts_b), n_win(rg_grid%npts_b), Te_win(rg_grid%npts_b), &
-                 Ti_win(rg_grid%npts_b), q_win(rg_grid%npts_b), Er_win(rg_grid%npts_b))
         r_win = rg_grid%xb
-        do j = 1, rg_grid%npts_b
-            call sample_periodic_primitives(rm, dx_asis, dx_tr, r_win(j), funs)
-            n_win(j)  = funs(1)
-            Te_win(j) = funs(2)
-            Ti_win(j) = funs(3)
-            q_win(j)  = funs(4)
-            Er_win(j) = funs(5)
-        end do
 
         ! Capture the TRUE B0 at the window's left edge (from the cached true
         ! geometry) as the force-balance ODE seed u0 = B0(r_lo)**2. Without this
@@ -330,14 +411,14 @@ contains
         call reallocate(plasma%spec(0)%T, rg_grid%npts_b)
         plasma%q  = q_win
         plasma%Er = Er_win
-        plasma%spec(0)%n = n_win
-        plasma%spec(0)%T = Te_win
+        plasma%spec(0)%n = n_win(:, 0)
+        plasma%spec(0)%T = T_win(:, 0)
         do sigma = 1, number_of_ion_species
             call reallocate(plasma%spec(sigma)%n, rg_grid%npts_b)
             call reallocate(plasma%spec(sigma)%T, rg_grid%npts_b)
-            plasma%spec(sigma)%T = Ti_win
+            plasma%spec(sigma)%n = n_win(:, sigma)
+            plasma%spec(sigma)%T = T_win(:, sigma)
         end do
-        call set_ion_density_quasineutral()
 
         ! Force calculate_equil / calc_plasma_parameter_derivs to recompute the
         ! profile derivatives (dndr, dTdr, dqdr) on the window instead of reusing
@@ -348,7 +429,7 @@ contains
         end do
         if (allocated(plasma%dqdr)) deallocate(plasma%dqdr)
 
-        deallocate(r_win, n_win, Te_win, Ti_win, q_win, Er_win)
+        deallocate(r_win, n_win, T_win, q_win, Er_win)
 
         ! ---- 4./5. Recompute derivatives + all derived quantities. ------------
         ! calculate_equil: recomputes dndr/dTdr/dqdr (via calc_plasma_parameter_
@@ -475,20 +556,49 @@ contains
             dfdr(N) = (f(1) - f(N-1)) / (2.0_dp * h)
         end subroutine periodic_central_diff
 
-        subroutine set_ion_density_quasineutral()
-            integer :: total_Z, sp, jj
+        subroutine enforce_dependent_main_ion_density(density, temperature, status)
+            use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
-            total_Z = 0
-            do sp = 1, number_of_ion_species
-                total_Z = total_Z + plasma%spec(sp)%Zspec
+            real(dp), intent(inout) :: density(:, 0:)
+            real(dp), intent(in) :: temperature(:, 0:)
+            integer, intent(out) :: status
+            real(dp) :: impurity_charge_density(size(density, 1))
+            integer :: sp
+
+            status = PERIODIC_BACKGROUND_INVALID_MAIN_ION
+            if (number_of_ion_species < 1 .or. plasma%spec(1)%Zspec <= 0) then
+                return
+            end if
+            do sp = 2, number_of_ion_species
+                if (plasma%spec(sp)%Zspec <= 0) return
             end do
-            if (total_Z == 0) return
-            do sp = 1, number_of_ion_species
-                do jj = 1, rg_grid%npts_b
-                    plasma%spec(sp)%n(jj) = plasma%spec(0)%n(jj) * plasma%spec(sp)%Zspec / total_Z
-                end do
+
+            status = PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE
+            if (any(.not. ieee_is_finite(density(:, 0))) .or. &
+                any(density(:, 0) <= 0.0_dp) .or. &
+                any(.not. ieee_is_finite(temperature)) .or. &
+                any(temperature <= 0.0_dp)) then
+                return
+            end if
+            do sp = 2, number_of_ion_species
+                if (any(.not. ieee_is_finite(density(:, sp))) .or. &
+                    any(density(:, sp) <= 0.0_dp)) return
             end do
-        end subroutine set_ion_density_quasineutral
+
+            impurity_charge_density = 0.0_dp
+            do sp = 2, number_of_ion_species
+                impurity_charge_density = impurity_charge_density + &
+                    real(plasma%spec(sp)%Zspec, dp)*density(:, sp)
+            end do
+            density(:, 1) = (density(:, 0) - impurity_charge_density) / &
+                            real(plasma%spec(1)%Zspec, dp)
+
+            if (any(.not. ieee_is_finite(density(:, 1))) .or. &
+                any(density(:, 1) <= 0.0_dp)) then
+                return
+            end if
+            status = PERIODIC_BACKGROUND_OK
+        end subroutine enforce_dependent_main_ion_density
 
         !> Deallocate the thermodynamic-force and susceptibility arrays that
         !> calculate_thermodynamic_forces_and_susc allocates behind a

--- a/KIM/src/background_equilibrium/periodization.f90
+++ b/KIM/src/background_equilibrium/periodization.f90
@@ -1,0 +1,81 @@
+module periodization_m
+    !> Forced-periodicity utility vendored from the FORCED_PERIODICITY reference
+    !> (make_periodic.f90, localizer.f90). Wraps an aperiodic profile into an
+    !> L-periodic one by mirroring neighbouring periods and blending them with a
+    !> C-infinity localizer weight across a transition band.
+    !>
+    !> The layout, for x_mid the period centre, is
+    !>   half_period = dx_asis + dx_tr,  period L = 2*half_period,
+    !> with an "as-is" core of half-width dx_asis (where the periodized functions
+    !> equal the aperiodic ones exactly) flanked by transition bands of width
+    !> dx_tr that smoothly hand over to the mirrored neighbouring periods.
+
+    use KIM_kinds_m, only: dp
+    implicit none
+    private
+
+    public :: make_periodic, localizer
+
+    abstract interface
+        !> Aperiodic sample functions evaluated at a single point x.
+        subroutine aperfuns_i(nfuns, x, funs)
+            import :: dp
+            integer, intent(in) :: nfuns
+            real(dp), intent(in) :: x
+            real(dp), intent(out) :: funs(nfuns)
+        end subroutine aperfuns_i
+    end interface
+
+contains
+
+    !> Wrap aperiodic sample functions into an L-periodic set at point x.
+    subroutine make_periodic(aperfuns, nfuns, x_mid, dx_asis, dx_tr, x, funs_per)
+        procedure(aperfuns_i) :: aperfuns
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x_mid, dx_asis, dx_tr, x
+        real(dp), intent(out) :: funs_per(nfuns)
+
+        real(dp) :: funs_aper(nfuns)
+        real(dp) :: period, half_period, x_inperiod, x_leftboundary, weight
+
+        half_period = dx_asis + dx_tr
+        period = 2.0_dp*half_period
+        x_leftboundary = x_mid - half_period
+
+        x_inperiod = x_leftboundary + modulo(x - x_leftboundary, period)
+
+        call aperfuns(nfuns, x_inperiod, funs_per)
+
+        call aperfuns(nfuns, x_inperiod - period, funs_aper)
+        call localizer(1.0_dp, x_mid + dx_asis, x_mid + dx_asis + 2.0_dp*dx_tr, x_inperiod, weight)
+        funs_per = funs_per*weight + funs_aper*(1.0_dp - weight)
+
+        call aperfuns(nfuns, x_inperiod + period, funs_aper)
+        call localizer(1.0_dp, x_mid - dx_asis - 2.0_dp*dx_tr, x_mid - dx_asis, x_inperiod, weight)
+        funs_per = funs_per*(1.0_dp - weight) + funs_aper*weight
+    end subroutine make_periodic
+
+    !> C-infinity transition weight over [x1, x2]. sig>0 ramps from 1 to 0,
+    !> otherwise from 0 to 1. The literals are 2*pi and sqrt(2).
+    subroutine localizer(sig, x1, x2, x, weight)
+        real(dp), intent(in) :: sig, x1, x2, x
+        real(dp), intent(out) :: weight
+
+        real(dp) :: t
+
+        if (sig .gt. 0.0_dp) then
+            t = (x - x1)/(x2 - x1)      ! from 1 to 0
+        else
+            t = (x2 - x)/(x2 - x1)      ! from 0 to 1
+        end if
+
+        if (t .le. 0.0_dp) then
+            weight = 1.0_dp
+        else if (t .ge. 1.0_dp) then
+            weight = 0.0_dp
+        else
+            weight = exp(-6.283185307179586d0/(1.0_dp - t)*exp(-1.414213562373095d0/t))
+        end if
+    end subroutine localizer
+
+end module periodization_m

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -86,6 +86,14 @@ module species_m
 
     integer, parameter :: nmmax = 3 ! max order of susceptibility functions to be calculated
 
+    !> Monotonic counter bumped every time the module-global `plasma` primitive
+    !> profiles are replaced via set_profiles_from_arrays (a new case / time step /
+    !> parameter-scan point). Downstream caches that snapshot the true background
+    !> (e.g. periodic_background_m's true-background cache) compare against this to
+    !> auto-invalidate on ANY profile change, without species_m needing to know
+    !> about them (which would create a circular module dependency).
+    integer, save, public :: profiles_generation = 0
+
     contains
 
     pure function scale_fp_collision_frequency(nu, species_index, ion_scale) result(scaled_nu)
@@ -1119,6 +1127,10 @@ module species_m
 
         ! Force resonance re-detection on next solve
         prop = .true.
+
+        ! Bump the profile generation so downstream true-background caches
+        ! (periodic_background_m) auto-invalidate: the profiles just changed.
+        profiles_generation = profiles_generation + 1
 
         ! Deallocate derived arrays to prevent double-allocation crashes
         call deallocate_plasma_derived()

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -56,25 +56,33 @@ contains
     !> periodic_background_m::build_periodic_plasma (rg_grid%xb holds the N
     !> equidistant boundary points that hatG_rho_phi / hatG_rho_B index).
     !>
-    !> Kphi and KB are allocated here to (2M+1) x (2M+1), row index im = m+M+1,
-    !> column index imp = m'+M+1.
-    subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+    !> All four matrices are allocated here to (2M+1) x (2M+1), row index
+    !> im = m+M+1, column index imp = m'+M+1.
+    !>
+    !> Kjphi and KjB are the parallel-current analogues, assembled with the same
+    !> quadrature from hatG_j_phi / hatG_j_B. They are post-processing only: the
+    !> solve uses Kphi/KB, and j_par follows from thesis (11.7) as
+    !> Kjphi . Phi_m + KjB . Br_m. Note the j-kernels carry NO /(4*pi) (see
+    !> flr2_fourier_kernel_m), so these matrices must not be scaled by 4*pi the
+    !> way solve_periodic scales Kphi/KB.
+    subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         use grid_m, only: rg_grid
-        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, hatG_j_phi, hatG_j_B
         use constants_m, only: pi
 
         type(plasma_t), intent(in) :: plasma
         real(dp), intent(in) :: L
         integer, intent(in) :: M
         complex(dp), allocatable, intent(out) :: Kphi(:,:), KB(:,:)
+        complex(dp), allocatable, intent(out) :: Kjphi(:,:), KjB(:,:)
 
         integer :: N, dim, m_row, m_col, im, imp, j
         real(dp) :: k_m, k_mp, weight
-        complex(dp) :: acc_phi, acc_B
+        complex(dp) :: acc_phi, acc_B, acc_jphi, acc_jB
 
         N = rg_grid%npts_b
         dim = 2 * M + 1
-        allocate(Kphi(dim, dim), KB(dim, dim))
+        allocate(Kphi(dim, dim), KB(dim, dim), Kjphi(dim, dim), KjB(dim, dim))
 
         ! Periodic trapezoidal weight. rg_grid%xb is EQUIDISTANT and ENDPOINT-
         ! EXCLUSIVE over one period (grid_generate_equidistant: h = L/N, xb(N) =
@@ -91,15 +99,21 @@ contains
                 k_m = k_of_m(m_row, L)
                 im = m_row + M + 1
 
-                acc_phi = (0.0_dp, 0.0_dp)
-                acc_B   = (0.0_dp, 0.0_dp)
+                acc_phi  = (0.0_dp, 0.0_dp)
+                acc_B    = (0.0_dp, 0.0_dp)
+                acc_jphi = (0.0_dp, 0.0_dp)
+                acc_jB   = (0.0_dp, 0.0_dp)
                 do j = 1, N
-                    acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
-                    acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
+                    acc_phi  = acc_phi  + hatG_rho_phi(plasma, k_m, k_mp, j)
+                    acc_B    = acc_B    + hatG_rho_B(plasma, k_m, k_mp, j)
+                    acc_jphi = acc_jphi + hatG_j_phi(plasma, k_m, k_mp, j)
+                    acc_jB   = acc_jB   + hatG_j_B(plasma, k_m, k_mp, j)
                 end do
 
-                Kphi(im, imp) = weight * acc_phi
-                KB(im, imp)   = weight * acc_B
+                Kphi(im, imp)  = weight * acc_phi
+                KB(im, imp)    = weight * acc_B
+                Kjphi(im, imp) = weight * acc_jphi
+                KjB(im, imp)   = weight * acc_jB
             end do
         end do
     end subroutine assemble_periodic_matrices

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -61,10 +61,9 @@ contains
     !>
     !> Kjphi and KjB are the parallel-current analogues, assembled with the same
     !> quadrature from hatG_j_phi / hatG_j_B. They are post-processing only: the
-    !> solve uses Kphi/KB, and j_par follows from thesis (11.7) as
-    !> Kjphi . Phi_m + KjB . Br_m. Note the j-kernels carry NO /(4*pi) (see
-    !> flr2_fourier_kernel_m), so these matrices must not be scaled by 4*pi the
-    !> way solve_periodic scales Kphi/KB.
+    !> solve uses Kphi/KB, and j_par follows from thesis (11.8) as
+    !> Kjphi . Phi_m + KjB . Br_m. The j-kernels already carry their
+    !> 1/(8*pi^2) Fourier normalization, so no further scaling is applied here.
     subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         use grid_m, only: rg_grid
         use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, hatG_j_phi, hatG_j_B
@@ -92,6 +91,13 @@ contains
         ! error that caps r_g-quadrature convergence.
         weight = 2.0_dp * pi / real(N, dp)
 
+        ! Each Fourier-space column is independent.  Parallelize the expensive
+        ! radial quadrature while retaining a fixed summation order in j for
+        ! bitwise-reproducible entries at a given compiler/architecture.
+        !$omp parallel do default(none) schedule(static) &
+        !$omp shared(M, L, N, weight, plasma, Kphi, KB, Kjphi, KjB) &
+        !$omp private(m_col, k_mp, imp, m_row, k_m, im, j, &
+        !$omp         acc_phi, acc_B, acc_jphi, acc_jB)
         do m_col = -M, M
             k_mp = k_of_m(m_col, L)
             imp = m_col + M + 1
@@ -116,6 +122,7 @@ contains
                 KjB(im, imp)   = weight * acc_jB
             end do
         end do
+        !$omp end parallel do
     end subroutine assemble_periodic_matrices
 
 end module periodic_assembly_m

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -15,15 +15,17 @@ module periodic_assembly_m
     !> The periodic background makes the integrand L-periodic, and the Fourier
     !> phase exp(i(k_m - k_{m'}) r_g) is exactly L-periodic since
     !> (k_m - k_{m'})*L = 2*pi*(m - m'). The periodic trapezoidal (equidistant)
-    !> rule is therefore spectrally accurate. The window grid rg_grid%xb has
-    !> N = rg_grid%npts_b equidistant points on [rm-L/2, rm+L/2]; points 1 and N
-    !> are one period apart (they coincide mod L), so only the N-1 DISTINCT
-    !> samples are summed -- no endpoint half-weights, no double-counted seam:
+    !> rule is therefore spectrally accurate. The window grid rg_grid%xb is
+    !> ENDPOINT-EXCLUSIVE over one period: grid_generate_equidistant sets h = L/N
+    !> and xb(j) = r_lo + (j-1)*h (N = rg_grid%npts_b), so the N grid points are the
+    !> N DISTINCT samples over [rm-L/2, rm+L/2) and xb(1)+L = rm+L/2 is NOT a node.
+    !> The periodic trapezoidal rule therefore sums ALL N samples with equal weight
+    !> -- no endpoint half-weights, no dropped sample:
     !>
-    !>   K^{rhoPhi}_{m,m'} = (2*pi/(N-1)) * sum_{j=1}^{N-1}
+    !>   K^{rhoPhi}_{m,m'} = (2*pi/N) * sum_{j=1}^{N}
     !>                         hatG_rho_phi(plasma, k_m, k_{m'}, j).
     !>
-    !> This equals (2*pi/L)*h*sum with h = L/(N-1); the L cancels. K^{rhoB} is
+    !> This equals (2*pi/L)*h*sum with h = L/N; the L cancels. K^{rhoB} is
     !> assembled identically with hatG_rho_B.
     !>
     !> The FLR factors depend on BOTH k_m and k_{m'} (design section 4.2), so K is
@@ -74,8 +76,13 @@ contains
         dim = 2 * M + 1
         allocate(Kphi(dim, dim), KB(dim, dim))
 
-        ! Periodic trapezoidal weight: (2*pi/L)*h with h = L/(N-1) -> 2*pi/(N-1).
-        weight = 2.0_dp * pi / real(N - 1, dp)
+        ! Periodic trapezoidal weight. rg_grid%xb is EQUIDISTANT and ENDPOINT-
+        ! EXCLUSIVE over one period (grid_generate_equidistant: h = L/N, xb(N) =
+        ! r_hi - h), so the N grid points are the N DISTINCT samples over one
+        ! period. Sum ALL N with equal weight (2*pi/L)*h = 2*pi/N -- dropping
+        ! sample N and using 2*pi/(N-1) (as if endpoint-inclusive) is an O(1/N)
+        ! error that caps r_g-quadrature convergence.
+        weight = 2.0_dp * pi / real(N, dp)
 
         do m_col = -M, M
             k_mp = k_of_m(m_col, L)
@@ -86,7 +93,7 @@ contains
 
                 acc_phi = (0.0_dp, 0.0_dp)
                 acc_B   = (0.0_dp, 0.0_dp)
-                do j = 1, N - 1
+                do j = 1, N
                     acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
                     acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
                 end do

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -1,0 +1,100 @@
+module periodic_assembly_m
+    !> Dense Fourier-matrix assembly for the forced-periodicity solver (Phase-2.4).
+    !>
+    !> Assembles the complex matrices K^{rhoPhi}_{m,m'} and K^{rhoB}_{m,m'} over
+    !> one period from the Phase-2.3 periodic plasma and the Phase-1 fused kernel
+    !> (flr2_fourier_kernel_m::hatG_rho_phi / hatG_rho_B).
+    !>
+    !> Discrete k-grid (memo eq. matelrhoPhi_discr): k_m = 2*pi*m/L for
+    !> m = -M..M, mapped to matrix index im = m + M + 1, so the matrices are
+    !> (2M+1) x (2M+1).
+    !>
+    !>   K^{rhoPhi}_{m,m'} = (2*pi/L) * INT_{rm-L/2}^{rm+L/2}
+    !>                         G^{rhoPhi}(k_m, k_{m'}, r_g) dr_g.
+    !>
+    !> The periodic background makes the integrand L-periodic, and the Fourier
+    !> phase exp(i(k_m - k_{m'}) r_g) is exactly L-periodic since
+    !> (k_m - k_{m'})*L = 2*pi*(m - m'). The periodic trapezoidal (equidistant)
+    !> rule is therefore spectrally accurate. The window grid rg_grid%xb has
+    !> N = rg_grid%npts_b equidistant points on [rm-L/2, rm+L/2]; points 1 and N
+    !> are one period apart (they coincide mod L), so only the N-1 DISTINCT
+    !> samples are summed -- no endpoint half-weights, no double-counted seam:
+    !>
+    !>   K^{rhoPhi}_{m,m'} = (2*pi/(N-1)) * sum_{j=1}^{N-1}
+    !>                         hatG_rho_phi(plasma, k_m, k_{m'}, j).
+    !>
+    !> This equals (2*pi/L)*h*sum with h = L/(N-1); the L cancels. K^{rhoB} is
+    !> assembled identically with hatG_rho_B.
+    !>
+    !> The FLR factors depend on BOTH k_m and k_{m'} (design section 4.2), so K is
+    !> in general NOT Toeplitz (not constant along its diagonals).
+
+    use KIM_kinds_m, only: dp
+    use species_m, only: plasma_t
+
+    implicit none
+    private
+
+    public :: assemble_periodic_matrices, k_of_m
+
+contains
+
+    !> Discrete radial wavenumber for Fourier index m over period L: k_m = 2*pi*m/L.
+    pure real(dp) function k_of_m(m, L) result(k)
+        use constants_m, only: pi
+        integer, intent(in) :: m
+        real(dp), intent(in) :: L
+        k = 2.0_dp * pi * real(m, dp) / L
+    end function k_of_m
+
+    !> Assemble the dense complex Fourier matrices K^{rhoPhi} and K^{rhoB} over
+    !> one period, using the periodic trapezoidal rule on the window grid.
+    !>
+    !> On entry `plasma` must be the periodic window plasma produced by
+    !> periodic_background_m::build_periodic_plasma (rg_grid%xb holds the N
+    !> equidistant boundary points that hatG_rho_phi / hatG_rho_B index).
+    !>
+    !> Kphi and KB are allocated here to (2M+1) x (2M+1), row index im = m+M+1,
+    !> column index imp = m'+M+1.
+    subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+        use grid_m, only: rg_grid
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+        use constants_m, only: pi
+
+        type(plasma_t), intent(in) :: plasma
+        real(dp), intent(in) :: L
+        integer, intent(in) :: M
+        complex(dp), allocatable, intent(out) :: Kphi(:,:), KB(:,:)
+
+        integer :: N, dim, m_row, m_col, im, imp, j
+        real(dp) :: k_m, k_mp, weight
+        complex(dp) :: acc_phi, acc_B
+
+        N = rg_grid%npts_b
+        dim = 2 * M + 1
+        allocate(Kphi(dim, dim), KB(dim, dim))
+
+        ! Periodic trapezoidal weight: (2*pi/L)*h with h = L/(N-1) -> 2*pi/(N-1).
+        weight = 2.0_dp * pi / real(N - 1, dp)
+
+        do m_col = -M, M
+            k_mp = k_of_m(m_col, L)
+            imp = m_col + M + 1
+            do m_row = -M, M
+                k_m = k_of_m(m_row, L)
+                im = m_row + M + 1
+
+                acc_phi = (0.0_dp, 0.0_dp)
+                acc_B   = (0.0_dp, 0.0_dp)
+                do j = 1, N - 1
+                    acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
+                    acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
+                end do
+
+                Kphi(im, imp) = weight * acc_phi
+                KB(im, imp)   = weight * acc_B
+            end do
+        end do
+    end subroutine assemble_periodic_matrices
+
+end module periodic_assembly_m

--- a/KIM/src/electrostatic_poisson/periodic_solve.f90
+++ b/KIM/src/electrostatic_poisson/periodic_solve.f90
@@ -1,0 +1,121 @@
+module periodic_solve_m
+    !> Dense solve of the periodic electrostatic system and inverse-DFT
+    !> reconstruction of the potential (Phase-2.5).
+    !>
+    !> Over Fourier modes m = -M..M with k_m = 2*pi*m/L, the electrostatic
+    !> forced-periodicity system (design section 3.4) is
+    !>
+    !>   [ D_m delta_{m,m'} + 4*pi K^{rhoPhi}_{m,m'} ] Phi_{m'}
+    !>                                        = -4*pi K^{rhoB}_{m,m'} Br_{m'},
+    !>
+    !> with D_m = -k_m^2 the (diagonal) Fourier-space radial Poisson operator.
+    !> This matches solve_poisson.f90, whose left-hand operator is
+    !> A_mat = Laplace + 4*pi K_rho_phi (solve_poisson.f90:49): the FEM Laplace
+    !> operator there (prepare_Laplace_matrix) is the RADIAL second derivative
+    !> only, which in the Fourier basis maps to -k_m^2. There is NO perpendicular
+    !> -k_s^2 term in that operator, so D_m = -k_m^2 as the design specifies.
+    !> (Convention question flagged for the P2.7 cross-check: whether a physical
+    !> perpendicular k_s^2 contribution belongs on the diagonal.)
+    !>
+    !> The right-hand side matches create_rhs_vector's sign convention
+    !> (solve_poisson.f90:129, rhs = -4*pi * K_rho_B * Br). For type_br_field=12
+    !> Br is constant over the window, so its Fourier coefficient is nonzero only
+    !> at m' = 0:  Br_{m'} = Br_const * delta_{m',0}. The RHS therefore reduces to
+    !>
+    !>   b_m = -4*pi * Br_const * KB(m, m'=0) = -4*pi * Br_const * KB(:, M+1).
+    !>
+    !> The dense complex system is solved with LAPACK zgesv (same argument
+    !> pattern as electromagnetic_solver.f90:243), then the potential is
+    !> reconstructed on an output radial grid as
+    !>
+    !>   dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r).
+
+    use KIM_kinds_m, only: dp
+
+    implicit none
+    private
+
+    public :: solve_periodic, reconstruct_delta_phi, dense_solve
+
+contains
+
+    !> Solve the periodic electrostatic system for the Fourier coefficients
+    !> Phi_m of the potential, given the Phase-2.4 matrices Kphi/KB, the period
+    !> L, the mode cutoff M, and the constant drive amplitude Br_const.
+    subroutine solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+        use constants_m, only: pi
+
+        complex(dp), intent(in) :: Kphi(:,:), KB(:,:)
+        real(dp), intent(in) :: L
+        integer, intent(in) :: M
+        complex(dp), intent(in) :: Br_const
+        complex(dp), allocatable, intent(out) :: Phi_m(:)
+        integer, intent(out) :: info
+
+        complex(dp), allocatable :: A(:,:), b(:)
+        real(dp) :: k_m
+        integer :: dim, im, m_row
+
+        dim = 2 * M + 1
+        allocate(A(dim, dim), b(dim))
+
+        ! A = 4*pi Kphi with the diagonal Fourier-space radial operator
+        ! D_m = -k_m^2 (k_m = 2*pi*m/L) added on the diagonal.
+        A = 4.0_dp * pi * Kphi
+        do m_row = -M, M
+            im = m_row + M + 1
+            k_m = 2.0_dp * pi * real(m_row, dp) / L
+            A(im, im) = A(im, im) - k_m * k_m
+        end do
+
+        ! b = -4*pi Br_const KB(:, m'=0). The constant drive projects onto the
+        ! m' = 0 column only (column index M+1).
+        b = -4.0_dp * pi * Br_const * KB(:, M + 1)
+
+        call dense_solve(A, b, info)
+
+        Phi_m = b
+    end subroutine solve_periodic
+
+    !> Solve the dense complex system A x = b in place via LAPACK zgesv, using
+    !> the same argument pattern as electromagnetic_solver.f90:243. On entry b
+    !> is the RHS; on exit b holds the solution and A is LU-overwritten.
+    !> info == 0 on success.
+    subroutine dense_solve(A, b, info)
+        complex(dp), intent(inout) :: A(:,:), b(:)
+        integer, intent(out) :: info
+
+        integer, allocatable :: ipiv(:)
+        integer :: dim
+
+        dim = size(A, 1)
+        allocate(ipiv(dim))
+        call zgesv(dim, 1, A, dim, ipiv, b, dim, info)
+        deallocate(ipiv)
+    end subroutine dense_solve
+
+    !> Inverse DFT: reconstruct dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r)
+    !> on the output radial grid r_out, with k_m = 2*pi*m/L. Phi_m is indexed
+    !> im = m + M + 1 (size 2M+1).
+    function reconstruct_delta_phi(Phi_m, L, M, r_out) result(dPhi)
+        use constants_m, only: pi, com_unit
+
+        complex(dp), intent(in) :: Phi_m(:)
+        real(dp), intent(in) :: L, r_out(:)
+        integer, intent(in) :: M
+        complex(dp) :: dPhi(size(r_out))
+
+        real(dp) :: k_m
+        integer :: i, m_row, im
+
+        dPhi = (0.0_dp, 0.0_dp)
+        do m_row = -M, M
+            im = m_row + M + 1
+            k_m = 2.0_dp * pi * real(m_row, dp) / L
+            do i = 1, size(r_out)
+                dPhi(i) = dPhi(i) + Phi_m(im) * exp(com_unit * k_m * r_out(i))
+            end do
+        end do
+    end function reconstruct_delta_phi
+
+end module periodic_solve_m

--- a/KIM/src/electrostatic_poisson/periodic_solve.f90
+++ b/KIM/src/electrostatic_poisson/periodic_solve.f90
@@ -110,10 +110,9 @@ contains
     !> Br_{m'} = Br_const * delta_{m',0} and the KjB term collapses to the
     !> m' = 0 column (index M+1) -- the same convention as solve_periodic's RHS.
     !>
-    !> There is NO 4*pi here. solve_periodic carries one because the potential
-    !> obeys Poisson's equation; (11.7) does not, and correspondingly hatG_j_phi
-    !> / hatG_j_B omit the /(4*pi) that hatG_rho_* apply (see
-    !> flr2_fourier_kernel_m). Kjphi/KjB therefore enter unscaled.
+    !> hatG_j_phi / hatG_j_B already include the 1/(8*pi^2) Fourier
+    !> normalization from equations (14.5)/(14.6). Kjphi/KjB therefore enter
+    !> this reconstruction without further scaling.
     !>
     !> j_par is then inverse-DFT'd exactly as the potential is:
     !>   j_par(r) = sum_{m=-M}^{M} j_m exp(i k_m r).

--- a/KIM/src/electrostatic_poisson/periodic_solve.f90
+++ b/KIM/src/electrostatic_poisson/periodic_solve.f90
@@ -35,7 +35,7 @@ module periodic_solve_m
     implicit none
     private
 
-    public :: solve_periodic, reconstruct_delta_phi, dense_solve
+    public :: solve_periodic, reconstruct_delta_phi, dense_solve, reconstruct_jpar
 
 contains
 
@@ -93,6 +93,44 @@ contains
         call zgesv(dim, 1, A, dim, ipiv, b, dim, info)
         deallocate(ipiv)
     end subroutine dense_solve
+
+    !> Reconstruct the parallel current density perturbation j_par(r) on the
+    !> output grid r_out, given the solved potential coefficients Phi_m and the
+    !> constant drive amplitude Br_const.
+    !>
+    !> Thesis (11.7) defines the current density directly from the two fields,
+    !>
+    !>   delta_j_par(x) = K^{jPhi}(x,x') delta_Phi(x') + K^{jB}(x,x') delta_Br(x'),
+    !>
+    !> which in the Fourier basis over m = -M..M is
+    !>
+    !>   j_m = sum_{m'} [ Kjphi(m,m') Phi_{m'} + KjB(m,m') Br_{m'} ].
+    !>
+    !> For type_br_field = 12 the drive is constant over the window, so
+    !> Br_{m'} = Br_const * delta_{m',0} and the KjB term collapses to the
+    !> m' = 0 column (index M+1) -- the same convention as solve_periodic's RHS.
+    !>
+    !> There is NO 4*pi here. solve_periodic carries one because the potential
+    !> obeys Poisson's equation; (11.7) does not, and correspondingly hatG_j_phi
+    !> / hatG_j_B omit the /(4*pi) that hatG_rho_* apply (see
+    !> flr2_fourier_kernel_m). Kjphi/KjB therefore enter unscaled.
+    !>
+    !> j_par is then inverse-DFT'd exactly as the potential is:
+    !>   j_par(r) = sum_{m=-M}^{M} j_m exp(i k_m r).
+    function reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out) result(jpar)
+        complex(dp), intent(in) :: Kjphi(:,:), KjB(:,:)
+        complex(dp), intent(in) :: Phi_m(:)
+        complex(dp), intent(in) :: Br_const
+        real(dp), intent(in) :: L, r_out(:)
+        integer, intent(in) :: M
+        complex(dp) :: jpar(size(r_out))
+
+        complex(dp), allocatable :: j_m(:)
+
+        j_m = matmul(Kjphi, Phi_m) + Br_const * KjB(:, M + 1)
+
+        jpar = reconstruct_delta_phi(j_m, L, M, r_out)
+    end function reconstruct_jpar
 
     !> Inverse DFT: reconstruct dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r)
     !> on the output radial grid r_out, with k_m = 2*pi*m/L. Phi_m is indexed

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -151,10 +151,12 @@ module rt_electrostatic_periodic_m
         print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
 
         ! 4. Window output grid: n_rg equidistant points on [rm - L/2, rm + L/2],
-        ! matching the grid build_periodic_plasma installs as rg_grid%xb.
+        ! bit-identical to the grid build_periodic_plasma installs as rg_grid%xb
+        ! via grid_generate_equidistant: spacing h = L/n_rg (NOT L/(n_rg-1)),
+        ! endpoint-exclusive at the top (last node = rm + L/2 - L/n_rg).
         allocate(r_win(n_rg))
         do i = 1, n_rg
-            r_win(i) = (rm - 0.5_dp * L) + real(i - 1, dp) * L / real(n_rg - 1, dp)
+            r_win(i) = (rm - 0.5_dp * L) + real(i - 1, dp) * L / real(n_rg, dp)
         end do
 
         ! 5. Build -> assemble -> solve -> reconstruct on r_win via the reusable
@@ -167,6 +169,12 @@ module rt_electrostatic_periodic_m
             error stop "electrostatic_periodic: periodic solve failed"
         end if
 
+        ! Lock: the core has installed rg_grid%xb via build_periodic_plasma; the
+        ! run-type's output grid r_win MUST equal it so EBdat is on the window.
+        if (maxval(abs(r_win - rg_grid%xb)) > 1.0e-9_dp) then
+            error stop "run_electrostatic_periodic: r_win grid does not match rg_grid%xb"
+        end if
+
         ! 6. Pack into EBdat (window grid + reconstructed potential).
         if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
         if (allocated(EBdat%Phi))    deallocate(EBdat%Phi)
@@ -174,7 +182,7 @@ module rt_electrostatic_periodic_m
         EBdat%Phi    = dPhi
 
         if (hdf5_output) then
-            call write_complex_profile_abs(rg_grid%xb, EBdat%Phi, rg_grid%npts_b, &
+            call write_complex_profile_abs(EBdat%r_grid, EBdat%Phi, rg_grid%npts_b, &
                 "/fields/Phi", &
                 'Electrostatic potential perturbation Phi, forced-periodicity solution', &
                 'statV')

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -19,7 +19,46 @@ module rt_electrostatic_periodic_m
             procedure :: run => run_electrostatic_periodic
     end type electrostatic_periodic_t
 
+    public :: compute_periodic_delta_phi
+
     contains
+
+    !> Reusable periodic core: build the window plasma, assemble the Fourier
+    !> matrices, solve for the coefficients Phi_m under a constant Br drive, and
+    !> reconstruct delta_Phi on the EXPLICIT output grid r_out (NOT on the window
+    !> grid rg_grid%xb). All window sizing is passed in EXPLICITLY so both the
+    !> run-type and the Phase-3 convergence harness can evaluate delta_Phi on a
+    !> fixed diagnostic grid independent of the (n_rg, M, dx) discretization.
+    !>
+    !> Does NOT error stop on a singular solve: it returns info /= 0 so the
+    !> caller can decide (the run-type error stops; the tests inspect info).
+    subroutine compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
+                                          r_out, dPhi, info)
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma
+        use periodic_background_m, only: build_periodic_plasma
+        use periodic_assembly_m, only: assemble_periodic_matrices
+        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi
+
+        real(dp),    intent(in)  :: rm, dx_asis, dx_tr
+        integer,     intent(in)  :: M, n_rg
+        complex(dp), intent(in)  :: Br_const
+        real(dp),    intent(in)  :: r_out(:)
+        complex(dp), allocatable, intent(out) :: dPhi(:)
+        integer,     intent(out) :: info
+
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:)
+        real(dp) :: L
+
+        L = 2.0_dp * (dx_asis + dx_tr)
+
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+        call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+        if (info /= 0) return
+
+        dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+    end subroutine compute_periodic_delta_phi
 
     !> Global setup, identical to the electrostatic run-type's init: build the
     !> grids and equilibrium and populate the GLOBAL plasma. run() reads the
@@ -71,9 +110,6 @@ module rt_electrostatic_periodic_m
         use species_m, only: plasma
         use grid_m, only: rg_grid
         use kim_resonances_m, only: r_res
-        use periodic_background_m, only: build_periodic_plasma
-        use periodic_assembly_m, only: assemble_periodic_matrices
-        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi
         use fields_m, only: EBdat
         use IO_collection_m, only: write_complex_profile_abs
 
@@ -81,10 +117,11 @@ module rt_electrostatic_periodic_m
 
         class(electrostatic_periodic_t), intent(inout) :: this
 
-        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:), dPhi(:)
+        complex(dp), allocatable :: dPhi(:)
         complex(dp) :: Br_const
+        real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
-        integer :: M, n_rg, info
+        integer :: M, n_rg, info, i
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
         call prepare_resonances
@@ -113,27 +150,27 @@ module rt_electrostatic_periodic_m
         print *, "electrostatic_periodic: rm = ", rm, " rho_L(rm) = ", rhoL_rm
         print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
 
-        ! 4. Build the periodic window plasma (redirects rg_grid + plasma).
-        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+        ! 4. Window output grid: n_rg equidistant points on [rm - L/2, rm + L/2],
+        ! matching the grid build_periodic_plasma installs as rg_grid%xb.
+        allocate(r_win(n_rg))
+        do i = 1, n_rg
+            r_win(i) = (rm - 0.5_dp * L) + real(i - 1, dp) * L / real(n_rg - 1, dp)
+        end do
 
-        ! 5. Assemble the dense periodic Fourier matrices over one period.
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
-
-        ! 6. Solve for the Fourier coefficients Phi_m under the constant Br drive.
+        ! 5. Build -> assemble -> solve -> reconstruct on r_win via the reusable
+        ! periodic core. It does NOT error stop on a singular solve; do it here.
         Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
-        call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+        call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
+                                        r_win, dPhi, info)
         if (info /= 0) then
             print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
             error stop "electrostatic_periodic: periodic solve failed"
         end if
 
-        ! 7. Reconstruct delta_Phi on the window grid via inverse DFT.
-        dPhi = reconstruct_delta_phi(Phi_m, L, M, rg_grid%xb)
-
-        ! 8. Pack into EBdat (window grid + reconstructed potential).
+        ! 6. Pack into EBdat (window grid + reconstructed potential).
         if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
         if (allocated(EBdat%Phi))    deallocate(EBdat%Phi)
-        EBdat%r_grid = rg_grid%xb
+        EBdat%r_grid = r_win
         EBdat%Phi    = dPhi
 
         if (hdf5_output) then

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -49,6 +49,8 @@ module rt_electrostatic_periodic_m
         use periodic_background_m, only: build_periodic_plasma
         use periodic_assembly_m, only: assemble_periodic_matrices
         use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, reconstruct_jpar
+        use config_m, only: periodic_match_global_kernel_approximations
+        use flr2_fourier_kernel_m, only: set_global_kernel_approximations
 
         real(dp),    intent(in)  :: rm, dx_asis, dx_tr
         integer,     intent(in)  :: M, n_rg
@@ -63,6 +65,7 @@ module rt_electrostatic_periodic_m
 
         L = 2.0_dp * (dx_asis + dx_tr)
 
+        call set_global_kernel_approximations(periodic_match_global_kernel_approximations)
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
         call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
@@ -195,6 +198,7 @@ module rt_electrostatic_periodic_m
         use constants_m, only: pi
         use config_m, only: periodic_dr_asis_scale, periodic_dr_tr_scale, &
                             periodic_kmax_scale, periodic_n_rg, hdf5_output, &
+                            periodic_match_global_kernel_approximations, &
                             turn_off_electrons, turn_off_ions
         use setup_m, only: Br_boundary_re, Br_boundary_im
         use species_m, only: plasma
@@ -253,6 +257,8 @@ module rt_electrostatic_periodic_m
                  " dx_tr [cm] = ", dx_tr, " L [cm] = ", L
         print *, "electrostatic_periodic: k_max [1/cm] = ", k_max, &
                  " M = ", M, " n_rg = ", n_rg
+        print *, "electrostatic_periodic: match global kernel approximations = ", &
+                 periodic_match_global_kernel_approximations
         call write_periodic_scale_metadata(reference_species, &
             plasma%spec(reference_species)%Zspec, &
             plasma%spec(reference_species)%mass, rhoL_rm, dx_asis, dx_tr, &

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -19,7 +19,11 @@ module rt_electrostatic_periodic_m
             procedure :: run => run_electrostatic_periodic
     end type electrostatic_periodic_t
 
-    public :: compute_periodic_delta_phi
+    integer, parameter, public :: PERIODIC_SCALE_OK = 0
+    integer, parameter, public :: PERIODIC_SCALE_NO_ACTIVE = 1
+    integer, parameter, public :: PERIODIC_SCALE_INVALID_RHO = 2
+
+    public :: compute_periodic_delta_phi, select_periodic_reference_scale
 
     contains
 
@@ -59,6 +63,80 @@ module rt_electrostatic_periodic_m
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
     end subroutine compute_periodic_delta_phi
+
+    !> Select the largest Larmor radius among species active in the FP kernel.
+    subroutine select_periodic_reference_scale(plasma_in, x, electrons_active, ions_active, &
+                                               rho_ref, reference_species, info)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: x
+        logical, intent(in) :: electrons_active, ions_active
+        real(dp), intent(out) :: rho_ref
+        integer, intent(out) :: reference_species, info
+
+        real(dp) :: rho_sp
+        integer :: sp
+
+        rho_ref = 0.0_dp
+        reference_species = -1
+        info = PERIODIC_SCALE_NO_ACTIVE
+        if (plasma_in%n_species <= 0) return
+        if (.not. allocated(plasma_in%spec) .or. .not. allocated(plasma_in%r_grid) &
+            .or. plasma_in%grid_size < 4) then
+            info = PERIODIC_SCALE_INVALID_RHO
+            return
+        end if
+
+        do sp = 0, plasma_in%n_species - 1
+            if (.not. electrons_active .and. sp == 0) cycle
+            if (.not. ions_active .and. sp >= 1) cycle
+            if (.not. allocated(plasma_in%spec(sp)%rho_L) &
+                .or. size(plasma_in%spec(sp)%rho_L) < plasma_in%grid_size) then
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            rho_sp = interp_species_rho_L(plasma_in, sp, x)
+            if (.not. ieee_is_finite(rho_sp) .or. rho_sp <= 0.0_dp) then
+                rho_ref = rho_sp
+                reference_species = sp
+                info = PERIODIC_SCALE_INVALID_RHO
+                return
+            end if
+            if (rho_sp > rho_ref) then
+                rho_ref = rho_sp
+                reference_species = sp
+            end if
+        end do
+
+        if (reference_species >= 0) info = PERIODIC_SCALE_OK
+    end subroutine select_periodic_reference_scale
+
+    real(dp) function interp_species_rho_L(plasma_in, sp, x) result(rhoLx)
+        use KIM_kinds_m, only: dp
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma_in%grid_size
+        call binsrc(plasma_in%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma_in%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma_in%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     !> Global setup, identical to the electrostatic run-type's init: build the
     !> grids and equilibrium and populate the GLOBAL plasma. run() reads the
@@ -105,13 +183,14 @@ module rt_electrostatic_periodic_m
         use KIM_kinds_m, only: dp
         use constants_m, only: pi
         use config_m, only: periodic_dr_asis_scale, periodic_dr_tr_scale, &
-                            periodic_kmax_scale, periodic_n_rg, hdf5_output
+                            periodic_kmax_scale, periodic_n_rg, hdf5_output, &
+                            turn_off_electrons, turn_off_ions
         use setup_m, only: Br_boundary_re, Br_boundary_im
         use species_m, only: plasma
         use grid_m, only: rg_grid
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
-        use IO_collection_m, only: write_complex_profile_abs
+        use IO_collection_m, only: write_complex_profile_abs, write_periodic_scale_metadata
 
         implicit none
 
@@ -121,7 +200,7 @@ module rt_electrostatic_periodic_m
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
-        integer :: M, n_rg, info, i
+        integer :: M, n_rg, info, i, reference_species
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
         call prepare_resonances
@@ -131,13 +210,20 @@ module rt_electrostatic_periodic_m
         end if
         rm = r_res
 
-        ! 2. Representative Larmor radius rho_L(rm) (electrons) on the global
-        ! plasma via 4-point Lagrange interpolation.
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, "Error (electrostatic_periodic): rho_L(rm) not positive, = ", rhoL_rm
-            error stop "electrostatic_periodic: invalid rho_L(rm)"
-        end if
+        ! 2. Select the largest Larmor radius among the species that the FP
+        ! kernel will actually assemble. This keeps the full response of every
+        ! active species resolved and is independent of species storage order.
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, info)
+        select case (info)
+        case (PERIODIC_SCALE_NO_ACTIVE)
+            error stop "electrostatic_periodic: no active kinetic species"
+        case (PERIODIC_SCALE_INVALID_RHO)
+            print *, "Error (electrostatic_periodic): invalid rho_L for species ", &
+                     reference_species, " value = ", rhoL_rm
+            error stop "electrostatic_periodic: invalid active-species rho_L(rm)"
+        end select
 
         ! 3. Window geometry and Fourier cutoff from rho_L(rm).
         dx_asis = periodic_dr_asis_scale * rhoL_rm
@@ -147,8 +233,19 @@ module rt_electrostatic_periodic_m
         M       = ceiling(k_max * L / (2.0_dp * pi))
         n_rg    = periodic_n_rg
 
-        print *, "electrostatic_periodic: rm = ", rm, " rho_L(rm) = ", rhoL_rm
-        print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
+        print *, "electrostatic_periodic: reference species = ", reference_species, &
+                 " Z = ", plasma%spec(reference_species)%Zspec, &
+                 " mass [g] = ", plasma%spec(reference_species)%mass
+        print *, "electrostatic_periodic: rm [cm] = ", rm, &
+                 " rho_L(rm) [cm] = ", rhoL_rm
+        print *, "electrostatic_periodic: dx_asis [cm] = ", dx_asis, &
+                 " dx_tr [cm] = ", dx_tr, " L [cm] = ", L
+        print *, "electrostatic_periodic: k_max [1/cm] = ", k_max, &
+                 " M = ", M, " n_rg = ", n_rg
+        call write_periodic_scale_metadata(reference_species, &
+            plasma%spec(reference_species)%Zspec, &
+            plasma%spec(reference_species)%mass, rhoL_rm, dx_asis, dx_tr, &
+            k_max, M, n_rg)
 
         ! 4. Window output grid: n_rg equidistant points on [rm - L/2, rm + L/2],
         ! bit-identical to the grid build_periodic_plasma installs as rg_grid%xb
@@ -187,29 +284,6 @@ module rt_electrostatic_periodic_m
                 'Electrostatic potential perturbation Phi, forced-periodicity solution', &
                 'statV')
         end if
-
-    contains
-
-        !> 4-point Lagrange interpolation of the global electron Larmor radius
-        !> plasma%spec(0)%rho_L at radius x, using the same binsrc + plag_coeff
-        !> stencil as the rest of KIM.
-        real(dp) function interp_rho_L(x) result(rhoLx)
-            real(dp), intent(in) :: x
-            integer, parameter :: nlagr = 4, nder = 0
-            real(dp) :: coef(0:nder, nlagr)
-            integer :: gs, ir, ibeg, iend
-
-            gs = plasma%grid_size
-            call binsrc(plasma%r_grid, 1, gs, x, ir)
-            ibeg = max(1, ir - nlagr/2)
-            iend = ibeg + nlagr - 1
-            if (iend > gs) then
-                iend = gs
-                ibeg = iend - nlagr + 1
-            end if
-            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-            rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-        end function interp_rho_L
 
     end subroutine run_electrostatic_periodic
 

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -1,0 +1,171 @@
+! run type for the electrostatic forced-periodicity model.
+!
+! On a given (m, n) case this run-type locates the resonant surface rm, sizes a
+! periodic window from a representative Larmor radius rho_L(rm), builds the
+! periodic plasma on that window (Phase-2.3), assembles the dense Fourier
+! matrices K^{rhoPhi}/K^{rhoB} over one period (Phase-2.4), solves the periodic
+! electrostatic system for the Fourier coefficients Phi_m and inverse-DFTs them
+! into delta_Phi(r) on the window grid (Phase-2.5), then packs delta_Phi into
+! fields_m::EBdat.
+module rt_electrostatic_periodic_m
+
+    use kim_base_m, only: kim_t
+
+    implicit none
+
+    type, extends(kim_t) :: electrostatic_periodic_t
+        contains
+            procedure :: init => init_electrostatic_periodic
+            procedure :: run => run_electrostatic_periodic
+    end type electrostatic_periodic_t
+
+    contains
+
+    !> Global setup, identical to the electrostatic run-type's init: build the
+    !> grids and equilibrium and populate the GLOBAL plasma. run() reads the
+    !> resonance rm and the representative rho_L(rm) from that global plasma
+    !> before redirecting the grid onto the periodic window.
+    subroutine init_electrostatic_periodic(this)
+
+        use species_m, only: plasma, set_plasma_quantities
+        use IO_collection_m, only: create_output_directories
+        use equilibrium_m, only: calculate_equil, interpolate_equil
+        use grid_m, only: rg_grid
+        use config_m, only: output_path, hdf5_output
+
+        implicit none
+
+        class(electrostatic_periodic_t), intent(inout) :: this
+        logical :: ex
+
+        this%run_type = "electrostatic_periodic"
+
+        call create_output_directories
+
+        ! Create setup/ directory for text output of setup parameters
+        if (.not. hdf5_output) then
+            inquire(file=trim(output_path)//'setup', exist=ex)
+            if (.not. ex) then
+                call system('mkdir -p '//trim(output_path)//'setup')
+            end if
+        end if
+        call generate_grids
+        call calculate_equil(.true.)
+        call set_plasma_quantities(plasma)
+        call interpolate_equil(rg_grid%xb)
+
+        print *, "..."//trim(this%run_type)//" model initialized."
+
+    end subroutine init_electrostatic_periodic
+
+    !> Locate the resonance, size and build the periodic window plasma, assemble
+    !> the Fourier matrices, solve, reconstruct delta_Phi on the window grid, and
+    !> pack it into fields_m::EBdat.
+    subroutine run_electrostatic_periodic(this)
+
+        use KIM_kinds_m, only: dp
+        use constants_m, only: pi
+        use config_m, only: periodic_dr_asis_scale, periodic_dr_tr_scale, &
+                            periodic_kmax_scale, periodic_n_rg, hdf5_output
+        use setup_m, only: Br_boundary_re, Br_boundary_im
+        use species_m, only: plasma
+        use grid_m, only: rg_grid
+        use kim_resonances_m, only: r_res
+        use periodic_background_m, only: build_periodic_plasma
+        use periodic_assembly_m, only: assemble_periodic_matrices
+        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi
+        use fields_m, only: EBdat
+        use IO_collection_m, only: write_complex_profile_abs
+
+        implicit none
+
+        class(electrostatic_periodic_t), intent(inout) :: this
+
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:), dPhi(:)
+        complex(dp) :: Br_const
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
+        integer :: M, n_rg, info
+
+        ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, "Error (electrostatic_periodic): no resonance found, r_res = ", r_res
+            error stop "electrostatic_periodic: resonance not found"
+        end if
+        rm = r_res
+
+        ! 2. Representative Larmor radius rho_L(rm) (electrons) on the global
+        ! plasma via 4-point Lagrange interpolation.
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, "Error (electrostatic_periodic): rho_L(rm) not positive, = ", rhoL_rm
+            error stop "electrostatic_periodic: invalid rho_L(rm)"
+        end if
+
+        ! 3. Window geometry and Fourier cutoff from rho_L(rm).
+        dx_asis = periodic_dr_asis_scale * rhoL_rm
+        dx_tr   = periodic_dr_tr_scale * rhoL_rm
+        L       = 2.0_dp * (dx_asis + dx_tr)
+        k_max   = periodic_kmax_scale / rhoL_rm
+        M       = ceiling(k_max * L / (2.0_dp * pi))
+        n_rg    = periodic_n_rg
+
+        print *, "electrostatic_periodic: rm = ", rm, " rho_L(rm) = ", rhoL_rm
+        print *, "electrostatic_periodic: L = ", L, " M = ", M, " n_rg = ", n_rg
+
+        ! 4. Build the periodic window plasma (redirects rg_grid + plasma).
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+
+        ! 5. Assemble the dense periodic Fourier matrices over one period.
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+
+        ! 6. Solve for the Fourier coefficients Phi_m under the constant Br drive.
+        Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
+        call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
+        if (info /= 0) then
+            print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
+            error stop "electrostatic_periodic: periodic solve failed"
+        end if
+
+        ! 7. Reconstruct delta_Phi on the window grid via inverse DFT.
+        dPhi = reconstruct_delta_phi(Phi_m, L, M, rg_grid%xb)
+
+        ! 8. Pack into EBdat (window grid + reconstructed potential).
+        if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
+        if (allocated(EBdat%Phi))    deallocate(EBdat%Phi)
+        EBdat%r_grid = rg_grid%xb
+        EBdat%Phi    = dPhi
+
+        if (hdf5_output) then
+            call write_complex_profile_abs(rg_grid%xb, EBdat%Phi, rg_grid%npts_b, &
+                "/fields/Phi", &
+                'Electrostatic potential perturbation Phi, forced-periodicity solution', &
+                'statV')
+        end if
+
+    contains
+
+        !> 4-point Lagrange interpolation of the global electron Larmor radius
+        !> plasma%spec(0)%rho_L at radius x, using the same binsrc + plag_coeff
+        !> stencil as the rest of KIM.
+        real(dp) function interp_rho_L(x) result(rhoLx)
+            real(dp), intent(in) :: x
+            integer, parameter :: nlagr = 4, nder = 0
+            real(dp) :: coef(0:nder, nlagr)
+            integer :: gs, ir, ibeg, iend
+
+            gs = plasma%grid_size
+            call binsrc(plasma%r_grid, 1, gs, x, ir)
+            ibeg = max(1, ir - nlagr/2)
+            iend = ibeg + nlagr - 1
+            if (iend > gs) then
+                iend = gs
+                ibeg = iend - nlagr + 1
+            end if
+            call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+            rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
+        end function interp_rho_L
+
+    end subroutine run_electrostatic_periodic
+
+end module rt_electrostatic_periodic_m

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -36,13 +36,19 @@ module rt_electrostatic_periodic_m
     !>
     !> Does NOT error stop on a singular solve: it returns info /= 0 so the
     !> caller can decide (the run-type error stops; the tests inspect info).
+    !>
+    !> The optional jpar returns the parallel current density perturbation on the
+    !> same r_out, per thesis (11.7): j_par = K^{jPhi} Phi + K^{jB} Br. It is
+    !> OPTIONAL because the Phase-3 convergence harnesses scan many (n_rg, M)
+    !> values for dPhi alone and have no use for it. Like dPhi, it is left
+    !> unallocated when the solve fails (info /= 0).
     subroutine compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                          r_out, dPhi, info)
+                                          r_out, dPhi, info, jpar)
         use KIM_kinds_m, only: dp
         use species_m, only: plasma
         use periodic_background_m, only: build_periodic_plasma
         use periodic_assembly_m, only: assemble_periodic_matrices
-        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi
+        use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, reconstruct_jpar
 
         real(dp),    intent(in)  :: rm, dx_asis, dx_tr
         integer,     intent(in)  :: M, n_rg
@@ -50,18 +56,23 @@ module rt_electrostatic_periodic_m
         real(dp),    intent(in)  :: r_out(:)
         complex(dp), allocatable, intent(out) :: dPhi(:)
         integer,     intent(out) :: info
+        complex(dp), allocatable, intent(out), optional :: jpar(:)
 
-        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:)
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:), Phi_m(:)
         real(dp) :: L
 
         L = 2.0_dp * (dx_asis + dx_tr)
 
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
         if (info /= 0) return
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+
+        if (present(jpar)) then
+            jpar = reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out)
+        end if
     end subroutine compute_periodic_delta_phi
 
     !> Select the largest Larmor radius among species active in the FP kernel.
@@ -196,7 +207,7 @@ module rt_electrostatic_periodic_m
 
         class(electrostatic_periodic_t), intent(inout) :: this
 
-        complex(dp), allocatable :: dPhi(:)
+        complex(dp), allocatable :: dPhi(:), jpar(:)
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
@@ -260,7 +271,7 @@ module rt_electrostatic_periodic_m
         ! periodic core. It does NOT error stop on a singular solve; do it here.
         Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
         call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                        r_win, dPhi, info)
+                                        r_win, dPhi, info, jpar)
         if (info /= 0) then
             print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
             error stop "electrostatic_periodic: periodic solve failed"
@@ -272,17 +283,23 @@ module rt_electrostatic_periodic_m
             error stop "run_electrostatic_periodic: r_win grid does not match rg_grid%xb"
         end if
 
-        ! 6. Pack into EBdat (window grid + reconstructed potential).
+        ! 6. Pack into EBdat (window grid + reconstructed potential + current).
         if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
         if (allocated(EBdat%Phi))    deallocate(EBdat%Phi)
+        if (allocated(EBdat%jpar))   deallocate(EBdat%jpar)
         EBdat%r_grid = r_win
         EBdat%Phi    = dPhi
+        EBdat%jpar   = jpar
 
         if (hdf5_output) then
             call write_complex_profile_abs(EBdat%r_grid, EBdat%Phi, rg_grid%npts_b, &
                 "/fields/Phi", &
                 'Electrostatic potential perturbation Phi, forced-periodicity solution', &
                 'statV')
+            call write_complex_profile_abs(EBdat%r_grid, EBdat%jpar, rg_grid%npts_b, &
+                "/fields/jpar", &
+                'Parallel current density perturbation j_par, forced-periodicity solution', &
+                'statA/cm^2')
         end if
 
     end subroutine run_electrostatic_periodic

--- a/KIM/src/general/KIM_mod.f90
+++ b/KIM/src/general/KIM_mod.f90
@@ -9,6 +9,7 @@ module kim_mod_m
         use kim_base_m, only: kim_t
         use rt_WKB_dispersion_m, only: WKB_dispersion_t
         use rt_electrostatic_m, only: electrostatic_t
+        use rt_electrostatic_periodic_m, only: electrostatic_periodic_t
         use rt_electromagnetic_m, only: electromagnetic_t
         use rt_flr2_benchmark_m, only: flr2_benchmark_t
 
@@ -20,6 +21,8 @@ module kim_mod_m
         select case(trim(type_of_run))
             case("electrostatic")
                 allocate(kim_instance, source=electrostatic_t())
+            case("electrostatic_periodic")
+                allocate(kim_instance, source=electrostatic_periodic_t())
             case("flr2_benchmark")
                 allocate(kim_instance, source=flr2_benchmark_t())
             case("WKB_dispersion")
@@ -28,7 +31,7 @@ module kim_mod_m
                 allocate(kim_instance, source=electromagnetic_t())
             case default
                 print *, "Invalid kim type of run " // trim(type_of_run)
-                print *, "Options are: electrostatic, electromagnetic, flr2_benchmark, WKB_dispersion"
+                print *, "Options are: electrostatic, electrostatic_periodic, electromagnetic, flr2_benchmark, WKB_dispersion"
                 stop "Due to invalid type of run"
         end select
 

--- a/KIM/src/general/kim_solver_m.f90
+++ b/KIM/src/general/kim_solver_m.f90
@@ -44,6 +44,7 @@ module kim_solver_m
         real(dp),    allocatable :: r_field(:)
         complex(dp), allocatable :: Es(:), Ep(:), Er(:), Etheta(:), Ez(:), Br(:)
         complex(dp), allocatable :: jpar(:), jpar_e(:), jpar_i(:)
+        complex(dp), allocatable :: Phi(:)
 
         ! derived background (plasma grid)
         real(dp), allocatable :: r_plasma(:)
@@ -278,6 +279,7 @@ contains
         if (allocated(EBdat%jpar))   res%jpar    = EBdat%jpar
         if (allocated(EBdat%jpar_e)) res%jpar_e  = EBdat%jpar_e
         if (allocated(EBdat%jpar_i)) res%jpar_i  = EBdat%jpar_i
+        if (allocated(EBdat%Phi))    res%Phi     = EBdat%Phi
 
         ! derived background (plasma grid)
         if (allocated(plasma%r_grid)) res%r_plasma = plasma%r_grid

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -52,7 +52,8 @@ subroutine kim_read_config
     ! Optional group for the forced-periodicity electrostatic run-type. Read
     ! separately (iostat-guarded, below) so config files without it still parse.
     namelist /KIM_PERIODIC/ periodic_dr_asis_scale, periodic_dr_tr_scale, &
-                        periodic_kmax_scale, periodic_n_rg
+                        periodic_kmax_scale, periodic_n_rg, &
+                        periodic_match_global_kernel_approximations
 
     integer :: periodic_iostat
 
@@ -80,6 +81,7 @@ subroutine kim_read_config
 
     ! Optional KIM_PERIODIC group: rewind and read with iostat so config files
     ! that omit it keep the config_m defaults instead of aborting the read.
+    periodic_match_global_kernel_approximations = .false.
     rewind(unit = 77)
     read(unit = 77, nml = KIM_PERIODIC, iostat = periodic_iostat)
 

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -49,6 +49,13 @@ subroutine kim_read_config
                         n_input_file, Te_input_file, Ti_input_file, Vz_input_file, &
                         n_file, Te_file, Ti_file, Vz_file, Er_file, q_file
 
+    ! Optional group for the forced-periodicity electrostatic run-type. Read
+    ! separately (iostat-guarded, below) so config files without it still parse.
+    namelist /KIM_PERIODIC/ periodic_dr_asis_scale, periodic_dr_tr_scale, &
+                        periodic_kmax_scale, periodic_n_rg
+
+    integer :: periodic_iostat
+
     num_args = command_argument_count()
     if (num_args > 1) then
         write(*,*) 'Too many arguments'
@@ -70,6 +77,12 @@ subroutine kim_read_config
     read(unit = 77, nml = KIM_SETUP)
     read(unit = 77, nml = KIM_GRID)
     read(unit = 77, nml = KIM_PROFILES)
+
+    ! Optional KIM_PERIODIC group: rewind and read with iostat so config files
+    ! that omit it keep the config_m defaults instead of aborting the read.
+    rewind(unit = 77)
+    read(unit = 77, nml = KIM_PERIODIC, iostat = periodic_iostat)
+
     close(unit = 77)
 
     ! Propagate KIM_CONFIG flag to the QL-Balance getIfunc_config module

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -41,6 +41,10 @@ module config_m
     real(dp) :: periodic_dr_tr_scale   = 10.0_dp  ! transition width / rho_L(rm)
     real(dp) :: periodic_kmax_scale    = 5.0_dp   ! k_max * rho_L(rm)
     integer  :: periodic_n_rg          = 96       ! window grid boundary points
+    ! Reproduce the global FEM kernel approximations for direct comparisons:
+    ! drop k_s^2 from Bessel arguments and take electrons in the zero-FLR limit.
+    ! The forced-periodic solver uses its full Fourier kernel by default.
+    logical :: periodic_match_global_kernel_approximations = .false.
 
     ! KIM_IO namelist variables
     character(256) :: profile_location ! path to profile directory

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -33,6 +33,15 @@ module config_m
     real(dp) :: WKB_root_tolerance = 1.0d-6           ! |f(z)| tolerance for valid roots
     logical :: WKB_verbose = .false.                  ! Verbose dispersion solver output
 
+    ! KIM_PERIODIC namelist variables (forced-periodicity electrostatic run-type).
+    ! Window half-widths and Fourier cutoff are set in units of the resonant-
+    ! surface Larmor radius rho_L(rm): dx_asis = scale*rho_L, dx_tr = scale*rho_L,
+    ! k_max = scale/rho_L. Defaults apply when the &KIM_PERIODIC group is absent.
+    real(dp) :: periodic_dr_asis_scale = 5.0_dp   ! as-is half-width / rho_L(rm)
+    real(dp) :: periodic_dr_tr_scale   = 10.0_dp  ! transition width / rho_L(rm)
+    real(dp) :: periodic_kmax_scale    = 5.0_dp   ! k_max * rho_L(rm)
+    integer  :: periodic_n_rg          = 96       ! window grid boundary points
+
     ! KIM_IO namelist variables
     character(256) :: profile_location ! path to profile directory
     character(256) :: output_path         ! path to output directory

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -58,6 +58,62 @@ module IO_collection_m
 
     end subroutine write_KIM_namelist_to_hdf5
 
+    subroutine write_periodic_scale_metadata(reference_species, charge, mass, rho_ref, &
+                                             dx_asis, dx_tr, k_max, n_modes, n_rg)
+
+        use config_m, only: output_path, hdf5_output
+        use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_open_group, &
+                                   h5_obj_exists, h5_add, h5_close_group
+
+        implicit none
+
+        integer, intent(in) :: reference_species, charge, n_modes, n_rg
+        real(dp), intent(in) :: mass, rho_ref, dx_asis, dx_tr, k_max
+
+        character(len=*), parameter :: header = &
+            '# reference_species charge mass_g rho_ref_cm dx_asis_cm dx_tr_cm ' // &
+            'k_max_cm_inv M N_rg'
+        integer :: iunit
+        integer(HID_T) :: h5grpid
+        logical :: ex
+
+        if (hdf5_output) then
+            call h5_obj_exists(h5id, 'setup/periodic_scale/', ex)
+            if (.not. ex) then
+                call h5_define_group(h5id, 'setup/periodic_scale/', h5grpid)
+            else
+                call h5_open_group(h5id, 'setup/periodic_scale/', h5grpid)
+            end if
+            call h5_add(h5grpid, 'reference_species', reference_species, &
+                        'Zero-based index of the species defining the periodic scale', '1')
+            call h5_add(h5grpid, 'charge', charge, &
+                        'Charge number of the periodic reference species', '1')
+            call h5_add(h5grpid, 'mass', mass, &
+                        'Mass of the periodic reference species', 'g')
+            call h5_add(h5grpid, 'rho_ref', rho_ref, &
+                        'Reference Larmor radius at the resonant surface', 'cm')
+            call h5_add(h5grpid, 'dx_asis', dx_asis, &
+                        'As-is half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'dx_tr', dx_tr, &
+                        'Transition half-width of the periodic window', 'cm')
+            call h5_add(h5grpid, 'k_max', k_max, &
+                        'Maximum resolved radial wavenumber', '1/cm')
+            call h5_add(h5grpid, 'M', n_modes, &
+                        'Maximum positive periodic Fourier mode', '1')
+            call h5_add(h5grpid, 'N_rg', n_rg, &
+                        'Number of radial quadrature points', '1')
+            call h5_close_group(h5grpid)
+        else
+            open(newunit=iunit, file=trim(output_path)//'setup/periodic_scale.dat', &
+                 status='replace', action='write')
+            write(iunit, '(A)') header
+            write(iunit, *) reference_species, charge, mass, rho_ref, dx_asis, &
+                            dx_tr, k_max, n_modes, n_rg
+            close(iunit)
+        end if
+
+    end subroutine write_periodic_scale_metadata
+
     subroutine write_config_namelist_to_hdf5()
 
         use KAMEL_hdf5_tools, only: HID_T, h5_define_group, h5_obj_exists, h5_add, h5_close_group

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -172,6 +172,17 @@ add_test(NAME test_periodic_assembly
 set_tests_properties(test_periodic_assembly PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
 
+# Dense zgesv solve + inverse DFT for the periodic potential (Phase-2.5).
+add_executable(test_periodic_solve ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_solve.f90)
+set_target_properties(test_periodic_solve PROPERTIES
+                        OUTPUT_NAME test_periodic_solve.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_solve KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_solve
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_solve.x)
+set_tests_properties(test_periodic_solve PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
 # Lifecycle/contract tests for the kim_solver_m API seam.
 add_executable(test_kim_solver ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver.f90)
 set_target_properties(test_kim_solver PROPERTIES

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -132,6 +132,15 @@ target_link_libraries(test_collision_scale_z0 KIM_lib kilca_lib lapack cerf fort
 add_test(NAME test_collision_scale_z0
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_collision_scale_z0.x)
 
+# Regression test for the vendored periodization utility.
+add_executable(test_periodization ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodization.f90)
+set_target_properties(test_periodization PROPERTIES
+                        OUTPUT_NAME test_periodization.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodization KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_periodization
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodization.x)
+
 # Lifecycle/contract tests for the kim_solver_m API seam.
 add_executable(test_kim_solver ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver.f90)
 set_target_properties(test_kim_solver PROPERTIES

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -141,6 +141,15 @@ target_link_libraries(test_periodization KIM_lib kilca_lib lapack cerf fortnum_a
 add_test(NAME test_periodization
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodization.x)
 
+# Periodic sampling of KIM background primitives (aperfuns callback + wrapper).
+add_executable(test_periodic_background ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_background.f90)
+set_target_properties(test_periodic_background PROPERTIES
+                        OUTPUT_NAME test_periodic_background.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_background KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_background
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_background.x)
+
 # Lifecycle/contract tests for the kim_solver_m API seam.
 add_executable(test_kim_solver ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver.f90)
 set_target_properties(test_kim_solver PROPERTIES

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -146,7 +146,7 @@ add_executable(test_periodic_background ${CMAKE_SOURCE_DIR}/KIM/tests/test_perio
 set_target_properties(test_periodic_background PROPERTIES
                         OUTPUT_NAME test_periodic_background.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_background KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_background KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_background
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_background.x)
 
@@ -155,7 +155,7 @@ add_executable(test_periodic_background_build ${CMAKE_SOURCE_DIR}/KIM/tests/test
 set_target_properties(test_periodic_background_build PROPERTIES
                         OUTPUT_NAME test_periodic_background_build.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_background_build KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_background_build KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_background_build
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_background_build.x)
 set_tests_properties(test_periodic_background_build PROPERTIES
@@ -166,7 +166,7 @@ add_executable(test_periodic_assembly ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodi
 set_target_properties(test_periodic_assembly PROPERTIES
                         OUTPUT_NAME test_periodic_assembly.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_assembly KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_assembly KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_assembly
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_assembly.x)
 set_tests_properties(test_periodic_assembly PROPERTIES
@@ -177,7 +177,7 @@ add_executable(test_periodic_solve ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_s
 set_target_properties(test_periodic_solve PROPERTIES
                         OUTPUT_NAME test_periodic_solve.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_solve KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_solve KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_solve
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_solve.x)
 set_tests_properties(test_periodic_solve PROPERTIES
@@ -210,7 +210,7 @@ add_executable(test_kim_solver_periodic ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_s
 set_target_properties(test_kim_solver_periodic PROPERTIES
                         OUTPUT_NAME test_kim_solver_periodic.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_kim_solver_periodic KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_kim_solver_periodic KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_kim_solver_periodic
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_periodic.x)
 set_tests_properties(test_kim_solver_periodic PROPERTIES
@@ -223,7 +223,7 @@ add_executable(test_periodic_vs_global ${CMAKE_SOURCE_DIR}/KIM/tests/test_period
 set_target_properties(test_periodic_vs_global PROPERTIES
                         OUTPUT_NAME test_periodic_vs_global.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_vs_global KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_vs_global KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_vs_global
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_vs_global.x)
 set_tests_properties(test_periodic_vs_global PROPERTIES
@@ -235,7 +235,7 @@ add_executable(test_periodic_convergence ${CMAKE_SOURCE_DIR}/KIM/tests/test_peri
 set_target_properties(test_periodic_convergence PROPERTIES
                         OUTPUT_NAME test_periodic_convergence.x
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
-target_link_libraries(test_periodic_convergence KIM_lib kilca_lib lapack cerf ddeabm slatec)
+target_link_libraries(test_periodic_convergence KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
 add_test(NAME test_periodic_convergence
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_convergence.x)
 set_tests_properties(test_periodic_convergence PROPERTIES

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -150,6 +150,17 @@ target_link_libraries(test_periodic_background KIM_lib kilca_lib lapack cerf dde
 add_test(NAME test_periodic_background
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_background.x)
 
+# Build a periodic background plasma on a redirected window grid (Phase-2.3).
+add_executable(test_periodic_background_build ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_background_build.f90)
+set_target_properties(test_periodic_background_build PROPERTIES
+                        OUTPUT_NAME test_periodic_background_build.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_background_build KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_background_build
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_background_build.x)
+set_tests_properties(test_periodic_background_build PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
 # Lifecycle/contract tests for the kim_solver_m API seam.
 add_executable(test_kim_solver ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver.f90)
 set_target_properties(test_kim_solver PROPERTIES

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -204,3 +204,14 @@ add_test(NAME test_kim_solver_em
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_em.x)
 set_tests_properties(test_kim_solver_em PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
+# End-to-end: the electrostatic_periodic run-type through the factory (Phase-2.6).
+add_executable(test_kim_solver_periodic ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver_periodic.f90)
+set_target_properties(test_kim_solver_periodic PROPERTIES
+                        OUTPUT_NAME test_kim_solver_periodic.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_kim_solver_periodic KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_kim_solver_periodic
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_periodic.x)
+set_tests_properties(test_kim_solver_periodic PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -215,3 +215,16 @@ add_test(NAME test_kim_solver_periodic
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_periodic.x)
 set_tests_properties(test_kim_solver_periodic PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
+# Phase-2.7 cross-check: periodic vs global electrostatic delta-Phi on the same
+# (m,n) = (-6,2) resonant case. Diagnostic (approx-vs-approx): logs the relative
+# difference; soft gate (only on missing/all-zero/NaN).
+add_executable(test_periodic_vs_global ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_vs_global.f90)
+set_target_properties(test_periodic_vs_global PROPERTIES
+                        OUTPUT_NAME test_periodic_vs_global.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_vs_global KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_vs_global
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_vs_global.x)
+set_tests_properties(test_periodic_vs_global PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -228,3 +228,15 @@ add_test(NAME test_periodic_vs_global
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_vs_global.x)
 set_tests_properties(test_periodic_vs_global PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
+# Phase-3.1: reusable periodic core compute_periodic_delta_phi evaluated on a
+# FIXED diagnostic grid (basis for the convergence harness P3.2-3.4).
+add_executable(test_periodic_convergence ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_convergence.f90)
+set_target_properties(test_periodic_convergence PROPERTIES
+                        OUTPUT_NAME test_periodic_convergence.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_convergence KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_convergence
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_convergence.x)
+set_tests_properties(test_periodic_convergence PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -79,6 +79,15 @@ add_test(NAME test_collisionless_ion_assembly
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_collisionless_ion_assembly.x)
 set_tests_properties(test_collisionless_ion_assembly PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
+add_executable(test_flr2_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_fourier_kernel.f90)
+set_target_properties(test_flr2_fourier_kernel PROPERTIES
+                        OUTPUT_NAME test_flr2_fourier_kernel.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_flr2_fourier_kernel KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_flr2_fourier_kernel
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_fourier_kernel.x)
+
 add_executable(test_ampere_matrices ${CMAKE_SOURCE_DIR}/KIM/tests/test_ampere_matrices.f90)
 set_target_properties(test_ampere_matrices PROPERTIES
                         OUTPUT_NAME test_ampere_matrices.x

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -161,6 +161,17 @@ add_test(NAME test_periodic_background_build
 set_tests_properties(test_periodic_background_build PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
 
+# Assemble the dense periodic Fourier matrices K_{m,m'} (Phase-2.4).
+add_executable(test_periodic_assembly ${CMAKE_SOURCE_DIR}/KIM/tests/test_periodic_assembly.f90)
+set_target_properties(test_periodic_assembly PROPERTIES
+                        OUTPUT_NAME test_periodic_assembly.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_periodic_assembly KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_periodic_assembly
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_periodic_assembly.x)
+set_tests_properties(test_periodic_assembly PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
 # Lifecycle/contract tests for the kim_solver_m API seam.
 add_executable(test_kim_solver ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver.f90)
 set_target_properties(test_kim_solver PROPERTIES

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -230,7 +230,10 @@ contains
         ! the Fourier phase exp(i*(kr-krp)*rg). Because b_+ and b_x are symmetric
         ! under (kr,krp) -> (krp,kr), the per-species cores are equal, so the only
         ! difference between hatG(kr,krp) and hatG(krp,kr) is that phase factor.
-        ! Stripping each of its own phase must leave identical (real-core) values.
+        ! Stripping each of its own phase must leave identical (phase-free,
+        ! still complex) core values. Tolerance is looser than the collapse
+        ! test: this compares two independent complex-exp/Bessel evaluations,
+        ! not a construction identity.
         use config_m, only: profiles_in_memory, nml_config_path
         use flr2_fourier_kernel_m, only: hatG_rho_phi, kern_include_ks2
         use constants_m, only: com_unit

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -25,6 +25,7 @@ program test_flr2_fourier_kernel
 
     call test_populated_plasma_and_kernel_stub()
     call test_diagonal_matches_inline()
+    call test_diagonal_j_matches_inline()
     call test_collapse_rho_phi()
     call test_phase_rho_phi()
     call test_collapse_rho_phi_ks2()
@@ -158,6 +159,129 @@ contains
         end do
 
         print *, 'PASS: shared diagonal integrand matches inline reference'
+    end subroutine
+
+    subroutine test_diagonal_j_matches_inline()
+        ! Characterization test: the fused two-wavenumber j-kernels evaluated on
+        ! the diagonal kr = krp must reproduce the diagonal j-kernel expressions
+        ! of calc_hatK_Phi_in_Fourier (FLR2_asymptotics.f90:216-234), the
+        ! source of truth for j-Phi (thesis 14.5) and j-B (thesis 14.6, reached
+        ! via the identities I11 = I02 and I13 = I22).
+        !
+        ! The INLINE reference below is the permanent anchor (verbatim copy of
+        ! the per-species source-of-truth expressions). It must not be
+        ! refactored to call the functions it validates.
+        !
+        ! Note the deliberately absent /(4*pi): the rho kernels carry that factor
+        ! only to cancel solve_periodic's Poisson 4*pi. Thesis (11.7) defines
+        ! delta_j_par = K^{jPhi} delta_Phi + K^{jB} delta_Br with no 4*pi, so
+        ! hatG_j_* omit it and the reference here is the raw per-species sum.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: artificial_debye_case, turn_off_ions, turn_off_electrons
+        use constants_m, only: com_unit, sol
+        use fortnum_special, only: bessel_in
+        use flr2_fourier_kernel_m, only: hatG_j_phi, hatG_j_B, kern_include_ks2
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, b, ks
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: jphi_inline, jphi_func, jB_inline, jB_func
+        real(dp) :: tol_jphi, tol_jB
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_jdiag_test.nml')
+        nml_config_path = './KIM_config_fourier_jdiag_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .false.
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                ! (i) INLINE reference: verbatim per-species expressions,
+                ! summed over the non-turned-off species. NO /(4*pi).
+                jphi_inline = (0.0_dp, 0.0_dp)
+                jB_inline = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+
+                    ks = plasma%ks(j)
+                    b = (kr**2.0d0) * plasma%spec(sp)%rho_L(j)**2.0d0
+
+                    if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+                        jphi_inline = jphi_inline + 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 &
+                            * com_unit * plasma%spec(sp)%vT(j)**3.0d0 &
+                            / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j)) * ks * exp(-b) * &
+                            (&
+                                plasma%spec(sp)%I01(j, 0) * (&
+                                    bessel_in(0, b) * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j) * (1-b)) &
+                                    + plasma%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                                )&
+                                + 0.5d0 * plasma%spec(sp)%I21(j, 0) * plasma%spec(sp)%A2(j) * bessel_in(0, b) &
+                            )
+
+                        jB_inline = jB_inline - 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 &
+                            * plasma%spec(sp)%vT(j)**4.0d0 &
+                            / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j) * sol) * exp(-b) * &
+                            (&
+                                plasma%spec(sp)%I11(j, 0) * (&
+                                    bessel_in(0, b) * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j) * (1-b)) &
+                                    + plasma%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                                )&
+                                + 0.5d0 * plasma%spec(sp)%I13(j, 0) * plasma%spec(sp)%A2(j) * bessel_in(0, b) &
+                            )
+                    end if
+                end do
+
+                ! (ii) Fused two-wavenumber kernels on the diagonal: the phase
+                ! exp(i*(kr-krp)*rg) is unity and (b_+, b_x) collapse to b.
+                jphi_func = hatG_j_phi(plasma, kr, kr, j)
+                jB_func = hatG_j_B(plasma, kr, kr, j)
+
+                tol_jphi = 1.0e-12_dp * (1.0_dp + abs(jphi_inline))
+                tol_jB = 1.0e-12_dp * (1.0_dp + abs(jB_inline))
+
+                if (abs(jphi_inline - jphi_func) >= tol_jphi) then
+                    print *, 'FAIL: j-Phi diagonal mismatch at kr=', kr, ' j=', j
+                    print *, '  inline   = ', jphi_inline
+                    print *, '  fromfunc = ', jphi_func
+                    print *, '  |diff|   = ', abs(jphi_inline - jphi_func), ' tol = ', tol_jphi
+                    error stop
+                end if
+                if (abs(jB_inline - jB_func) >= tol_jB) then
+                    print *, 'FAIL: j-B diagonal mismatch at kr=', kr, ' j=', j
+                    print *, '  inline   = ', jB_inline
+                    print *, '  fromfunc = ', jB_func
+                    print *, '  |diff|   = ', abs(jB_inline - jB_func), ' tol = ', tol_jB
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: fused j kernels match inline diagonal reference'
     end subroutine
 
     subroutine test_collapse_rho_phi()

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -18,7 +18,7 @@ program test_flr2_fourier_kernel
     ! is needed to read the boundary-grid susceptibility functions.
 
     use KIM_kinds_m, only: dp
-    use flr2_fourier_kernel_m, only: hatG_rho_phi
+    use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
     use flr2_fourier_kernel_m, only: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
 
     implicit none
@@ -29,6 +29,9 @@ program test_flr2_fourier_kernel
     call test_phase_rho_phi()
     call test_collapse_rho_phi_ks2()
     call test_zero_wavenumber_limit()
+    call test_collapse_rho_B()
+    call test_collapse_rho_B_ks2()
+    call test_zero_wavenumber_limit_rho_B()
 
     print *, 'All tests PASSED'
     stop 0
@@ -474,6 +477,242 @@ contains
         end do
 
         print *, 'PASS: fused rho-Phi kernel matches b->0 closed form'
+    end subroutine
+
+    subroutine test_collapse_rho_B()
+        ! Collapse-by-construction for the rho-B kernel (drop-k_s^2 path): the
+        ! fused two-wavenumber hatG_rho_B evaluated on the diagonal k_r = k'_r
+        ! must equal the per-species signed diagonal integrand summed over the
+        ! non-turned-off species and divided by 4*pi. Exact to machine precision
+        ! because both share the same per-species core.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_B, hatG_rho_B_diag_sp, kern_include_ks2
+        use constants_m, only: pi
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, tol
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: dref, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_collapse_B_test.nml')
+        nml_config_path = './KIM_config_fourier_collapse_B_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .false.
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                dref = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+                    dref = dref + hatG_rho_B_diag_sp(plasma, sp, kr, j)
+                end do
+                dref = dref / (4.0d0 * pi)
+
+                gfused = hatG_rho_B(plasma, kr, kr, j)
+
+                tol = 1.0e-12_dp * (1.0_dp + abs(dref))
+                if (abs(gfused - dref) >= tol) then
+                    print *, 'FAIL: rho-B collapse mismatch at kr=', kr, ' j=', j
+                    print *, '  diag/4pi = ', dref
+                    print *, '  fused    = ', gfused
+                    print *, '  |diff|   = ', abs(gfused - dref), ' tol = ', tol
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: fused rho-B kernel collapses to diagonal at kr=krp'
+    end subroutine
+
+    subroutine test_collapse_rho_B_ks2()
+        ! Structural collapse for the rho-B k_s^2-inclusive path
+        ! (kern_include_ks2 = .true.). On the diagonal k_r = k'_r both FLR
+        ! arguments reduce to the full perpendicular argument
+        ! bf = (k_s^2 + k_r^2) * rho_L^2, so the fused kernel must equal the
+        ! per-species core evaluated at (bf, bf), summed over the non-turned-off
+        ! species and divided by 4*pi.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_B, core_rho_B_sp, kern_include_ks2
+        use constants_m, only: pi
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, bf, tol
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: ref, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_collapse_B_ks2_test.nml')
+        nml_config_path = './KIM_config_fourier_collapse_B_ks2_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .true.
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                ref = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+                    bf = (plasma%ks(j)**2 + kr**2) * plasma%spec(sp)%rho_L(j)**2
+                    ref = ref + core_rho_B_sp(plasma, sp, bf, bf, j)
+                end do
+                ref = ref / (4.0d0 * pi)
+
+                gfused = hatG_rho_B(plasma, kr, kr, j)
+
+                tol = 1.0e-12_dp * (1.0_dp + abs(ref))
+                if (abs(gfused - ref) >= tol) then
+                    print *, 'FAIL: rho-B ks2 collapse mismatch at kr=', kr, ' j=', j
+                    print *, '  core(bf,bf)/4pi = ', ref
+                    print *, '  fused           = ', gfused
+                    print *, '  |diff|          = ', abs(gfused - ref), ' tol = ', tol
+                    error stop
+                end if
+            end do
+        end do
+
+        ! Defensive: restore the default so any later test sees the drop-k_s^2
+        ! path in the shared module state.
+        kern_include_ks2 = .false.
+
+        print *, 'PASS: fused rho-B kernel (ks2 path) collapses to core(bf,bf) at kr=krp'
+    end subroutine
+
+    subroutine test_zero_wavenumber_limit_rho_B()
+        ! Analytic b -> 0 anchor for the rho-B kernel (drop-k_s^2 path): at
+        ! kr = krp = 0 both FLR arguments vanish (b_+ = b_x = 0). With
+        ! I_0(0) = 1, I_{-1}(0) = 0, exp(-b_+) = 1, (1 - b_+) = 1 and the
+        ! A2 * b_x * I_{-1}(b_x) term vanishing, and the Fourier phase = 1, the
+        ! per-species signed FP core collapses to
+        !   -1/lambda_D^2 * vT^3/(omega_c*nu*sol) * ( I01*(A1+A2) + 0.5*I21*A2 ).
+        ! We fold I_0(0)=1 and I_{-1}(0)=0 in analytically (no bessel_in call),
+        ! so this validates the kernel's argument assembly against math, not the
+        ! Bessel routine. rho-B has NO Debye term. Only valid for the .false. path.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: artificial_debye_case, turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_B, kern_include_ks2
+        use constants_m, only: pi, sol
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: tol
+        integer :: j, sp, jj_arr(3), k
+        complex(dp) :: closed, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_zero_wavenumber_B_test.nml')
+        nml_config_path = './KIM_config_fourier_zero_wavenumber_B_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Closed form derived above only holds for the drop-k_s^2 path.
+        kern_include_ks2 = .false.
+
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do k = 1, size(jj_arr)
+            j = jj_arr(k)
+
+            ! Per-species b -> 0 closed form, summed over the non-turned-off
+            ! species, with I_0(0)=1 and I_{-1}(0)=0 folded in analytically.
+            ! rho-B carries no Debye term.
+            closed = (0.0_dp, 0.0_dp)
+            do sp = 0, plasma%n_species - 1
+                if (turn_off_ions .and. sp >= 1) cycle
+                if (turn_off_electrons .and. sp == 0) cycle
+
+                if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+                    closed = closed - 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 &
+                        * plasma%spec(sp)%vT(j)**3.0d0 &
+                        / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j) * sol) * &
+                        (&
+                            plasma%spec(sp)%I01(j, 0) &
+                                * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j)) &
+                            + 0.5d0 * plasma%spec(sp)%I21(j, 0) * plasma%spec(sp)%A2(j) &
+                        )
+                end if
+            end do
+            closed = closed / (4.0d0 * pi)
+
+            gfused = hatG_rho_B(plasma, 0.0_dp, 0.0_dp, j)
+
+            tol = 1.0e-12_dp * (1.0_dp + abs(closed))
+            if (abs(gfused - closed) >= tol) then
+                print *, 'FAIL: rho-B b->0 limit mismatch at j=', j
+                print *, '  closed = ', closed
+                print *, '  fused  = ', gfused
+                print *, '  |diff| = ', abs(gfused - closed), ' tol = ', tol
+                error stop
+            end if
+        end do
+
+        print *, 'PASS: fused rho-B kernel matches b->0 closed form'
     end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -1,0 +1,218 @@
+program test_flr2_fourier_kernel
+    ! Plumbing-validation harness for the fused FLR2 Fourier kernel.
+    !
+    ! Proves two things before any kernel math is written:
+    !   (a) the new flr2_fourier_kernel_m module compiles and links into a
+    !       standalone CTest program, and
+    !   (b) an electrostatic FokkerPlanck run populates a global `plasma`
+    !       whose per-species susceptibility functions I00(j,0) and
+    !       backgrounds rho_L(j), lambda_D(j) are available on the
+    !       guiding-centre grid rg_grid%xb.
+    !
+    ! Setup mirrors the in-memory-profile path of test_kim_diagnostics.f90:
+    !   write_test_namelist -> nml_config_path -> profiles_in_memory ->
+    !   kim_init -> set_profiles_from_arrays -> electrostatic %init().
+    ! The electrostatic init calls set_plasma_quantities(plasma), which runs
+    ! calculate_plasma_backs (rho_L, lambda_D) and
+    ! calculate_thermodynamic_forces_and_susc (I00) on rg_grid%xb. No %run()
+    ! is needed to read the boundary-grid susceptibility functions.
+
+    use KIM_kinds_m, only: dp
+    use flr2_fourier_kernel_m, only: hatG_rho_phi
+
+    implicit none
+
+    call test_populated_plasma_and_kernel_stub()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_populated_plasma_and_kernel_stub()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        complex(dp) :: I00_val, G_stub
+        real(dp) :: rho_L_val, lambda_D_val
+        integer :: j
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_test.nml')
+        nml_config_path = './KIM_config_fourier_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Interior guiding-centre boundary-grid index.
+        j = rg_grid%npts_b / 2
+
+        if (.not. allocated(plasma%spec(0)%I00)) then
+            print *, 'FAIL: plasma%spec(0)%I00 not allocated after init'
+            error stop
+        end if
+        if (.not. allocated(plasma%spec(0)%rho_L)) then
+            print *, 'FAIL: plasma%spec(0)%rho_L not allocated after init'
+            error stop
+        end if
+        if (.not. allocated(plasma%spec(0)%lambda_D)) then
+            print *, 'FAIL: plasma%spec(0)%lambda_D not allocated after init'
+            error stop
+        end if
+
+        I00_val = plasma%spec(0)%I00(j, 0)
+        rho_L_val = plasma%spec(0)%rho_L(j)
+        lambda_D_val = plasma%spec(0)%lambda_D(j)
+
+        if (.not. is_finite_complex(I00_val)) then
+            print *, 'FAIL: plasma%spec(0)%I00(j,0) is not finite: ', I00_val
+            error stop
+        end if
+        if (.not. (rho_L_val > 0.0_dp)) then
+            print *, 'FAIL: plasma%spec(0)%rho_L(j) must be positive, got ', rho_L_val
+            error stop
+        end if
+        if (.not. (lambda_D_val > 0.0_dp)) then
+            print *, 'FAIL: plasma%spec(0)%lambda_D(j) must be positive, got ', lambda_D_val
+            error stop
+        end if
+
+        ! Drive the (stubbed) kernel to prove it links and is callable with a
+        ! populated plasma. Diagonal argument k_r = k'_r = 1.
+        G_stub = hatG_rho_phi(plasma, 1.0_dp, 1.0_dp, j)
+
+        print *, 'PASS: electrostatic init populated plasma on rg grid'
+        print *, '  index j        = ', j, ' of npts_b = ', rg_grid%npts_b
+        print *, '  I00(j,0)       = ', I00_val
+        print *, '  rho_L(j)       = ', rho_L_val
+        print *, '  lambda_D(j)    = ', lambda_D_val
+        print *, '  hatG_rho_phi   = ', G_stub
+    end subroutine
+
+    logical function is_finite_complex(z) result(ok)
+        complex(dp), intent(in) :: z
+        real(dp) :: re, im
+
+        re = real(z, dp)
+        im = aimag(z)
+        ok = (re == re) .and. (im == im) &
+             .and. (abs(re) < huge(1.0_dp)) .and. (abs(im) < huge(1.0_dp))
+    end function is_finite_complex
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm with q in [1.5, 2.5];
+        ! q crosses |m/n| = 2 at r ~ 31 cm, inside the solver domain
+        ! [r_min, r_plas] = [10, 50].
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration on a coarse grid,
+        ! written in the exact group order kim_read_config reads them. The
+        ! FokkerPlanck collision model is required so the susceptibility
+        ! functions (I00, ...) are computed during set_plasma_quantities.
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_fourier_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -2'
+        write(iunit, '(A)') ' n_mode = 1'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine
+
+end program

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -105,13 +105,10 @@ contains
     end subroutine
 
     logical function is_finite_complex(z) result(ok)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         complex(dp), intent(in) :: z
-        real(dp) :: re, im
 
-        re = real(z, dp)
-        im = aimag(z)
-        ok = (re == re) .and. (im == im) &
-             .and. (abs(re) < huge(1.0_dp)) .and. (abs(im) < huge(1.0_dp))
+        ok = ieee_is_finite(real(z, dp)) .and. ieee_is_finite(aimag(z))
     end function is_finite_complex
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -32,6 +32,8 @@ program test_flr2_fourier_kernel
     call test_collapse_rho_B()
     call test_collapse_rho_B_ks2()
     call test_zero_wavenumber_limit_rho_B()
+    call test_scaled_bessel_large_arg()
+    call test_large_bcross_kernel_finite()
 
     print *, 'All tests PASSED'
     stop 0
@@ -713,6 +715,121 @@ contains
         end do
 
         print *, 'PASS: fused rho-B kernel matches b->0 closed form'
+    end subroutine
+
+    subroutine test_scaled_bessel_large_arg()
+        ! Overflow-safe scaled Bessel products in the large-argument regime.
+        ! At b_+ = b_x = 1000 the unscaled I_0(1000) overflows to +Inf (near
+        ! the ~710 argument limit), so the naive exp(-b_+)*I_0(b_x) is Inf*0.
+        ! The asymptotic branch must instead return finite values matching the
+        ! analytic limits exp(-b)*I_0(b) -> 1/sqrt(2*pi*b) and I_{-1}/I_0 -> 1.
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use flr2_fourier_kernel_m, only: scaled_bessel_pair
+        use constants_m, only: pi
+
+        real(dp) :: b, sI0, sIm1, analytic_sI0, tol
+
+        b = 1000.0_dp
+        call scaled_bessel_pair(b, b, sI0, sIm1)
+
+        if (.not. ieee_is_finite(sI0)) then
+            print *, 'FAIL: scaled_bessel_pair sI0 not finite at b=1000: ', sI0
+            error stop
+        end if
+        if (.not. ieee_is_finite(sIm1)) then
+            print *, 'FAIL: scaled_bessel_pair sIm1 not finite at b=1000: ', sIm1
+            error stop
+        end if
+
+        ! exp(-b)*I_0(b) -> 1/sqrt(2*pi*b) as b -> infinity.
+        analytic_sI0 = 1.0_dp / sqrt(2.0_dp * pi * b)
+        tol = 1.0e-3_dp * analytic_sI0
+        if (abs(sI0 - analytic_sI0) >= tol) then
+            print *, 'FAIL: scaled sI0 off analytic limit at b=1000'
+            print *, '  sI0      = ', sI0
+            print *, '  analytic = ', analytic_sI0
+            print *, '  |diff|   = ', abs(sI0 - analytic_sI0), ' tol = ', tol
+            error stop
+        end if
+
+        ! I_{-1}(b)/I_0(b) -> 1, so sIm1 is positive and within ~2% of sI0.
+        if (.not. (sIm1 > 0.0_dp)) then
+            print *, 'FAIL: scaled sIm1 must be positive at b=1000, got ', sIm1
+            error stop
+        end if
+        if (abs(sIm1 - sI0) >= 0.02_dp * sI0) then
+            print *, 'FAIL: scaled sIm1 not within 2% of sI0 at b=1000'
+            print *, '  sI0    = ', sI0
+            print *, '  sIm1   = ', sIm1
+            print *, '  |diff| = ', abs(sIm1 - sI0), ' tol = ', 0.02_dp * sI0
+            error stop
+        end if
+
+        print *, 'PASS: scaled_bessel_pair finite and matches large-arg asymptotics'
+    end subroutine
+
+    subroutine test_large_bcross_kernel_finite()
+        ! End-to-end overflow guard: the per-species cores must stay finite when
+        ! driven with a forced large FLR argument (b_x = 1000) that would
+        ! overflow the naive exp(-b_+)*I_0(b_x) path. Uses the public
+        ! core_*_sp entry points with an interior guiding-centre index and the
+        ! default artificial_debye_case = 0 (FP term active).
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: artificial_debye_case
+        use flr2_fourier_kernel_m, only: core_rho_phi_sp, core_rho_B_sp
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: big
+        integer :: j
+        complex(dp) :: g_phi, g_B
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_large_bcross_test.nml')
+        nml_config_path = './KIM_config_fourier_large_bcross_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! The namelist sets artificial_debye_case = 0, so the FP branch (which
+        ! evaluates the Bessel products) is active.
+        if (.not. (artificial_debye_case == 0 .or. artificial_debye_case == 2)) then
+            print *, 'FAIL: FP branch inactive; artificial_debye_case = ', artificial_debye_case
+            error stop
+        end if
+
+        j = rg_grid%npts_b / 2
+        big = 1000.0_dp
+
+        g_phi = core_rho_phi_sp(plasma, 0, big, big, j)
+        g_B = core_rho_B_sp(plasma, 0, big, big, j)
+
+        if (.not. is_finite_complex(g_phi)) then
+            print *, 'FAIL: core_rho_phi_sp not finite at bcross=1000: ', g_phi
+            error stop
+        end if
+        if (.not. is_finite_complex(g_B)) then
+            print *, 'FAIL: core_rho_B_sp not finite at bcross=1000: ', g_B
+            error stop
+        end if
+
+        print *, 'PASS: core_*_sp stay finite at large bcross (overflow guard)'
+        print *, '  core_rho_phi_sp = ', g_phi
+        print *, '  core_rho_B_sp   = ', g_B
     end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -18,21 +18,25 @@ program test_flr2_fourier_kernel
     ! is needed to read the boundary-grid susceptibility functions.
 
     use KIM_kinds_m, only: dp
-    use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+    use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, kern_include_ks2
+    use flr2_fourier_kernel_m, only: kern_zero_flr_electrons, flr_arg_pair_sp
     use flr2_fourier_kernel_m, only: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
 
     implicit none
 
+    call test_full_kernel_defaults()
+    call test_global_approximation_switch()
     call test_populated_plasma_and_kernel_stub()
     call test_diagonal_matches_inline()
     call test_diagonal_j_matches_inline()
     call test_collapse_rho_phi()
-    call test_phase_rho_phi()
+    call test_kernel_fourier_phase()
     call test_collapse_rho_phi_ks2()
     call test_zero_wavenumber_limit()
     call test_collapse_rho_B()
     call test_collapse_rho_B_ks2()
     call test_zero_wavenumber_limit_rho_B()
+    call test_electron_zero_flr_arguments()
     call test_scaled_bessel_large_arg()
     call test_large_bcross_kernel_finite()
 
@@ -40,6 +44,37 @@ program test_flr2_fourier_kernel
     stop 0
 
 contains
+
+    subroutine test_full_kernel_defaults()
+        if (.not. kern_include_ks2) then
+            print *, 'FAIL: full periodic kernel must include k_s^2 by default'
+            error stop
+        end if
+        if (kern_zero_flr_electrons) then
+            print *, 'FAIL: full periodic kernel must retain electron FLR by default'
+            error stop
+        end if
+
+        print *, 'PASS: production defaults select the full periodic kernel'
+    end subroutine test_full_kernel_defaults
+
+    subroutine test_global_approximation_switch()
+        use flr2_fourier_kernel_m, only: set_global_kernel_approximations
+
+        call set_global_kernel_approximations(.true.)
+        if (kern_include_ks2 .or. .not. kern_zero_flr_electrons) then
+            print *, 'FAIL: enabled global approximation did not select the simplified kernel'
+            error stop
+        end if
+
+        call set_global_kernel_approximations(.false.)
+        if (.not. kern_include_ks2 .or. kern_zero_flr_electrons) then
+            print *, 'FAIL: disabled global approximation did not restore the full kernel'
+            error stop
+        end if
+
+        print *, 'PASS: global-kernel approximation switch is reversible'
+    end subroutine test_global_approximation_switch
 
     subroutine test_diagonal_matches_inline()
         ! Characterization test: the shared per-species diagonal integrand
@@ -163,22 +198,19 @@ contains
 
     subroutine test_diagonal_j_matches_inline()
         ! Characterization test: the fused two-wavenumber j-kernels evaluated on
-        ! the diagonal kr = krp must reproduce the diagonal j-kernel expressions
-        ! of calc_hatK_Phi_in_Fourier (FLR2_asymptotics.f90:216-234), the
-        ! source of truth for j-Phi (thesis 14.5) and j-B (thesis 14.6, reached
-        ! via the identities I11 = I02 and I13 = I22).
+        ! the diagonal kr = krp must reproduce equations (14.5)/(14.6), with
+        ! I11 = I02 and I13 = I22 for the j-B susceptibility moments.
         !
         ! The INLINE reference below is the permanent anchor (verbatim copy of
         ! the per-species source-of-truth expressions). It must not be
         ! refactored to call the functions it validates.
         !
-        ! Note the deliberately absent /(4*pi): the rho kernels carry that factor
-        ! only to cancel solve_periodic's Poisson 4*pi. Thesis (11.7) defines
-        ! delta_j_par = K^{jPhi} delta_Phi + K^{jB} delta_Br with no 4*pi, so
-        ! hatG_j_* omit it and the reference here is the raw per-species sum.
+        ! Equations (14.5) and (14.6) carry the full current-kernel Fourier
+        ! normalization 1/(2^3*pi^2). Keep it explicit in this independent
+        ! reference: omitting it inflated reconstructed j_parallel by 8*pi^2.
         use config_m, only: profiles_in_memory, nml_config_path
         use config_m, only: artificial_debye_case, turn_off_ions, turn_off_electrons
-        use constants_m, only: com_unit, sol
+        use constants_m, only: pi, com_unit, sol
         use fortnum_special, only: bessel_in
         use flr2_fourier_kernel_m, only: hatG_j_phi, hatG_j_B, kern_include_ks2
         use species_m, only: plasma, set_profiles_from_arrays
@@ -220,8 +252,8 @@ contains
             do k = 1, size(jj_arr)
                 j = jj_arr(k)
 
-                ! (i) INLINE reference: verbatim per-species expressions,
-                ! summed over the non-turned-off species. NO /(4*pi).
+                ! (i) INLINE reference numerator, summed over active species;
+                ! the independent Fourier normalization is applied below.
                 jphi_inline = (0.0_dp, 0.0_dp)
                 jB_inline = (0.0_dp, 0.0_dp)
                 do sp = 0, plasma%n_species - 1
@@ -256,6 +288,9 @@ contains
                     end if
                 end do
 
+                jphi_inline = jphi_inline / (8.0_dp * pi**2)
+                jB_inline = jB_inline / (8.0_dp * pi**2)
+
                 ! (ii) Fused two-wavenumber kernels on the diagonal: the phase
                 ! exp(i*(kr-krp)*rg) is unity and (b_+, b_x) collapse to b.
                 jphi_func = hatG_j_phi(plasma, kr, kr, j)
@@ -287,8 +322,8 @@ contains
     subroutine test_collapse_rho_phi()
         ! Collapse-by-construction: the fused two-wavenumber kernel evaluated on
         ! the diagonal k_r = k'_r must equal the per-species diagonal integrand
-        ! summed over the non-turned-off species and divided by 4*pi (the
-        ! source-of-truth normalization). Exact to machine precision because the
+        ! summed over the non-turned-off species and divided by 8*pi^2 (the
+        ! continuous Fourier-kernel normalization). Exact to machine precision because the
         ! diagonal and the fused kernel share the same per-species core.
         use config_m, only: profiles_in_memory, nml_config_path
         use config_m, only: turn_off_ions, turn_off_electrons
@@ -338,14 +373,14 @@ contains
                     if (turn_off_electrons .and. sp == 0) cycle
                     dref = dref + hatG_rho_phi_diag_sp(plasma, sp, kr, j)
                 end do
-                dref = dref / (4.0d0 * pi)
+                dref = dref / (8.0d0 * pi**2)
 
                 gfused = hatG_rho_phi(plasma, kr, kr, j)
 
                 tol = 1.0e-12_dp * (1.0_dp + abs(dref))
                 if (abs(gfused - dref) >= tol) then
                     print *, 'FAIL: rho-Phi collapse mismatch at kr=', kr, ' j=', j
-                    print *, '  diag/4pi = ', dref
+                    print *, '  diag/(8pi^2) = ', dref
                     print *, '  fused    = ', gfused
                     print *, '  |diff|   = ', abs(gfused - dref), ' tol = ', tol
                     error stop
@@ -356,9 +391,9 @@ contains
         print *, 'PASS: fused rho-Phi kernel collapses to diagonal at kr=krp'
     end subroutine
 
-    subroutine test_phase_rho_phi()
+    subroutine test_kernel_fourier_phase()
         ! Off-diagonal phase structure: for k_r /= k'_r the fused kernel carries
-        ! the Fourier phase exp(i*(kr-krp)*rg). Because b_+ and b_x are symmetric
+        ! the forward-transform phase exp(-i*(kr-krp)*rg). Because b_+ and b_x are symmetric
         ! under (kr,krp) -> (krp,kr), the per-species cores are equal, so the only
         ! difference between hatG(kr,krp) and hatG(krp,kr) is that phase factor.
         ! Stripping each of its own phase must leave identical (phase-free,
@@ -366,7 +401,8 @@ contains
         ! test: this compares two independent complex-exp/Bessel evaluations,
         ! not a construction identity.
         use config_m, only: profiles_in_memory, nml_config_path
-        use flr2_fourier_kernel_m, only: hatG_rho_phi, kern_include_ks2
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+        use flr2_fourier_kernel_m, only: hatG_j_phi, hatG_j_B, kern_include_ks2
         use constants_m, only: com_unit
         use species_m, only: plasma, set_profiles_from_arrays
         use grid_m, only: rg_grid
@@ -379,8 +415,10 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
         real(dp) :: kr_arr(3), krp_arr(3), kr, krp, rg, tol
-        integer :: i, j, jj_arr(3), k
-        complex(dp) :: ci, g_fwd, g_rev, stripped_fwd, stripped_rev
+        integer :: i, j, jj_arr(3), k, ikernel
+        complex(dp) :: ci, g_fwd(4), g_rev(4), stripped_fwd, stripped_rev
+        character(len=7), parameter :: kernel_name(4) = &
+            ['rho-Phi', 'rho-B  ', 'j-Phi  ', 'j-B    ']
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                 q_prof, Er_prof)
@@ -410,25 +448,34 @@ contains
                 j = jj_arr(k)
                 rg = rg_grid%xb(j)
 
-                g_fwd = hatG_rho_phi(plasma, kr, krp, j)
-                g_rev = hatG_rho_phi(plasma, krp, kr, j)
+                g_fwd = [hatG_rho_phi(plasma, kr, krp, j), &
+                         hatG_rho_B(plasma, kr, krp, j), &
+                         hatG_j_phi(plasma, kr, krp, j), &
+                         hatG_j_B(plasma, kr, krp, j)]
+                g_rev = [hatG_rho_phi(plasma, krp, kr, j), &
+                         hatG_rho_B(plasma, krp, kr, j), &
+                         hatG_j_phi(plasma, krp, kr, j), &
+                         hatG_j_B(plasma, krp, kr, j)]
 
-                stripped_fwd = g_fwd * exp(-ci * (kr - krp) * rg)
-                stripped_rev = g_rev * exp(-ci * (krp - kr) * rg)
+                do ikernel = 1, size(g_fwd)
+                    stripped_fwd = g_fwd(ikernel) * exp(ci * (kr - krp) * rg)
+                    stripped_rev = g_rev(ikernel) * exp(ci * (krp - kr) * rg)
 
-                tol = 1.0e-10_dp * (1.0_dp + abs(g_fwd))
-                if (abs(stripped_fwd - stripped_rev) >= tol) then
-                    print *, 'FAIL: rho-Phi phase mismatch at kr=', kr, ' krp=', krp, ' j=', j
-                    print *, '  stripped_fwd = ', stripped_fwd
-                    print *, '  stripped_rev = ', stripped_rev
-                    print *, '  |diff|       = ', abs(stripped_fwd - stripped_rev), ' tol = ', tol
-                    error stop
-                end if
+                    tol = 1.0e-10_dp * (1.0_dp + abs(g_fwd(ikernel)))
+                    if (abs(stripped_fwd - stripped_rev) >= tol) then
+                        print *, 'FAIL: ', trim(kernel_name(ikernel)), &
+                            ' phase mismatch at kr=', kr, ' krp=', krp, ' j=', j
+                        print *, '  stripped_fwd = ', stripped_fwd
+                        print *, '  stripped_rev = ', stripped_rev
+                        print *, '  |diff|       = ', abs(stripped_fwd - stripped_rev), ' tol = ', tol
+                        error stop
+                    end if
+                end do
             end do
         end do
 
-        print *, 'PASS: fused rho-Phi kernel carries the Fourier phase only'
-    end subroutine
+        print *, 'PASS: all fused kernels carry the forward-transform phase only'
+    end subroutine test_kernel_fourier_phase
 
     subroutine test_collapse_rho_phi_ks2()
         ! Structural collapse for the k_s^2-inclusive path (kern_include_ks2 =
@@ -437,7 +484,7 @@ contains
         ! diagonal k_r = k'_r the two FLR arguments both reduce to the full
         ! perpendicular argument bf = (k_s^2 + k_r^2) * rho_L^2, so the fused
         ! kernel must equal the per-species core evaluated at (bf, bf), summed
-        ! over the non-turned-off species and divided by 4*pi. This validates the
+        ! over the non-turned-off species and divided by 8*pi^2. This validates the
         ! sqrt/2 algebra of the .true. branch without needing a k_s = 0 setup.
         use config_m, only: profiles_in_memory, nml_config_path
         use config_m, only: turn_off_ions, turn_off_electrons
@@ -488,14 +535,14 @@ contains
                     bf = (plasma%ks(j)**2 + kr**2) * plasma%spec(sp)%rho_L(j)**2
                     ref = ref + core_rho_phi_sp(plasma, sp, bf, bf, j)
                 end do
-                ref = ref / (4.0d0 * pi)
+                ref = ref / (8.0d0 * pi**2)
 
                 gfused = hatG_rho_phi(plasma, kr, kr, j)
 
                 tol = 1.0e-12_dp * (1.0_dp + abs(ref))
                 if (abs(gfused - ref) >= tol) then
                     print *, 'FAIL: rho-Phi ks2 collapse mismatch at kr=', kr, ' j=', j
-                    print *, '  core(bf,bf)/4pi = ', ref
+                    print *, '  core(bf,bf)/(8pi^2) = ', ref
                     print *, '  fused           = ', gfused
                     print *, '  |diff|          = ', abs(gfused - ref), ' tol = ', tol
                     error stop
@@ -588,7 +635,7 @@ contains
                         )
                 end if
             end do
-            closed = closed / (4.0d0 * pi)
+            closed = closed / (8.0d0 * pi**2)
 
             gfused = hatG_rho_phi(plasma, 0.0_dp, 0.0_dp, j)
 
@@ -609,7 +656,7 @@ contains
         ! Collapse-by-construction for the rho-B kernel (drop-k_s^2 path): the
         ! fused two-wavenumber hatG_rho_B evaluated on the diagonal k_r = k'_r
         ! must equal the per-species signed diagonal integrand summed over the
-        ! non-turned-off species and divided by 4*pi. Exact to machine precision
+        ! non-turned-off species and divided by 8*pi^2. Exact to machine precision
         ! because both share the same per-species core.
         use config_m, only: profiles_in_memory, nml_config_path
         use config_m, only: turn_off_ions, turn_off_electrons
@@ -659,14 +706,14 @@ contains
                     if (turn_off_electrons .and. sp == 0) cycle
                     dref = dref + hatG_rho_B_diag_sp(plasma, sp, kr, j)
                 end do
-                dref = dref / (4.0d0 * pi)
+                dref = dref / (8.0d0 * pi**2)
 
                 gfused = hatG_rho_B(plasma, kr, kr, j)
 
                 tol = 1.0e-12_dp * (1.0_dp + abs(dref))
                 if (abs(gfused - dref) >= tol) then
                     print *, 'FAIL: rho-B collapse mismatch at kr=', kr, ' j=', j
-                    print *, '  diag/4pi = ', dref
+                    print *, '  diag/(8pi^2) = ', dref
                     print *, '  fused    = ', gfused
                     print *, '  |diff|   = ', abs(gfused - dref), ' tol = ', tol
                     error stop
@@ -683,7 +730,7 @@ contains
         ! arguments reduce to the full perpendicular argument
         ! bf = (k_s^2 + k_r^2) * rho_L^2, so the fused kernel must equal the
         ! per-species core evaluated at (bf, bf), summed over the non-turned-off
-        ! species and divided by 4*pi.
+        ! species and divided by 8*pi^2.
         use config_m, only: profiles_in_memory, nml_config_path
         use config_m, only: turn_off_ions, turn_off_electrons
         use flr2_fourier_kernel_m, only: hatG_rho_B, core_rho_B_sp, kern_include_ks2
@@ -733,14 +780,14 @@ contains
                     bf = (plasma%ks(j)**2 + kr**2) * plasma%spec(sp)%rho_L(j)**2
                     ref = ref + core_rho_B_sp(plasma, sp, bf, bf, j)
                 end do
-                ref = ref / (4.0d0 * pi)
+                ref = ref / (8.0d0 * pi**2)
 
                 gfused = hatG_rho_B(plasma, kr, kr, j)
 
                 tol = 1.0e-12_dp * (1.0_dp + abs(ref))
                 if (abs(gfused - ref) >= tol) then
                     print *, 'FAIL: rho-B ks2 collapse mismatch at kr=', kr, ' j=', j
-                    print *, '  core(bf,bf)/4pi = ', ref
+                    print *, '  core(bf,bf)/(8pi^2) = ', ref
                     print *, '  fused           = ', gfused
                     print *, '  |diff|          = ', abs(gfused - ref), ' tol = ', tol
                     error stop
@@ -824,7 +871,7 @@ contains
                         )
                 end if
             end do
-            closed = closed / (4.0d0 * pi)
+            closed = closed / (8.0d0 * pi**2)
 
             gfused = hatG_rho_B(plasma, 0.0_dp, 0.0_dp, j)
 
@@ -840,6 +887,49 @@ contains
 
         print *, 'PASS: fused rho-B kernel matches b->0 closed form'
     end subroutine
+
+    subroutine test_electron_zero_flr_arguments()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: bplus, bcross
+        integer :: j
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_fourier_electron_zero_flr_test.nml')
+        nml_config_path = './KIM_config_fourier_electron_zero_flr_test.nml'
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        j = rg_grid%npts_b / 2
+        kern_include_ks2 = .false.
+        kern_zero_flr_electrons = .true.
+        call flr_arg_pair_sp(plasma, 0, 3.0_dp, -5.0_dp, j, bplus, bcross)
+        if (bplus /= 0.0_dp .or. bcross /= 0.0_dp) then
+            print *, 'FAIL: electron FLR arguments are not zero: ', bplus, bcross
+            error stop
+        end if
+
+        call flr_arg_pair_sp(plasma, 1, 3.0_dp, -5.0_dp, j, bplus, bcross)
+        if (bplus <= 0.0_dp .or. bcross <= 0.0_dp) then
+            print *, 'FAIL: ion FLR arguments were incorrectly zeroed: ', bplus, bcross
+            error stop
+        end if
+
+        print *, 'PASS: zero-FLR production approximation applies only to electrons'
+    end subroutine test_electron_zero_flr_arguments
 
     subroutine test_scaled_bessel_large_arg()
         ! Overflow-safe scaled Bessel products in the large-argument regime.

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -28,6 +28,7 @@ program test_flr2_fourier_kernel
     call test_collapse_rho_phi()
     call test_phase_rho_phi()
     call test_collapse_rho_phi_ks2()
+    call test_zero_wavenumber_limit()
 
     print *, 'All tests PASSED'
     stop 0
@@ -378,6 +379,101 @@ contains
         kern_include_ks2 = .false.
 
         print *, 'PASS: fused rho-Phi kernel (ks2 path) collapses to core(bf,bf) at kr=krp'
+    end subroutine
+
+    subroutine test_zero_wavenumber_limit()
+        ! Analytic b -> 0 anchor: at kr = krp = 0 in the default drop-k_s^2 path,
+        ! both FLR arguments vanish (b_+ = b_x = 0). The Bessel/exp assembly then
+        ! reduces to a closed form INDEPENDENT of the Bessel routine, because
+        ! exp(-b_+) = 1, (1 - b_+) = 1, I_0(0) = 1, I_{-1}(0) = 0, and the
+        ! A2 * b_x * I_{-1}(b_x) term vanishes with b_x = 0. The Fourier phase
+        ! exp(i*0*rg) = 1. So the per-species FP core collapses to
+        !   1/lambda_D^2 * i * vT^2 * ks / (omega_c*nu) * ( I00*(A1+A2) + 0.5*I20*A2 )
+        ! and the Debye term stays -1/lambda_D^2. We hard-code I_0(0)=1 and
+        ! I_{-1}(0)=0 here rather than calling bessel_in, so this test validates
+        ! the kernel's argument assembly against math, not against the Bessel
+        ! routine it shares with the collapse/phase tests. Only valid for the
+        ! .false. path (in the .true. path the arguments are rho_L^2*ks^2 /= 0).
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: artificial_debye_case, turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, kern_include_ks2
+        use constants_m, only: com_unit, pi
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: tol, ks
+        integer :: j, sp, jj_arr(3), k
+        complex(dp) :: closed, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_zero_wavenumber_test.nml')
+        nml_config_path = './KIM_config_fourier_zero_wavenumber_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Closed form derived above only holds for the drop-k_s^2 path; the
+        ! toggle is deliberately fixed here (do NOT sweep it).
+        kern_include_ks2 = .false.
+
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do k = 1, size(jj_arr)
+            j = jj_arr(k)
+
+            ! Per-species b -> 0 closed form, summed over the non-turned-off
+            ! species, with I_0(0)=1 and I_{-1}(0)=0 folded in analytically.
+            closed = (0.0_dp, 0.0_dp)
+            do sp = 0, plasma%n_species - 1
+                if (turn_off_ions .and. sp >= 1) cycle
+                if (turn_off_electrons .and. sp == 0) cycle
+
+                ks = plasma%ks(j)
+
+                if (artificial_debye_case <= 1) then
+                    closed = closed - 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0
+                end if
+
+                if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+                    closed = closed + 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 &
+                        * com_unit * plasma%spec(sp)%vT(j)**2.0d0 * ks &
+                        / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j)) * &
+                        (&
+                            plasma%spec(sp)%I00(j, 0) &
+                                * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j)) &
+                            + 0.5d0 * plasma%spec(sp)%I20(j, 0) * plasma%spec(sp)%A2(j) &
+                        )
+                end if
+            end do
+            closed = closed / (4.0d0 * pi)
+
+            gfused = hatG_rho_phi(plasma, 0.0_dp, 0.0_dp, j)
+
+            tol = 1.0e-12_dp * (1.0_dp + abs(closed))
+            if (abs(gfused - closed) >= tol) then
+                print *, 'FAIL: rho-Phi b->0 limit mismatch at j=', j
+                print *, '  closed = ', closed
+                print *, '  fused  = ', gfused
+                print *, '  |diff| = ', abs(gfused - closed), ' tol = ', tol
+                error stop
+            end if
+        end do
+
+        print *, 'PASS: fused rho-Phi kernel matches b->0 closed form'
     end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -25,6 +25,8 @@ program test_flr2_fourier_kernel
 
     call test_populated_plasma_and_kernel_stub()
     call test_diagonal_matches_inline()
+    call test_collapse_rho_phi()
+    call test_phase_rho_phi()
 
     print *, 'All tests PASSED'
     stop 0
@@ -149,6 +151,149 @@ contains
         end do
 
         print *, 'PASS: shared diagonal integrand matches inline reference'
+    end subroutine
+
+    subroutine test_collapse_rho_phi()
+        ! Collapse-by-construction: the fused two-wavenumber kernel evaluated on
+        ! the diagonal k_r = k'_r must equal the per-species diagonal integrand
+        ! summed over the non-turned-off species and divided by 4*pi (the
+        ! source-of-truth normalization). Exact to machine precision because the
+        ! diagonal and the fused kernel share the same per-species core.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_phi_diag_sp, kern_include_ks2
+        use constants_m, only: pi
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, tol
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: dref, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_collapse_test.nml')
+        nml_config_path = './KIM_config_fourier_collapse_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .false.
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                dref = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+                    dref = dref + hatG_rho_phi_diag_sp(plasma, sp, kr, j)
+                end do
+                dref = dref / (4.0d0 * pi)
+
+                gfused = hatG_rho_phi(plasma, kr, kr, j)
+
+                tol = 1.0e-12_dp * (1.0_dp + abs(dref))
+                if (abs(gfused - dref) >= tol) then
+                    print *, 'FAIL: rho-Phi collapse mismatch at kr=', kr, ' j=', j
+                    print *, '  diag/4pi = ', dref
+                    print *, '  fused    = ', gfused
+                    print *, '  |diff|   = ', abs(gfused - dref), ' tol = ', tol
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: fused rho-Phi kernel collapses to diagonal at kr=krp'
+    end subroutine
+
+    subroutine test_phase_rho_phi()
+        ! Off-diagonal phase structure: for k_r /= k'_r the fused kernel carries
+        ! the Fourier phase exp(i*(kr-krp)*rg). Because b_+ and b_x are symmetric
+        ! under (kr,krp) -> (krp,kr), the per-species cores are equal, so the only
+        ! difference between hatG(kr,krp) and hatG(krp,kr) is that phase factor.
+        ! Stripping each of its own phase must leave identical (real-core) values.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, kern_include_ks2
+        use constants_m, only: com_unit
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), krp_arr(3), kr, krp, rg, tol
+        integer :: i, j, jj_arr(3), k
+        complex(dp) :: ci, g_fwd, g_rev, stripped_fwd, stripped_rev
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_phase_test.nml')
+        nml_config_path = './KIM_config_fourier_phase_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .false.
+        ci = com_unit
+
+        kr_arr = [0.1_dp, 1.0_dp, 2.0_dp]
+        krp_arr = [1.0_dp, 5.0_dp, 0.5_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            krp = krp_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+                rg = rg_grid%xb(j)
+
+                g_fwd = hatG_rho_phi(plasma, kr, krp, j)
+                g_rev = hatG_rho_phi(plasma, krp, kr, j)
+
+                stripped_fwd = g_fwd * exp(-ci * (kr - krp) * rg)
+                stripped_rev = g_rev * exp(-ci * (krp - kr) * rg)
+
+                tol = 1.0e-10_dp * (1.0_dp + abs(g_fwd))
+                if (abs(stripped_fwd - stripped_rev) >= tol) then
+                    print *, 'FAIL: rho-Phi phase mismatch at kr=', kr, ' krp=', krp, ' j=', j
+                    print *, '  stripped_fwd = ', stripped_fwd
+                    print *, '  stripped_rev = ', stripped_rev
+                    print *, '  |diff|       = ', abs(stripped_fwd - stripped_rev), ' tol = ', tol
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: fused rho-Phi kernel carries the Fourier phase only'
     end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -19,15 +19,137 @@ program test_flr2_fourier_kernel
 
     use KIM_kinds_m, only: dp
     use flr2_fourier_kernel_m, only: hatG_rho_phi
+    use flr2_fourier_kernel_m, only: hatG_rho_phi_diag_sp, hatG_rho_B_diag_sp
 
     implicit none
 
     call test_populated_plasma_and_kernel_stub()
+    call test_diagonal_matches_inline()
 
     print *, 'All tests PASSED'
     stop 0
 
 contains
+
+    subroutine test_diagonal_matches_inline()
+        ! Characterization test: the shared per-species diagonal integrand
+        ! functions must reproduce, bit-for-bit within tolerance, the original
+        ! inline expressions in calc_hatK_Phi_in_Fourier. The INLINE reference
+        ! below is the permanent anchor (verbatim copy of the source-of-truth
+        ! per-species rho-Phi Debye+FP term and signed rho-B FP term). It must
+        ! not be refactored to call the functions it validates.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: artificial_debye_case, turn_off_ions, turn_off_electrons
+        use constants_m, only: com_unit, sol
+        use fortnum_special, only: bessel_in
+        use species_m, only: plasma, set_profiles_from_arrays, plasma_t
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, b, ks
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: phi_inline, phi_func, B_inline, B_func
+        real(dp) :: tol_phi, tol_B
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_diag_test.nml')
+        nml_config_path = './KIM_config_fourier_diag_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        ! A few interior guiding-centre boundary-grid indices.
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                ! (i) INLINE reference: verbatim per-species expressions,
+                ! summed over the non-turned-off species.
+                phi_inline = (0.0_dp, 0.0_dp)
+                B_inline = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+
+                    ks = plasma%ks(j)
+                    b = (kr**2.0d0) * plasma%spec(sp)%rho_L(j)**2.0d0
+
+                    if (artificial_debye_case <= 1) then
+                        phi_inline = phi_inline - 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0
+                    end if
+
+                    if (artificial_debye_case == 0 .or. artificial_debye_case == 2) then
+                        phi_inline = phi_inline + 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 &
+                            * com_unit * plasma%spec(sp)%vT(j)**2.0d0 * plasma%ks(j) &
+                            / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j)) * exp(-b) * &
+                            (&
+                                plasma%spec(sp)%I00(j, 0) * (&
+                                    bessel_in(0, b) * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j) * (1-b)) &
+                                    + plasma%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                                )&
+                                + 0.5d0 * plasma%spec(sp)%I20(j, 0) * plasma%spec(sp)%A2(j) * bessel_in(0, b) &
+                            )
+                        B_inline = B_inline - 1.0d0 / plasma%spec(sp)%lambda_D(j)**2.0d0 * plasma%spec(sp)%vT(j)**3.0d0 &
+                            / (plasma%spec(sp)%omega_c(j) * plasma%spec(sp)%nu(j) * sol) * exp(-b) * &
+                            (&
+                                plasma%spec(sp)%I01(j, 0) * (&
+                                    bessel_in(0, b) * (plasma%spec(sp)%A1(j) + plasma%spec(sp)%A2(j) * (1-b)) &
+                                    + plasma%spec(sp)%A2(j) * b * bessel_in(-1, b) &
+                                )&
+                                + 0.5d0 * plasma%spec(sp)%I21(j, 0) * plasma%spec(sp)%A2(j) * bessel_in(0, b) &
+                            )
+                    end if
+                end do
+
+                ! (ii) Shared functions: sum over the same non-turned-off species.
+                phi_func = (0.0_dp, 0.0_dp)
+                B_func = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+                    phi_func = phi_func + hatG_rho_phi_diag_sp(plasma, sp, kr, j)
+                    B_func = B_func + hatG_rho_B_diag_sp(plasma, sp, kr, j)
+                end do
+
+                tol_phi = 1.0e-12_dp * (1.0_dp + abs(phi_inline))
+                tol_B = 1.0e-12_dp * (1.0_dp + abs(B_inline))
+
+                if (abs(phi_inline - phi_func) >= tol_phi) then
+                    print *, 'FAIL: rho-Phi diagonal mismatch at kr=', kr, ' j=', j
+                    print *, '  inline   = ', phi_inline
+                    print *, '  fromfunc = ', phi_func
+                    print *, '  |diff|   = ', abs(phi_inline - phi_func), ' tol = ', tol_phi
+                    error stop
+                end if
+                if (abs(B_inline - B_func) >= tol_B) then
+                    print *, 'FAIL: rho-B diagonal mismatch at kr=', kr, ' j=', j
+                    print *, '  inline   = ', B_inline
+                    print *, '  fromfunc = ', B_func
+                    print *, '  |diff|   = ', abs(B_inline - B_func), ' tol = ', tol_B
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: shared diagonal integrand matches inline reference'
+    end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()
         use config_m, only: profiles_in_memory, nml_config_path

--- a/KIM/tests/test_flr2_fourier_kernel.f90
+++ b/KIM/tests/test_flr2_fourier_kernel.f90
@@ -27,6 +27,7 @@ program test_flr2_fourier_kernel
     call test_diagonal_matches_inline()
     call test_collapse_rho_phi()
     call test_phase_rho_phi()
+    call test_collapse_rho_phi_ks2()
 
     print *, 'All tests PASSED'
     stop 0
@@ -297,6 +298,86 @@ contains
         end do
 
         print *, 'PASS: fused rho-Phi kernel carries the Fourier phase only'
+    end subroutine
+
+    subroutine test_collapse_rho_phi_ks2()
+        ! Structural collapse for the k_s^2-inclusive path (kern_include_ks2 =
+        ! .true.). This branch keeps k_s in the FLR arguments, so it does NOT
+        ! collapse to the k_s-dropped diagonal source-of-truth. Instead, on the
+        ! diagonal k_r = k'_r the two FLR arguments both reduce to the full
+        ! perpendicular argument bf = (k_s^2 + k_r^2) * rho_L^2, so the fused
+        ! kernel must equal the per-species core evaluated at (bf, bf), summed
+        ! over the non-turned-off species and divided by 4*pi. This validates the
+        ! sqrt/2 algebra of the .true. branch without needing a k_s = 0 setup.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: turn_off_ions, turn_off_electrons
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, core_rho_phi_sp, kern_include_ks2
+        use constants_m, only: pi
+        use species_m, only: plasma, set_profiles_from_arrays
+        use grid_m, only: rg_grid
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: kr_arr(3), kr, bf, tol
+        integer :: i, j, sp, jj_arr(3), k
+        complex(dp) :: ref, gfused
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_fourier_collapse_ks2_test.nml')
+        nml_config_path = './KIM_config_fourier_collapse_ks2_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        kern_include_ks2 = .true.
+
+        kr_arr = [0.1_dp, 1.0_dp, 5.0_dp]
+        jj_arr = [rg_grid%npts_b / 4, rg_grid%npts_b / 2, (3 * rg_grid%npts_b) / 4]
+
+        do i = 1, size(kr_arr)
+            kr = kr_arr(i)
+            do k = 1, size(jj_arr)
+                j = jj_arr(k)
+
+                ref = (0.0_dp, 0.0_dp)
+                do sp = 0, plasma%n_species - 1
+                    if (turn_off_ions .and. sp >= 1) cycle
+                    if (turn_off_electrons .and. sp == 0) cycle
+                    bf = (plasma%ks(j)**2 + kr**2) * plasma%spec(sp)%rho_L(j)**2
+                    ref = ref + core_rho_phi_sp(plasma, sp, bf, bf, j)
+                end do
+                ref = ref / (4.0d0 * pi)
+
+                gfused = hatG_rho_phi(plasma, kr, kr, j)
+
+                tol = 1.0e-12_dp * (1.0_dp + abs(ref))
+                if (abs(gfused - ref) >= tol) then
+                    print *, 'FAIL: rho-Phi ks2 collapse mismatch at kr=', kr, ' j=', j
+                    print *, '  core(bf,bf)/4pi = ', ref
+                    print *, '  fused           = ', gfused
+                    print *, '  |diff|          = ', abs(gfused - ref), ' tol = ', tol
+                    error stop
+                end if
+            end do
+        end do
+
+        ! Defensive: restore the default so any later test sees the drop-k_s^2
+        ! path in the shared module state.
+        kern_include_ks2 = .false.
+
+        print *, 'PASS: fused rho-Phi kernel (ks2 path) collapses to core(bf,bf) at kr=krp'
     end subroutine
 
     subroutine test_populated_plasma_and_kernel_stub()

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -25,6 +25,7 @@ program test_kim_solver_periodic
     implicit none
 
     call test_run_type_end_to_end()
+    call test_multi_ion_order_independence()
 
     print *, 'All tests PASSED'
     stop 0
@@ -33,8 +34,9 @@ contains
 
     subroutine test_run_type_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -47,7 +49,7 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        real(dp) :: rm, r_lo, r_hi, tol
+        real(dp) :: rm, r_lo, r_hi, tol, rho_i_rm, expected_r_lo
         integer :: i, N
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
@@ -64,14 +66,23 @@ contains
         ! Full lifecycle through the new run-type.
         call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
         call kim_instance%init()
-        call kim_instance%run()
 
-        ! The resonance the run-type located (q = |m/n| = 3 on the global plasma).
+        ! Capture the reference scale from the TRUE global plasma before run()
+        ! redirects it onto the periodic window. This is the same state used by
+        ! run_electrostatic_periodic to derive and store the window parameters.
+        call prepare_resonances
         rm = r_res
         if (.not. (rm > 0.0_dp)) then
             print *, 'FAIL: resonance not found, r_res = ', rm
             error stop
         end if
+        rho_i_rm = interp_species_rho_L(1, rm)
+        if (.not. (rho_i_rm > 0.0_dp)) then
+            print *, 'FAIL: deuterium rho_L(rm) is not positive:', rho_i_rm
+            error stop
+        end if
+
+        call kim_instance%run()
         print *, 'resonant radius rm = ', rm
 
         N = rg_grid%npts_b
@@ -116,6 +127,14 @@ contains
         r_lo = EBdat%r_grid(1)
         r_hi = EBdat%r_grid(N)
         tol = 1.0e-8_dp * (1.0_dp + abs(rm))
+        expected_r_lo = rm - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_i_rm
+        if (abs(r_lo - expected_r_lo) > tol) then
+            print *, 'FAIL: periodic window is not sized from deuterium rho_L'
+            print *, '  actual lower edge =', r_lo
+            print *, '  expected lower edge =', expected_r_lo
+            print *, '  deuterium rho_L(rm) =', rho_i_rm
+            error stop
+        end if
         if (abs(0.5_dp * (r_lo + r_hi) - rm) > (r_hi - r_lo) / real(N - 1, dp)) then
             print *, 'FAIL: window not centred on rm; midpoint =', &
                      0.5_dp * (r_lo + r_hi), ' rm =', rm
@@ -127,7 +146,157 @@ contains
         end if
         print *, 'PASS: EBdat%r_grid spans window [', r_lo, ',', r_hi, &
                  '] about rm =', rm
+
+        call assert_scale_metadata(rho_i_rm)
     end subroutine test_run_type_end_to_end
+
+    subroutine assert_scale_metadata(expected_rho)
+        use constants_m, only: pi
+        use config_m, only: output_path, periodic_dr_asis_scale, &
+                            periodic_dr_tr_scale, periodic_kmax_scale, periodic_n_rg
+
+        real(dp), intent(in) :: expected_rho
+        character(len=512) :: metadata_path, header
+        integer :: io_unit, io_status, reference_species, charge, M, n_rg
+        real(dp) :: mass, rho_ref, dx_asis, dx_tr, k_max, period, tol
+        logical :: exists
+
+        metadata_path = trim(output_path)//'setup/periodic_scale.dat'
+        inquire(file=trim(metadata_path), exist=exists)
+        if (.not. exists) then
+            print *, 'FAIL: periodic scale metadata was not stored at ', trim(metadata_path)
+            error stop
+        end if
+
+        open(newunit=io_unit, file=trim(metadata_path), status='old', action='read')
+        read(io_unit, '(A)', iostat=io_status) header
+        if (io_status /= 0 .or. index(header, 'reference_species') == 0) then
+            print *, 'FAIL: periodic scale metadata header is missing or invalid'
+            error stop
+        end if
+        read(io_unit, *, iostat=io_status) reference_species, charge, mass, rho_ref, &
+            dx_asis, dx_tr, k_max, M, n_rg
+        close(io_unit)
+        if (io_status /= 0) then
+            print *, 'FAIL: periodic scale metadata row could not be read'
+            error stop
+        end if
+
+        tol = 1.0e-10_dp * max(1.0_dp, expected_rho)
+        period = 2.0_dp * (periodic_dr_asis_scale + periodic_dr_tr_scale) * expected_rho
+        if (reference_species /= 1 .or. charge /= 1 .or. .not. (mass > 0.0_dp) .or. &
+            abs(rho_ref - expected_rho) > tol .or. &
+            abs(dx_asis - periodic_dr_asis_scale * expected_rho) > tol .or. &
+            abs(dx_tr - periodic_dr_tr_scale * expected_rho) > tol .or. &
+            abs(k_max - periodic_kmax_scale / expected_rho) > tol .or. &
+            M /= ceiling((periodic_kmax_scale / expected_rho) * period / (2.0_dp * pi)) .or. &
+            n_rg /= periodic_n_rg) then
+            print *, 'FAIL: stored periodic scale metadata does not match the run'
+            print *, '  species/Z/mass =', reference_species, charge, mass
+            print *, '  rho stored/expected/tol =', rho_ref, expected_rho, tol
+            print *, '  dx_asis stored/expected =', dx_asis, &
+                     periodic_dr_asis_scale * expected_rho
+            print *, '  dx_tr stored/expected =', dx_tr, &
+                     periodic_dr_tr_scale * expected_rho
+            print *, '  k_max stored/expected =', k_max, &
+                     periodic_kmax_scale / expected_rho
+            print *, '  M/N_rg stored =', M, n_rg, ' expected N_rg =', periodic_n_rg
+            error stop
+        end if
+        print *, 'PASS: periodic scale provenance stored in ', trim(metadata_path)
+    end subroutine assert_scale_metadata
+
+    subroutine test_multi_ion_order_independence()
+        integer, parameter :: masses_forward(2) = [2, 12]
+        integer, parameter :: masses_reverse(2) = [12, 2]
+        real(dp) :: lower_forward, lower_reverse, expected_forward, expected_reverse
+        real(dp) :: tol
+
+        call run_multi_ion_case(masses_forward, lower_forward, expected_forward)
+        call run_multi_ion_case(masses_reverse, lower_reverse, expected_reverse)
+
+        tol = 1.0e-8_dp * (1.0_dp + abs(expected_forward))
+        if (abs(lower_forward - expected_forward) > tol) then
+            print *, 'FAIL: forward-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_forward
+            print *, '  expected lower edge =', expected_forward
+            error stop
+        end if
+        if (abs(lower_reverse - expected_reverse) > tol) then
+            print *, 'FAIL: reverse-order window does not cover the largest ion rho_L'
+            print *, '  actual lower edge =', lower_reverse
+            print *, '  expected lower edge =', expected_reverse
+            error stop
+        end if
+        if (abs(lower_forward - lower_reverse) > tol) then
+            print *, 'FAIL: reference scale depends on ion storage order'
+            print *, '  forward lower edge =', lower_forward
+            print *, '  reverse lower edge =', lower_reverse
+            error stop
+        end if
+        print *, 'PASS: largest active-ion rho_L is storage-order independent'
+    end subroutine test_multi_ion_order_independence
+
+    subroutine run_multi_ion_case(ion_masses, lower_edge, expected_lower_edge)
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_dr_asis_scale, periodic_dr_tr_scale
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use fields_m, only: EBdat, EBdat_t
+
+        integer, intent(in) :: ion_masses(:)
+        real(dp), intent(out) :: lower_edge, expected_lower_edge
+        integer, parameter :: npts = 201
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp) :: rho_max
+        class(kim_t), allocatable :: kim_instance
+        integer :: sp
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_run_test.nml', ion_masses)
+        nml_config_path = './KIM_config_periodic_run_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        rho_max = 0.0_dp
+        do sp = 1, plasma%n_species - 1
+            rho_max = max(rho_max, interp_species_rho_L(sp, r_res))
+        end do
+        lower_edge = EBdat%r_grid(1)
+        expected_lower_edge = r_res &
+            - (periodic_dr_asis_scale + periodic_dr_tr_scale) * rho_max
+    end subroutine run_multi_ion_case
+
+    real(dp) function interp_species_rho_L(sp, x) result(rhoLx)
+        use species_m, only: plasma
+        integer, intent(in) :: sp
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+        call binsrc(plasma%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma%spec(sp)%rho_L(ibeg:iend))
+    end function interp_species_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)
@@ -148,21 +317,27 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path)
+    subroutine write_test_namelist(path, ion_masses)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
         ! config defaults apply when the optional namelist is absent.
         character(len=*), intent(in) :: path
-        integer :: iunit
+        integer, intent(in), optional :: ion_masses(:)
+        integer :: iunit, i, nions
+        logical :: custom_species
+
+        custom_species = present(ion_masses)
+        nions = 1
+        if (custom_species) nions = size(ion_masses)
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
-        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A,I0)') ' number_of_ion_species = ', nions
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic_periodic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
-        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A,L1)') ' read_species_from_namelist = ', custom_species
         write(iunit, '(A)') ' turn_off_ions = .false.'
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
@@ -170,6 +345,20 @@ contains
         write(iunit, '(A)') ' number_density_rescale = 1.0'
         write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
         write(iunit, '(A)') '/'
+        if (custom_species) then
+            write(iunit, '(A)') '&KIM_species'
+            write(iunit, '(A)', advance='no') ' ai ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') ion_masses(i)
+            end do
+            write(iunit, *)
+            write(iunit, '(A)', advance='no') ' zi ='
+            do i = 1, nions
+                write(iunit, '(1X,I0)', advance='no') 1
+            end do
+            write(iunit, *)
+            write(iunit, '(A)') '/'
+        end if
         write(iunit, '(A)') '&WKB_DISPERSION'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_IO'

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -1,0 +1,232 @@
+program test_kim_solver_periodic
+    ! Integration test for the electrostatic_periodic run-type (Phase-2.6).
+    !
+    ! Drives the full lifecycle of the new run-type end-to-end:
+    !   from_kim_factory_get_kim('electrostatic_periodic', kim)
+    !   -> kim%init()   (global setup: grids + equilibrium + plasma quantities)
+    !   -> kim%run()    (locate resonance rm, size the window from rho_L(rm),
+    !                    build the periodic plasma, assemble the Fourier
+    !                    matrices, solve, reconstruct dPhi on the window grid,
+    !                    and pack it into fields_m::EBdat).
+    !
+    ! Setup mirrors test_periodic_assembly.f90 / test_periodic_solve.f90:
+    ! in-memory analytic profiles, (m,n) = (-6, 2) so q is resonant at q = 3
+    ! inside the solver domain, type_br_field = 12 (constant Br over the window).
+    !
+    ! This is the wiring/integration proof (localization/physics-vs-global is
+    ! Phase-2.7). Assertions on the packed result in fields_m::EBdat:
+    !   (Phi)    EBdat%Phi allocated, size == rg_grid%npts_b, all finite,
+    !            and NOT all-zero (maxval(abs(EBdat%Phi)) > 0);
+    !   (r_grid) EBdat%r_grid allocated, size == rg_grid%npts_b, spans the
+    !            window [rm - L/2, rm + L/2].
+
+    use KIM_kinds_m, only: dp
+
+    implicit none
+
+    call test_run_type_end_to_end()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_run_type_end_to_end()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use grid_m, only: rg_grid
+        use fields_m, only: EBdat
+
+        integer, parameter :: npts = 201
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        real(dp) :: rm, r_lo, r_hi, tol
+        integer :: i, N
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_run_test.nml')
+        nml_config_path = './KIM_config_periodic_run_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        ! Full lifecycle through the new run-type.
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        ! The resonance the run-type located (q = |m/n| = 3 on the global plasma).
+        rm = r_res
+        if (.not. (rm > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', rm
+            error stop
+        end if
+        print *, 'resonant radius rm = ', rm
+
+        N = rg_grid%npts_b
+
+        ! (Phi) allocated, correct size, finite, non-zero.
+        if (.not. allocated(EBdat%Phi)) then
+            print *, 'FAIL: EBdat%Phi not allocated'
+            error stop
+        end if
+        if (size(EBdat%Phi) /= N) then
+            print *, 'FAIL: size(EBdat%Phi) /= rg_grid%npts_b; got ', &
+                     size(EBdat%Phi), ' expected ', N
+            error stop
+        end if
+        do i = 1, N
+            if (.not. ieee_is_finite(real(EBdat%Phi(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(EBdat%Phi(i)))) then
+                print *, 'FAIL: non-finite EBdat%Phi at', i
+                error stop
+            end if
+        end do
+        if (.not. (maxval(abs(EBdat%Phi)) > 0.0_dp)) then
+            print *, 'FAIL: EBdat%Phi all zero (constant Br should drive response)'
+            error stop
+        end if
+        print *, 'PASS: EBdat%Phi allocated, size ', N, &
+                 ', finite & non-zero, max|Phi| =', maxval(abs(EBdat%Phi))
+
+        ! (r_grid) allocated, correct size, spans the window [rm - L/2, rm + L/2].
+        if (.not. allocated(EBdat%r_grid)) then
+            print *, 'FAIL: EBdat%r_grid not allocated'
+            error stop
+        end if
+        if (size(EBdat%r_grid) /= N) then
+            print *, 'FAIL: size(EBdat%r_grid) /= rg_grid%npts_b; got ', &
+                     size(EBdat%r_grid), ' expected ', N
+            error stop
+        end if
+
+        ! The window is symmetric about rm; recover L from its span and check
+        ! the endpoints match rm -+ L/2 to within a grid-spacing tolerance.
+        r_lo = EBdat%r_grid(1)
+        r_hi = EBdat%r_grid(N)
+        tol = 1.0e-8_dp * (1.0_dp + abs(rm))
+        if (abs(0.5_dp * (r_lo + r_hi) - rm) > (r_hi - r_lo) / real(N - 1, dp)) then
+            print *, 'FAIL: window not centred on rm; midpoint =', &
+                     0.5_dp * (r_lo + r_hi), ' rm =', rm
+            error stop
+        end if
+        if (.not. (r_lo < rm .and. rm < r_hi)) then
+            print *, 'FAIL: rm not inside window [', r_lo, ',', r_hi, ']'
+            error stop
+        end if
+        print *, 'PASS: EBdat%r_grid spans window [', r_lo, ',', r_hi, &
+                 '] about rm =', rm
+    end subroutine test_run_type_end_to_end
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm; q crosses 3 inside [10, 50] so
+        ! the (m,n) = (-6, 2) mode (|m/n| = 3) has a resonance there.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
+        ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
+        ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
+        ! config defaults apply when the optional namelist is absent.
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic_periodic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_run_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_kim_solver_periodic

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -111,6 +111,32 @@ contains
         print *, 'PASS: EBdat%Phi allocated, size ', N, &
                  ', finite & non-zero, max|Phi| =', maxval(abs(EBdat%Phi))
 
+        ! (jpar) allocated, correct size, all finite, and NOT all-zero: the same
+        ! constant Br that drives Phi must drive a parallel current response via
+        ! thesis (11.7), j_par = K^{jPhi} Phi + K^{jB} Br.
+        if (.not. allocated(EBdat%jpar)) then
+            print *, 'FAIL: EBdat%jpar not allocated'
+            error stop
+        end if
+        if (size(EBdat%jpar) /= N) then
+            print *, 'FAIL: size(EBdat%jpar) /= rg_grid%npts_b; got ', &
+                     size(EBdat%jpar), ' expected ', N
+            error stop
+        end if
+        do i = 1, N
+            if (.not. ieee_is_finite(real(EBdat%jpar(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(EBdat%jpar(i)))) then
+                print *, 'FAIL: non-finite EBdat%jpar at', i
+                error stop
+            end if
+        end do
+        if (.not. (maxval(abs(EBdat%jpar)) > 0.0_dp)) then
+            print *, 'FAIL: EBdat%jpar all zero (constant Br should drive a current)'
+            error stop
+        end if
+        print *, 'PASS: EBdat%jpar allocated, size ', N, &
+                 ', finite & non-zero, max|jpar| =', maxval(abs(EBdat%jpar))
+
         ! (r_grid) allocated, correct size, spans the window [rm - L/2, rm + L/2].
         if (.not. allocated(EBdat%r_grid)) then
             print *, 'FAIL: EBdat%r_grid not allocated'

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -26,6 +26,7 @@ program test_kim_solver_periodic
 
     call test_run_type_end_to_end()
     call test_multi_ion_order_independence()
+    call test_global_approximation_enabled()
 
     print *, 'All tests PASSED'
     stop 0
@@ -35,7 +36,9 @@ contains
     subroutine test_run_type_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         use config_m, only: profiles_in_memory, nml_config_path, &
-                            periodic_dr_asis_scale, periodic_dr_tr_scale
+                            periodic_dr_asis_scale, periodic_dr_tr_scale, &
+                            periodic_match_global_kernel_approximations
+        use flr2_fourier_kernel_m, only: kern_include_ks2, kern_zero_flr_electrons
         use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
@@ -84,6 +87,16 @@ contains
 
         call kim_instance%run()
         print *, 'resonant radius rm = ', rm
+
+        if (periodic_match_global_kernel_approximations) then
+            print *, 'FAIL: global-kernel approximation must default to false'
+            error stop
+        end if
+        if (.not. kern_include_ks2 .or. kern_zero_flr_electrons) then
+            print *, 'FAIL: default periodic run did not use the full Fourier kernel'
+            error stop
+        end if
+        print *, 'PASS: omitted periodic approximation flag selects full kernel'
 
         N = rg_grid%npts_b
 
@@ -263,6 +276,44 @@ contains
         print *, 'PASS: largest active-ion rho_L is storage-order independent'
     end subroutine test_multi_ion_order_independence
 
+    subroutine test_global_approximation_enabled()
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            periodic_match_global_kernel_approximations
+        use flr2_fourier_kernel_m, only: kern_include_ks2, kern_zero_flr_electrons
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 201
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_run_test.nml', &
+                                 match_global_approximations=.true.)
+        nml_config_path = './KIM_config_periodic_run_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        if (.not. periodic_match_global_kernel_approximations) then
+            print *, 'FAIL: explicit global-kernel approximation flag was not read'
+            error stop
+        end if
+        if (kern_include_ks2 .or. .not. kern_zero_flr_electrons) then
+            print *, 'FAIL: enabled global approximation did not configure kernels'
+            error stop
+        end if
+        print *, 'PASS: enabled global approximation matches global kernel assumptions'
+    end subroutine test_global_approximation_enabled
+
     subroutine run_multi_ion_case(ion_masses, lower_edge, expected_lower_edge)
         use config_m, only: profiles_in_memory, nml_config_path, &
                             periodic_dr_asis_scale, periodic_dr_tr_scale
@@ -343,13 +394,14 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path, ion_masses)
+    subroutine write_test_namelist(path, ion_masses, match_global_approximations)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
         ! config defaults apply when the optional namelist is absent.
         character(len=*), intent(in) :: path
         integer, intent(in), optional :: ion_masses(:)
+        logical, intent(in), optional :: match_global_approximations
         integer :: iunit, i, nions
         logical :: custom_species
 
@@ -441,6 +493,13 @@ contains
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_PROFILES'
         write(iunit, '(A)') '/'
+        if (present(match_global_approximations)) then
+            write(iunit, '(A)') '&KIM_PERIODIC'
+            write(iunit, '(A,L1)') &
+                ' periodic_match_global_kernel_approximations = ', &
+                match_global_approximations
+            write(iunit, '(A)') '/'
+        end if
         close(iunit)
     end subroutine write_test_namelist
 

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -8,10 +8,10 @@ program test_periodic_assembly
     ! Because the periodic background makes the integrand L-periodic and the
     ! Fourier phase exp(i(k_m - k_m') r_g) is exactly L-periodic
     ! ((k_m - k_m')*L = 2*pi*(m - m')), the periodic trapezoidal (equidistant)
-    ! rule is spectrally accurate. The window grid rg_grid%xb has N = npts_b
-    ! equidistant points on [rm - L/2, rm + L/2]; points 1 and N are one period
-    ! apart, so only the N-1 DISTINCT samples are summed:
-    !   K_{m,m'} = (2*pi/(N-1)) * sum_{j=1}^{N-1} hatG(plasma, k_m, k_m', j).
+    ! rule is spectrally accurate. The window grid rg_grid%xb is endpoint-
+    ! exclusive over one period (h = L/N, xb(N) = rm + L/2 - h), so the N points
+    ! are the N DISTINCT samples and all are summed with equal weight:
+    !   K_{m,m'} = (2*pi/N) * sum_{j=1}^{N} hatG(plasma, k_m, k_m', j).
     !
     ! Setup mirrors test_periodic_background_build.f90 (in-memory profiles,
     ! (m,n) = (-6, 2) so q resonant at q = 3, build a periodic window at rm).
@@ -180,14 +180,16 @@ contains
         k_m  = 2.0_dp * pi * real(mm,  dp) / L
         k_mp = 2.0_dp * pi * real(mmp, dp) / L
 
+        ! SAME formula as assemble_periodic_matrices: endpoint-exclusive window,
+        ! sum ALL N distinct samples with equal weight 2*pi/N.
         acc_phi = (0.0_dp, 0.0_dp)
         acc_B   = (0.0_dp, 0.0_dp)
-        do j = 1, N - 1
+        do j = 1, N
             acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
             acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
         end do
-        ref_phi = (2.0_dp * pi / real(N - 1, dp)) * acc_phi
-        ref_B   = (2.0_dp * pi / real(N - 1, dp)) * acc_B
+        ref_phi = (2.0_dp * pi / real(N, dp)) * acc_phi
+        ref_B   = (2.0_dp * pi / real(N, dp)) * acc_B
 
         im  = mm  + M + 1
         imp = mmp + M + 1

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -83,11 +83,13 @@ contains
         rm = r_res
         print *, 'resonant radius rm = ', rm
 
-        ! Representative Larmor radius near rm (electrons) on the global plasma.
+        ! Representative ion Larmor radius near rm on the global plasma. The
+        ! production kernel deliberately takes electrons in the zero-FLR limit,
+        ! so ion FLR must set the test window and supply the non-Toeplitz signal.
         rho_L_rm = rho_L_near(rm)
-        print *, 'rho_L(rm) [electron] = ', rho_L_rm
+        print *, 'rho_L(rm) [ion] = ', rho_L_rm
 
-        ! Window half-widths: 5 and 10 Larmor radii (guard against a degenerate
+        ! Window half-widths: 5 and 10 ion Larmor radii (guard against a degenerate
         ! window if rho_L is unexpectedly small).
         dx_asis =  5.0_dp * rho_L_rm
         dx_tr   = 10.0_dp * rho_L_rm
@@ -253,13 +255,13 @@ contains
     end function not_equal_pair
 
     real(dp) function rho_L_near(r) result(val)
-        !> Electron Larmor radius of the global plasma at the grid point nearest
+        !> Ion Larmor radius of the global plasma at the grid point nearest
         !> radius r (the plasma is still on the global grid here).
         use species_m, only: plasma
         real(dp), intent(in) :: r
         integer :: jn
         jn = minloc(abs(plasma%r_grid - r), dim=1)
-        val = plasma%spec(0)%rho_L(jn)
+        val = plasma%spec(1)%rho_L(jn)
     end function rho_L_near
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -56,7 +56,7 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        complex(dp), allocatable :: Kphi(:,:), KB(:,:)
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:)
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
         integer :: n_rg, N, dim, im, imp
 
@@ -107,23 +107,27 @@ contains
             error stop
         end if
 
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
 
-        ! (shape) both matrices are (2M+1) x (2M+1).
+        ! (shape) all four matrices are (2M+1) x (2M+1).
         dim = 2 * M + 1
         if (size(Kphi, 1) /= dim .or. size(Kphi, 2) /= dim .or. &
-            size(KB, 1)   /= dim .or. size(KB, 2)   /= dim) then
+            size(KB, 1)   /= dim .or. size(KB, 2)   /= dim .or. &
+            size(Kjphi, 1) /= dim .or. size(Kjphi, 2) /= dim .or. &
+            size(KjB, 1)  /= dim .or. size(KjB, 2)  /= dim) then
             print *, 'FAIL: matrix shape wrong'
             print *, '  Kphi:', size(Kphi, 1), size(Kphi, 2), &
-                     '  KB:', size(KB, 1), size(KB, 2), ' expected ', dim
+                     '  KB:', size(KB, 1), size(KB, 2), &
+                     '  Kjphi:', size(Kjphi, 1), size(Kjphi, 2), &
+                     '  KjB:', size(KjB, 1), size(KjB, 2), ' expected ', dim
             error stop
         end if
         print *, 'PASS: shape (2M+1)x(2M+1) =', dim, 'x', dim
 
         ! (characterization) recompute two elements by an inline brute-force sum
         ! with the SAME quadrature formula and compare to the stored elements.
-        call check_element(plasma, Kphi, KB, L, M, N,  0,  0)
-        call check_element(plasma, Kphi, KB, L, M, N,  1, -2)
+        call check_element(plasma, Kphi, KB, Kjphi, KjB, L, M, N,  0,  0)
+        call check_element(plasma, Kphi, KB, Kjphi, KjB, L, M, N,  1, -2)
         print *, 'PASS: characterization -- brute-force sum reproduces elements'
 
         ! (diagonal nonzero) the m = m' = 0 element.
@@ -145,13 +149,17 @@ contains
         end if
         print *, 'PASS: Kphi is NOT Toeplitz (k_m/k_m'' dependence confirmed)'
 
-        ! (finiteness) every element of both matrices is finite.
+        ! (finiteness) every element of all four matrices is finite.
         do imp = 1, dim
             do im = 1, dim
                 if (.not. ieee_is_finite(real(Kphi(im, imp), dp)) .or. &
                     .not. ieee_is_finite(aimag(Kphi(im, imp))) .or. &
                     .not. ieee_is_finite(real(KB(im, imp), dp)) .or. &
-                    .not. ieee_is_finite(aimag(KB(im, imp)))) then
+                    .not. ieee_is_finite(aimag(KB(im, imp))) .or. &
+                    .not. ieee_is_finite(real(Kjphi(im, imp), dp)) .or. &
+                    .not. ieee_is_finite(aimag(Kjphi(im, imp))) .or. &
+                    .not. ieee_is_finite(real(KjB(im, imp), dp)) .or. &
+                    .not. ieee_is_finite(aimag(KjB(im, imp)))) then
                     print *, 'FAIL: non-finite matrix element at', im, imp
                     error stop
                 end if
@@ -160,20 +168,21 @@ contains
         print *, 'PASS: all matrix elements finite'
     end subroutine test_assemble
 
-    !> Recompute K^{rhoPhi}_{m,m'} and K^{rhoB}_{m,m'} by an INLINE brute-force
-    !> periodic-trapezoidal sum using the SAME formula as the module, and assert
-    !> both stored elements match to < 1e-12*(1 + |elem|).
-    subroutine check_element(plasma, Kphi, KB, L, M, N, mm, mmp)
+    !> Recompute K^{rhoPhi}, K^{rhoB}, K^{jPhi} and K^{jB} at (m,m') by an INLINE
+    !> brute-force periodic-trapezoidal sum using the SAME formula as the module,
+    !> and assert every stored element matches to < 1e-12*(1 + |elem|).
+    subroutine check_element(plasma, Kphi, KB, Kjphi, KjB, L, M, N, mm, mmp)
         use species_m, only: plasma_t
-        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, hatG_j_phi, hatG_j_B
         use constants_m, only: pi
 
         type(plasma_t), intent(in) :: plasma
-        complex(dp), intent(in) :: Kphi(:,:), KB(:,:)
+        complex(dp), intent(in) :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:)
         real(dp), intent(in) :: L
         integer, intent(in) :: M, N, mm, mmp
 
         complex(dp) :: acc_phi, acc_B, ref_phi, ref_B
+        complex(dp) :: acc_jphi, acc_jB, ref_jphi, ref_jB
         real(dp) :: k_m, k_mp, tol
         integer :: im, imp, j
 
@@ -182,14 +191,20 @@ contains
 
         ! SAME formula as assemble_periodic_matrices: endpoint-exclusive window,
         ! sum ALL N distinct samples with equal weight 2*pi/N.
-        acc_phi = (0.0_dp, 0.0_dp)
-        acc_B   = (0.0_dp, 0.0_dp)
+        acc_phi  = (0.0_dp, 0.0_dp)
+        acc_B    = (0.0_dp, 0.0_dp)
+        acc_jphi = (0.0_dp, 0.0_dp)
+        acc_jB   = (0.0_dp, 0.0_dp)
         do j = 1, N
-            acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
-            acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
+            acc_phi  = acc_phi  + hatG_rho_phi(plasma, k_m, k_mp, j)
+            acc_B    = acc_B    + hatG_rho_B(plasma, k_m, k_mp, j)
+            acc_jphi = acc_jphi + hatG_j_phi(plasma, k_m, k_mp, j)
+            acc_jB   = acc_jB   + hatG_j_B(plasma, k_m, k_mp, j)
         end do
-        ref_phi = (2.0_dp * pi / real(N, dp)) * acc_phi
-        ref_B   = (2.0_dp * pi / real(N, dp)) * acc_B
+        ref_phi  = (2.0_dp * pi / real(N, dp)) * acc_phi
+        ref_B    = (2.0_dp * pi / real(N, dp)) * acc_B
+        ref_jphi = (2.0_dp * pi / real(N, dp)) * acc_jphi
+        ref_jB   = (2.0_dp * pi / real(N, dp)) * acc_jB
 
         im  = mm  + M + 1
         imp = mmp + M + 1
@@ -207,6 +222,22 @@ contains
             print *, 'FAIL: KB element mismatch at (m,mp)=', mm, mmp
             print *, '  stored =', KB(im, imp), ' ref =', ref_B
             print *, '  |diff| =', abs(KB(im, imp) - ref_B), ' tol =', tol
+            error stop
+        end if
+
+        tol = 1.0e-12_dp * (1.0_dp + abs(ref_jphi))
+        if (abs(Kjphi(im, imp) - ref_jphi) >= tol) then
+            print *, 'FAIL: Kjphi element mismatch at (m,mp)=', mm, mmp
+            print *, '  stored =', Kjphi(im, imp), ' ref =', ref_jphi
+            print *, '  |diff| =', abs(Kjphi(im, imp) - ref_jphi), ' tol =', tol
+            error stop
+        end if
+
+        tol = 1.0e-12_dp * (1.0_dp + abs(ref_jB))
+        if (abs(KjB(im, imp) - ref_jB) >= tol) then
+            print *, 'FAIL: KjB element mismatch at (m,mp)=', mm, mmp
+            print *, '  stored =', KjB(im, imp), ' ref =', ref_jB
+            print *, '  |diff| =', abs(KjB(im, imp) - ref_jB), ' tol =', tol
             error stop
         end if
     end subroutine check_element

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -1,0 +1,332 @@
+program test_periodic_assembly
+    ! Validates assemble_periodic_matrices (Phase-2.4): assembly of the dense
+    ! complex Fourier matrices K^{rhoPhi}_{m,m'} and K^{rhoB}_{m,m'} over one
+    ! period, reusing the Phase-2.3 periodic plasma and the Phase-1 fused kernel
+    ! (hatG_rho_phi / hatG_rho_B).
+    !
+    ! Discrete k-grid: k_m = 2*pi*m/L, m = -M..M (row/col index im = m + M + 1).
+    ! Because the periodic background makes the integrand L-periodic and the
+    ! Fourier phase exp(i(k_m - k_m') r_g) is exactly L-periodic
+    ! ((k_m - k_m')*L = 2*pi*(m - m')), the periodic trapezoidal (equidistant)
+    ! rule is spectrally accurate. The window grid rg_grid%xb has N = npts_b
+    ! equidistant points on [rm - L/2, rm + L/2]; points 1 and N are one period
+    ! apart, so only the N-1 DISTINCT samples are summed:
+    !   K_{m,m'} = (2*pi/(N-1)) * sum_{j=1}^{N-1} hatG(plasma, k_m, k_m', j).
+    !
+    ! Setup mirrors test_periodic_background_build.f90 (in-memory profiles,
+    ! (m,n) = (-6, 2) so q resonant at q = 3, build a periodic window at rm).
+    !
+    ! Assertions:
+    !   (shape)          size(K,1) == size(K,2) == 2M+1 for both matrices;
+    !   (characterization) for (m,m') = (0,0) and (1,-2), an INLINE brute-force
+    !                    sum with the SAME formula reproduces the stored element
+    !                    to < 1e-12*(1 + |elem|) -- pins k_m mapping, h factor,
+    !                    index mapping, and seam handling;
+    !   (diagonal nonzero) |Kphi(M+1, M+1)| > 0 (the m = m' = 0 element);
+    !   (not Toeplitz)   elements with equal (m - m') but different m differ
+    !                    (the FLR factors depend on both k_m and k_m');
+    !   (finiteness)     all elements finite.
+
+    use KIM_kinds_m, only: dp
+    use periodic_assembly_m, only: assemble_periodic_matrices
+
+    implicit none
+
+    call test_assemble()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_assemble()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use grid_m, only: rg_grid
+        use periodic_background_m, only: build_periodic_plasma
+
+        integer, parameter :: npts = 201
+        integer, parameter :: M = 3        ! small: yields a 7x7 matrix
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:)
+        real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
+        integer :: n_rg, N, dim, im, imp
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_assembly_test.nml')
+        nml_config_path = './KIM_config_periodic_assembly_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Locate the resonance (q = |m/n| = 3) on the global plasma.
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+        print *, 'resonant radius rm = ', rm
+
+        ! Representative Larmor radius near rm (electrons) on the global plasma.
+        rho_L_rm = rho_L_near(rm)
+        print *, 'rho_L(rm) [electron] = ', rho_L_rm
+
+        ! Window half-widths: 5 and 10 Larmor radii (guard against a degenerate
+        ! window if rho_L is unexpectedly small).
+        dx_asis =  5.0_dp * rho_L_rm
+        dx_tr   = 10.0_dp * rho_L_rm
+        if (dx_asis < 1.0e-3_dp) then
+            dx_asis = 1.0_dp
+            dx_tr   = 2.0_dp
+            print *, 'NOTE: rho_L(rm) tiny; using fixed dx_asis/dx_tr [cm]'
+        end if
+        n_rg = 96
+        L = 2.0_dp * (dx_asis + dx_tr)
+
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+
+        N = rg_grid%npts_b
+        if (N /= n_rg) then
+            print *, 'FAIL: rg_grid%npts_b /= n_rg; got ', N
+            error stop
+        end if
+
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+
+        ! (shape) both matrices are (2M+1) x (2M+1).
+        dim = 2 * M + 1
+        if (size(Kphi, 1) /= dim .or. size(Kphi, 2) /= dim .or. &
+            size(KB, 1)   /= dim .or. size(KB, 2)   /= dim) then
+            print *, 'FAIL: matrix shape wrong'
+            print *, '  Kphi:', size(Kphi, 1), size(Kphi, 2), &
+                     '  KB:', size(KB, 1), size(KB, 2), ' expected ', dim
+            error stop
+        end if
+        print *, 'PASS: shape (2M+1)x(2M+1) =', dim, 'x', dim
+
+        ! (characterization) recompute two elements by an inline brute-force sum
+        ! with the SAME quadrature formula and compare to the stored elements.
+        call check_element(plasma, Kphi, KB, L, M, N,  0,  0)
+        call check_element(plasma, Kphi, KB, L, M, N,  1, -2)
+        print *, 'PASS: characterization -- brute-force sum reproduces elements'
+
+        ! (diagonal nonzero) the m = m' = 0 element.
+        im  = 0 + M + 1
+        if (.not. (abs(Kphi(im, im)) > 0.0_dp)) then
+            print *, 'FAIL: Kphi(0,0) element is zero'
+            error stop
+        end if
+        print *, 'PASS: diagonal (m=m''=0) element nonzero, |Kphi| =', abs(Kphi(im, im))
+
+        ! (not Toeplitz) elements sharing (m - m') but with different m must
+        ! differ (the FLR factors depend on both k_m and k_m'). Try two
+        ! independent super-diagonal pairs to guard against a coincidental
+        ! equality; passing if EITHER pair differs above a tiny tolerance.
+        if (.not. ( not_equal_pair(Kphi, M, -1, -2,  0, -1) .or. &
+                    not_equal_pair(Kphi, M,  1,  0,  2,  1) )) then
+            print *, 'FAIL: Kphi appears Toeplitz (constant along a diagonal)'
+            error stop
+        end if
+        print *, 'PASS: Kphi is NOT Toeplitz (k_m/k_m'' dependence confirmed)'
+
+        ! (finiteness) every element of both matrices is finite.
+        do imp = 1, dim
+            do im = 1, dim
+                if (.not. ieee_is_finite(real(Kphi(im, imp), dp)) .or. &
+                    .not. ieee_is_finite(aimag(Kphi(im, imp))) .or. &
+                    .not. ieee_is_finite(real(KB(im, imp), dp)) .or. &
+                    .not. ieee_is_finite(aimag(KB(im, imp)))) then
+                    print *, 'FAIL: non-finite matrix element at', im, imp
+                    error stop
+                end if
+            end do
+        end do
+        print *, 'PASS: all matrix elements finite'
+    end subroutine test_assemble
+
+    !> Recompute K^{rhoPhi}_{m,m'} and K^{rhoB}_{m,m'} by an INLINE brute-force
+    !> periodic-trapezoidal sum using the SAME formula as the module, and assert
+    !> both stored elements match to < 1e-12*(1 + |elem|).
+    subroutine check_element(plasma, Kphi, KB, L, M, N, mm, mmp)
+        use species_m, only: plasma_t
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B
+        use constants_m, only: pi
+
+        type(plasma_t), intent(in) :: plasma
+        complex(dp), intent(in) :: Kphi(:,:), KB(:,:)
+        real(dp), intent(in) :: L
+        integer, intent(in) :: M, N, mm, mmp
+
+        complex(dp) :: acc_phi, acc_B, ref_phi, ref_B
+        real(dp) :: k_m, k_mp, tol
+        integer :: im, imp, j
+
+        k_m  = 2.0_dp * pi * real(mm,  dp) / L
+        k_mp = 2.0_dp * pi * real(mmp, dp) / L
+
+        acc_phi = (0.0_dp, 0.0_dp)
+        acc_B   = (0.0_dp, 0.0_dp)
+        do j = 1, N - 1
+            acc_phi = acc_phi + hatG_rho_phi(plasma, k_m, k_mp, j)
+            acc_B   = acc_B   + hatG_rho_B(plasma, k_m, k_mp, j)
+        end do
+        ref_phi = (2.0_dp * pi / real(N - 1, dp)) * acc_phi
+        ref_B   = (2.0_dp * pi / real(N - 1, dp)) * acc_B
+
+        im  = mm  + M + 1
+        imp = mmp + M + 1
+
+        tol = 1.0e-12_dp * (1.0_dp + abs(ref_phi))
+        if (abs(Kphi(im, imp) - ref_phi) >= tol) then
+            print *, 'FAIL: Kphi element mismatch at (m,mp)=', mm, mmp
+            print *, '  stored =', Kphi(im, imp), ' ref =', ref_phi
+            print *, '  |diff| =', abs(Kphi(im, imp) - ref_phi), ' tol =', tol
+            error stop
+        end if
+
+        tol = 1.0e-12_dp * (1.0_dp + abs(ref_B))
+        if (abs(KB(im, imp) - ref_B) >= tol) then
+            print *, 'FAIL: KB element mismatch at (m,mp)=', mm, mmp
+            print *, '  stored =', KB(im, imp), ' ref =', ref_B
+            print *, '  |diff| =', abs(KB(im, imp) - ref_B), ' tol =', tol
+            error stop
+        end if
+    end subroutine check_element
+
+    !> True if the two elements at (m1,mp1) and (m2,mp2) differ by more than a
+    !> tiny tolerance. Used to show K is not constant along a diagonal.
+    logical function not_equal_pair(K, M, m1, mp1, m2, mp2) result(differ)
+        complex(dp), intent(in) :: K(:,:)
+        integer, intent(in) :: M, m1, mp1, m2, mp2
+        real(dp) :: d
+        d = abs(K(m1 + M + 1, mp1 + M + 1) - K(m2 + M + 1, mp2 + M + 1))
+        differ = d > 1.0e3_dp * tiny(1.0_dp)
+    end function not_equal_pair
+
+    real(dp) function rho_L_near(r) result(val)
+        !> Electron Larmor radius of the global plasma at the grid point nearest
+        !> radius r (the plasma is still on the global grid here).
+        use species_m, only: plasma
+        real(dp), intent(in) :: r
+        integer :: jn
+        jn = minloc(abs(plasma%r_grid - r), dim=1)
+        val = plasma%spec(0)%rho_L(jn)
+    end function rho_L_near
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm. q rises monotonically through 3
+        ! inside the solver domain [r_min, r_plas] = [10, 50] so that the
+        ! (m,n) = (-6, 2) mode (|m/n| = 3) has a resonance there.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            ! q: 1.5 at r=2 to 4.0 at r=60  ->  crosses 3 near r=36 cm.
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration on a coarse grid.
+        ! m_mode = -6, n_mode = 2 makes q resonant at q = 3.
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_assembly_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_periodic_assembly

--- a/KIM/tests/test_periodic_background.f90
+++ b/KIM/tests/test_periodic_background.f90
@@ -20,6 +20,7 @@ program test_periodic_background
     implicit none
 
     call test_periodic_sampling()
+    call test_cache_invalidation()
 
     print *, 'All tests PASSED'
     stop 0
@@ -138,6 +139,74 @@ contains
         end do
 
         print *, 'PASS: periodic sampling is as-is faithful, L-periodic, finite'
+    end subroutine
+
+    !> Prove the true-background cache AUTO-INVALIDATES when the profiles change.
+    !> Two DIFFERENT cases in one process: init with profile set A (kim_aperfuns
+    !> captures the cache at generation G), then swap in a DIFFERENT set B via
+    !> set_profiles_from_arrays + re-init (which bumps
+    !> species_m::profiles_generation to G+1 and rebuilds the true geometry),
+    !> sample again, and assert the periodized as-is value now reflects B -- NOT
+    !> the stale A snapshot. Without auto-invalidation kim_aperfuns would keep
+    !> returning A's density. Mirrors the production QL-Balance / time-step path
+    !> (set_profiles_from_arrays is always followed by an equilibrium re-init).
+    subroutine test_cache_invalidation()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays, profiles_generation
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101, nfuns = 5
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp) :: x_core, funs_A(nfuns), funs_B(nfuns), n_expected_B
+        class(kim_t), allocatable :: kim_instance
+        integer :: gen_A, gen_B
+
+        call write_test_namelist('./KIM_config_periodic_bg_test.nml')
+        nml_config_path = './KIM_config_periodic_bg_test.nml'
+        profiles_in_memory = .true.
+
+        ! Case A: analytic profiles, init the equilibrium, sample n_e at a core
+        ! radius. The direct kim_aperfuns callback captures the cache at gen A.
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+        gen_A = profiles_generation
+
+        x_core = 30.0_dp
+        call kim_aperfuns(nfuns, x_core, funs_A)
+
+        ! Case B: DOUBLE the density everywhere (a clearly distinct case), swap it
+        ! in and re-init the equilibrium -- this bumps profiles_generation.
+        n_prof = 2.0_dp * n_prof
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        call kim_instance%init()
+        gen_B = profiles_generation
+
+        if (gen_B <= gen_A) then
+            print *, 'FAIL: profiles_generation did not advance:', gen_A, gen_B
+            error stop
+        end if
+
+        call kim_aperfuns(nfuns, x_core, funs_B)
+
+        ! B's electron density at x_core must be ~2x A's (auto-invalidated cache).
+        n_expected_B = 2.0_dp * funs_A(1)
+        if (abs(funs_B(1) - n_expected_B) > 1.0e-6_dp * abs(n_expected_B)) then
+            print *, 'FAIL: cache did NOT invalidate on profile change.'
+            print *, '  n_e(A)          = ', funs_A(1)
+            print *, '  n_e(B) returned = ', funs_B(1)
+            print *, '  n_e(B) expected = ', n_expected_B, ' (2x A)'
+            error stop
+        end if
+
+        print *, 'PASS: true-background cache auto-invalidates on profile change'
     end subroutine
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_periodic_background.f90
+++ b/KIM/tests/test_periodic_background.f90
@@ -1,0 +1,241 @@
+program test_periodic_background
+    ! Validates the KIM aperfuns callback and the periodic primitive sampler
+    ! (periodic_background_m) against the vendored make_periodic utility.
+    !
+    ! Setup mirrors the in-memory-profile path of test_flr2_fourier_kernel.f90:
+    !   write_test_namelist -> nml_config_path -> profiles_in_memory ->
+    !   kim_init -> set_profiles_from_arrays -> electrostatic %init().
+    ! After init the global `plasma` holds the TRUE primitive profiles
+    ! (n_e, Te, Ti, q, Er) on plasma%r_grid, which kim_aperfuns interpolates.
+    !
+    ! Three properties are checked on a mid-domain period:
+    !   (a) as-is fidelity: inside the as-is core the periodized value equals
+    !       the direct interpolated (true) value to machine precision,
+    !   (b) periodicity: sample(x) == sample(x + L),
+    !   (c) finiteness + physicality: all components finite; n_e, Te, Ti > 0.
+
+    use KIM_kinds_m, only: dp
+    use periodic_background_m, only: kim_aperfuns, sample_periodic_primitives
+
+    implicit none
+
+    call test_periodic_sampling()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_periodic_sampling()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+
+        integer, parameter :: npts = 101
+        integer, parameter :: nfuns = 5
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        real(dp) :: x_mid, dx_asis, dx_tr, period_len
+        real(dp) :: x, x_arr(5)
+        real(dp) :: funs_per(nfuns), funs_true(nfuns), funs_shift(nfuns)
+        real(dp) :: r_min_grid, r_max_grid, tol
+        integer :: i, k, gs
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_bg_test.nml')
+        nml_config_path = './KIM_config_periodic_bg_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        gs = plasma%grid_size
+        r_min_grid = plasma%r_grid(1)
+        r_max_grid = plasma%r_grid(gs)
+
+        ! Mid-domain period centre; small half-period so [x_mid +- L/2] stays
+        ! well inside the profile domain. L = 2*(dx_asis + dx_tr) = 18 cm.
+        x_mid = 0.5_dp*(r_min_grid + r_max_grid)
+        dx_asis = 3.0_dp
+        dx_tr = 6.0_dp
+        period_len = 2.0_dp*(dx_asis + dx_tr)
+
+        tol = 1.0e-10_dp
+
+        ! (a) As-is fidelity: inside |x - x_mid| <= dx_asis the periodized value
+        ! must equal the direct interpolated true value to machine precision.
+        x_arr = [x_mid - dx_asis, x_mid - 0.5_dp*dx_asis, x_mid, &
+                 x_mid + 0.5_dp*dx_asis, x_mid + dx_asis]
+        do k = 1, size(x_arr)
+            x = x_arr(k)
+            call sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
+            call kim_aperfuns(nfuns, x, funs_true)
+            do i = 1, nfuns
+                if (abs(funs_per(i) - funs_true(i)) >= tol) then
+                    print *, 'FAIL: as-is fidelity broken at x=', x, ' comp=', i
+                    print *, '  periodized = ', funs_per(i)
+                    print *, '  true       = ', funs_true(i)
+                    print *, '  |diff|     = ', abs(funs_per(i) - funs_true(i))
+                    error stop
+                end if
+            end do
+            ! Physicality at as-is points: n_e, Te, Ti strictly positive.
+            if (.not. (funs_per(1) > 0.0_dp)) then
+                print *, 'FAIL: n_e not positive at x=', x, ' got ', funs_per(1)
+                error stop
+            end if
+            if (.not. (funs_per(2) > 0.0_dp)) then
+                print *, 'FAIL: Te not positive at x=', x, ' got ', funs_per(2)
+                error stop
+            end if
+            if (.not. (funs_per(3) > 0.0_dp)) then
+                print *, 'FAIL: Ti not positive at x=', x, ' got ', funs_per(3)
+                error stop
+            end if
+        end do
+
+        ! (b) Periodicity: sample(x) == sample(x + L) across the transition
+        ! bands and the as-is core.
+        x_arr = [x_mid - dx_asis - dx_tr, x_mid - dx_asis, x_mid, &
+                 x_mid + dx_asis, x_mid + dx_asis + dx_tr]
+        do k = 1, size(x_arr)
+            x = x_arr(k)
+            call sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
+            call sample_periodic_primitives(x_mid, dx_asis, dx_tr, &
+                                            x + period_len, funs_shift)
+            do i = 1, nfuns
+                if (abs(funs_per(i) - funs_shift(i)) >= tol) then
+                    print *, 'FAIL: periodicity broken at x=', x, ' comp=', i
+                    print *, '  f(x)   = ', funs_per(i)
+                    print *, '  f(x+L) = ', funs_shift(i)
+                    print *, '  |diff| = ', abs(funs_per(i) - funs_shift(i))
+                    error stop
+                end if
+            end do
+        end do
+
+        ! (c) Finiteness across the whole period (including transition bands).
+        do k = 0, 20
+            x = x_mid - 0.5_dp*period_len + period_len*real(k, dp)/20.0_dp
+            call sample_periodic_primitives(x_mid, dx_asis, dx_tr, x, funs_per)
+            do i = 1, nfuns
+                if (.not. ieee_is_finite(funs_per(i))) then
+                    print *, 'FAIL: non-finite component at x=', x, ' comp=', i
+                    error stop
+                end if
+            end do
+        end do
+
+        print *, 'PASS: periodic sampling is as-is faithful, L-periodic, finite'
+    end subroutine
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm with q in [1.5, 2.5];
+        ! solver domain [r_min, r_plas] = [10, 50].
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration on a coarse grid,
+        ! written in the exact group order kim_read_config reads them.
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_bg_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -2'
+        write(iunit, '(A)') ' n_mode = 1'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine
+
+end program

--- a/KIM/tests/test_periodic_background_build.f90
+++ b/KIM/tests/test_periodic_background_build.f90
@@ -15,13 +15,15 @@ program test_periodic_background_build
     ! Assertions on the window:
     !   (1) rho_L, lambda_D finite and > 0 everywhere,
     !   (2) I00(j,0) finite everywhere (susceptibility recomputed),
-    !   (3) periodicity: rho_L at index j equals rho_L one period L away,
+    !   (3) as-is fidelity: inside the as-is core the BUILT derived quantities
+    !       (rho_L, lambda_D) reproduce the TRUE global derived plasma there
+    !       (the periodized primitives equal the true primitives in the core),
     !   (4) resonance: parallel wavenumber kp ~ 0 at the window point nearest rm
     !       (confirms q = 3 there and a correct kp recompute),
     !   (5) all finite (no NaN/Inf).
 
     use KIM_kinds_m, only: dp
-    use periodic_background_m, only: build_periodic_plasma, sample_periodic_primitives
+    use periodic_background_m, only: build_periodic_plasma
 
     implicit none
 
@@ -42,16 +44,16 @@ contains
         use grid_m, only: rg_grid
 
         integer, parameter :: npts = 201
-        integer, parameter :: nfuns = 5
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        real(dp) :: rm, dx_asis, dx_tr, dx_asis_glob, dx_tr_glob, L, rho_L_rm
+        real(dp) :: rm, dx_asis, dx_tr, rho_L_rm
+        real(dp) :: r_asis, rho_L_true, lambda_D_true, rho_L_built, lambda_D_built
         integer :: n_rg
         integer :: j, gs, j_rm
-        real(dp) :: kp_scale, tol_kp, rel, tol_per
+        real(dp) :: kp_scale, tol_kp, tol_asis, rel
         logical :: any_bad
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
@@ -91,11 +93,20 @@ contains
             print *, 'NOTE: rho_L(rm) tiny; using fixed dx_asis/dx_tr [cm]'
         end if
         n_rg = 96
-        L = 2.0_dp*(dx_asis + dx_tr)
 
-        ! Keep the periodization half-widths for the periodicity check below.
-        dx_asis_glob = dx_asis
-        dx_tr_glob   = dx_tr
+        ! Capture the TRUE (non-periodic) resonant-layer physics BEFORE the
+        ! build. At this point the global `plasma` is the true derived plasma on
+        ! the global rg_grid. Pick r_asis inside the as-is core (|r - rm| <=
+        ! dx_asis), where the periodized primitives equal the true primitives so
+        ! the derived quantities of the periodic build MUST reproduce the true
+        ! global build. Interpolate the true rho_L / lambda_D at r_asis with the
+        ! same 4-point Lagrange pattern KIM uses (binsrc + plag_coeff on
+        ! plasma%r_grid). These are just scalars, safe across the mutation.
+        r_asis = rm + 0.5_dp*dx_asis
+        rho_L_true    = interp_lagrange4(plasma%r_grid, plasma%spec(0)%rho_L, &
+                                         plasma%grid_size, r_asis)
+        lambda_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(0)%lambda_D, &
+                                         plasma%grid_size, r_asis)
 
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
 
@@ -137,51 +148,38 @@ contains
         end do
         print *, 'PASS: rho_L, lambda_D finite/positive; I00 finite everywhere'
 
-        ! (3) Periodicity of a DERIVED quantity, lambda_D.
-        ! The window [rm-L/2, rm+L/2] is EXACTLY one period wide (make_periodic
-        ! uses period = 2*(dx_asis+dx_tr) = L). On an equidistant grid of n_rg
-        ! points over one period, h = L/n_rg and NO two interior grid points are
-        ! exactly L apart -- so on-grid index shifts cannot express a period.
-        ! We instead verify periodicity of lambda_D directly: lambda_D is a pure
-        ! function of the primitives (n, T) only (lambda_D = sqrt(T ev /
-        ! (4 pi n (Z e)^2))), and those primitives are exactly L-periodic. Hence
-        ! lambda_D(r) must equal lambda_D(r+L).
-        !
-        ! We compare a built grid point in the as-is core (index j_rm, radius
-        ! ~rm) against the same physical location reached one period to the
-        ! right, r_ref + L, via re-sampling. r_ref is kept clear of the period
-        ! seam (r_lo / r_hi) so the make_periodic modulo is well-conditioned;
-        ! sampling AT the seam is numerically ill-posed (modulo(L, L) rounds to
-        ! either 0 or L) and is not a property of the built plasma. We
-        ! reconstruct lambda_D(r_ref+L) from the built lambda_D(j_rm) via the
-        ! primitive ratio (no hardcoded constants):
-        !   lambda_D(r+L) = lambda_D(r) * sqrt( (T(r+L)/T(r)) * (n(r)/n(r+L)) ).
-        ! If lambda_D is periodic the correction factor is 1 to round-off.
-        block
-            integer :: j_ref
-            real(dp) :: funs_shift(nfuns), lam_ref, lam_recon, tshift, nshift, r_ref
-            ! Reference point: nearest grid node to rm (interior, in the as-is
-            ! core, far from the period seam).
-            j_ref = minloc(abs(rg_grid%xb - rm), dim=1)
-            r_ref = rg_grid%xb(j_ref)
-            call sample_periodic_primitives(rm, dx_asis_glob, dx_tr_glob, &
-                                            r_ref + L, funs_shift)
-            nshift = funs_shift(1)
-            tshift = funs_shift(2)
-            lam_ref   = plasma%spec(0)%lambda_D(j_ref)
-            lam_recon = lam_ref * sqrt((tshift / plasma%spec(0)%T(j_ref)) * &
-                                       (plasma%spec(0)%n(j_ref) / nshift))
-            tol_per = 1.0e-6_dp
-            rel = abs(lam_recon - lam_ref) / max(abs(lam_ref), tiny(1.0_dp))
-            if (rel >= tol_per) then
-                print *, 'FAIL: lambda_D not L-periodic'
-                print *, '  lambda_D(r_ref)     = ', lam_ref, ' at r=', r_ref
-                print *, '  lambda_D(r_ref + L) = ', lam_recon, ' at r=', r_ref + L
-                print *, '  rel diff = ', rel
-                error stop
-            end if
-            print *, 'PASS: lambda_D is L-periodic (rel diff = ', rel, ')'
-        end block
+        ! (3) As-is fidelity: the periodic build must reproduce the TRUE
+        ! resonant-layer physics inside the as-is core. In |r - rm| <= dx_asis
+        ! the periodized primitives equal the true primitives, so the DERIVED
+        ! quantities recomputed by build_periodic_plasma must match the true
+        ! global derived plasma there. We interpolate the BUILT rho_L / lambda_D
+        ! at the SAME r_asis (now on the window grid) and compare to the true
+        ! values captured before the build. The modest 1e-3 relative tolerance
+        ! covers only the resolution difference between the global grid and the
+        ! finer window grid -- it cannot pass trivially: a broken recompute
+        ! (wrong B0/omega_c, wrong n/T redirection) would miss by orders of
+        ! magnitude. This is the load-bearing correctness signal.
+        rho_L_built    = interp_lagrange4(rg_grid%xb, plasma%spec(0)%rho_L, &
+                                          gs, r_asis)
+        lambda_D_built = interp_lagrange4(rg_grid%xb, plasma%spec(0)%lambda_D, &
+                                          gs, r_asis)
+        tol_asis = 1.0e-3_dp
+
+        rel = abs(rho_L_built - rho_L_true) / max(abs(rho_L_true), tiny(1.0_dp))
+        print *, 'as-is r_asis =', r_asis
+        print *, '  rho_L  true =', rho_L_true, ' built =', rho_L_built, ' rel =', rel
+        if (rel >= tol_asis) then
+            print *, 'FAIL: built rho_L does not reproduce true value in as-is core'
+            error stop
+        end if
+
+        rel = abs(lambda_D_built - lambda_D_true) / max(abs(lambda_D_true), tiny(1.0_dp))
+        print *, '  lambda_D true =', lambda_D_true, ' built =', lambda_D_built, ' rel =', rel
+        if (rel >= tol_asis) then
+            print *, 'FAIL: built lambda_D does not reproduce true value in as-is core'
+            error stop
+        end if
+        print *, 'PASS: periodic build reproduces true rho_L, lambda_D in as-is core'
 
         ! (4) Resonance: kp ~ 0 at the window point nearest rm (q = 3 there).
         j_rm = minloc(abs(rg_grid%xb - rm), dim=1)
@@ -220,6 +218,27 @@ contains
         jn = minloc(abs(plasma%r_grid - r), dim=1)
         val = plasma%spec(0)%rho_L(jn)
     end function rho_L_near
+
+    real(dp) function interp_lagrange4(grid, vals, ngrid, x) result(fx)
+        !> 4-point Lagrange interpolation of vals(:) on grid(:) at radius x.
+        !> Mirrors the binsrc + plag_coeff stencil used throughout KIM
+        !> (kim_aperfuns, interpolate_plasma_backs, calculate_equil).
+        integer, intent(in) :: ngrid
+        real(dp), intent(in) :: grid(ngrid), vals(ngrid), x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: ir, ibeg, iend
+
+        call binsrc(grid, 1, ngrid, x, ir)
+        ibeg = max(1, ir - nlagr/2)
+        iend = ibeg + nlagr - 1
+        if (iend > ngrid) then
+            iend = ngrid
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, grid(ibeg:iend), coef)
+        fx = sum(coef(0, :) * vals(ibeg:iend))
+    end function interp_lagrange4
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)

--- a/KIM/tests/test_periodic_background_build.f90
+++ b/KIM/tests/test_periodic_background_build.f90
@@ -1,0 +1,324 @@
+program test_periodic_background_build
+    ! Validates build_periodic_plasma (Phase-2.3, THE CRUX): it must produce a
+    ! fully-populated PERIODIC `plasma` on an equidistant window grid
+    !   [rm - L/2, rm + L/2],  L = 2*(dx_asis + dx_tr),  n_rg boundary points,
+    ! whose DERIVED quantities (rho_L, lambda_D, and the susceptibility
+    ! functions I00..I21) are recomputed FROM the periodized primitives
+    ! (n, Te, Ti, q, Er) and are therefore periodic.
+    !
+    ! Setup mirrors the in-memory-profile path of test_periodic_background.f90:
+    !   write_test_namelist -> nml_config_path -> profiles_in_memory ->
+    !   kim_init -> set_profiles_from_arrays -> electrostatic %init().
+    ! The (m,n) = (-6, 2) mode makes q resonant at q = |m/n| = 3, so the
+    ! q-profile is built to cross 3 inside the solver domain [r_min, r_plas].
+    !
+    ! Assertions on the window:
+    !   (1) rho_L, lambda_D finite and > 0 everywhere,
+    !   (2) I00(j,0) finite everywhere (susceptibility recomputed),
+    !   (3) periodicity: rho_L at index j equals rho_L one period L away,
+    !   (4) resonance: parallel wavenumber kp ~ 0 at the window point nearest rm
+    !       (confirms q = 3 there and a correct kp recompute),
+    !   (5) all finite (no NaN/Inf).
+
+    use KIM_kinds_m, only: dp
+    use periodic_background_m, only: build_periodic_plasma, sample_periodic_primitives
+
+    implicit none
+
+    call test_build_periodic()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_build_periodic()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use grid_m, only: rg_grid
+
+        integer, parameter :: npts = 201
+        integer, parameter :: nfuns = 5
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        real(dp) :: rm, dx_asis, dx_tr, dx_asis_glob, dx_tr_glob, L, rho_L_rm
+        integer :: n_rg
+        integer :: j, gs, j_rm
+        real(dp) :: kp_scale, tol_kp, rel, tol_per
+        logical :: any_bad
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_build_test.nml')
+        nml_config_path = './KIM_config_periodic_build_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Locate the resonance (q = |m/n| = 3) on the global plasma.
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+        print *, 'resonant radius rm = ', rm
+
+        ! Representative Larmor radius near rm (electrons) on the global plasma.
+        rho_L_rm = rho_L_near(rm)
+        print *, 'rho_L(rm) [electron] = ', rho_L_rm
+
+        ! Window half-widths (task: 5 and 10 Larmor radii). Guard against a
+        ! degenerate tiny window if rho_L is unexpectedly small.
+        dx_asis =  5.0_dp * rho_L_rm
+        dx_tr   = 10.0_dp * rho_L_rm
+        if (dx_asis < 1.0e-3_dp) then
+            dx_asis = 1.0_dp
+            dx_tr   = 2.0_dp
+            print *, 'NOTE: rho_L(rm) tiny; using fixed dx_asis/dx_tr [cm]'
+        end if
+        n_rg = 96
+        L = 2.0_dp*(dx_asis + dx_tr)
+
+        ! Keep the periodization half-widths for the periodicity check below.
+        dx_asis_glob = dx_asis
+        dx_tr_glob   = dx_tr
+
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+
+        gs = plasma%grid_size
+        if (gs /= n_rg) then
+            print *, 'FAIL: grid_size /= n_rg after build; got ', gs
+            error stop
+        end if
+        if (rg_grid%npts_b /= n_rg) then
+            print *, 'FAIL: rg_grid%npts_b /= n_rg; got ', rg_grid%npts_b
+            error stop
+        end if
+
+        ! (1) rho_L, lambda_D finite and strictly positive everywhere.
+        any_bad = .false.
+        do j = 1, gs
+            if (.not. ieee_is_finite(plasma%spec(0)%rho_L(j)) .or. &
+                .not. (plasma%spec(0)%rho_L(j) > 0.0_dp)) then
+                print *, 'FAIL: rho_L not finite/positive at j=', j, &
+                         ' val=', plasma%spec(0)%rho_L(j)
+                any_bad = .true.
+            end if
+            if (.not. ieee_is_finite(plasma%spec(0)%lambda_D(j)) .or. &
+                .not. (plasma%spec(0)%lambda_D(j) > 0.0_dp)) then
+                print *, 'FAIL: lambda_D not finite/positive at j=', j, &
+                         ' val=', plasma%spec(0)%lambda_D(j)
+                any_bad = .true.
+            end if
+        end do
+        if (any_bad) error stop
+
+        ! (2) Susceptibility I00(:,0) recomputed and finite everywhere.
+        do j = 1, gs
+            if (.not. ieee_is_finite(real(plasma%spec(0)%I00(j, 0), dp)) .or. &
+                .not. ieee_is_finite(aimag(plasma%spec(0)%I00(j, 0)))) then
+                print *, 'FAIL: I00 non-finite at j=', j, ' val=', plasma%spec(0)%I00(j, 0)
+                error stop
+            end if
+        end do
+        print *, 'PASS: rho_L, lambda_D finite/positive; I00 finite everywhere'
+
+        ! (3) Periodicity of a DERIVED quantity, lambda_D.
+        ! The window [rm-L/2, rm+L/2] is EXACTLY one period wide (make_periodic
+        ! uses period = 2*(dx_asis+dx_tr) = L). On an equidistant grid of n_rg
+        ! points over one period, h = L/n_rg and NO two interior grid points are
+        ! exactly L apart -- so on-grid index shifts cannot express a period.
+        ! We instead verify periodicity of lambda_D directly: lambda_D is a pure
+        ! function of the primitives (n, T) only (lambda_D = sqrt(T ev /
+        ! (4 pi n (Z e)^2))), and those primitives are exactly L-periodic. Hence
+        ! lambda_D(r) must equal lambda_D(r+L).
+        !
+        ! We compare a built grid point in the as-is core (index j_rm, radius
+        ! ~rm) against the same physical location reached one period to the
+        ! right, r_ref + L, via re-sampling. r_ref is kept clear of the period
+        ! seam (r_lo / r_hi) so the make_periodic modulo is well-conditioned;
+        ! sampling AT the seam is numerically ill-posed (modulo(L, L) rounds to
+        ! either 0 or L) and is not a property of the built plasma. We
+        ! reconstruct lambda_D(r_ref+L) from the built lambda_D(j_rm) via the
+        ! primitive ratio (no hardcoded constants):
+        !   lambda_D(r+L) = lambda_D(r) * sqrt( (T(r+L)/T(r)) * (n(r)/n(r+L)) ).
+        ! If lambda_D is periodic the correction factor is 1 to round-off.
+        block
+            integer :: j_ref
+            real(dp) :: funs_shift(nfuns), lam_ref, lam_recon, tshift, nshift, r_ref
+            ! Reference point: nearest grid node to rm (interior, in the as-is
+            ! core, far from the period seam).
+            j_ref = minloc(abs(rg_grid%xb - rm), dim=1)
+            r_ref = rg_grid%xb(j_ref)
+            call sample_periodic_primitives(rm, dx_asis_glob, dx_tr_glob, &
+                                            r_ref + L, funs_shift)
+            nshift = funs_shift(1)
+            tshift = funs_shift(2)
+            lam_ref   = plasma%spec(0)%lambda_D(j_ref)
+            lam_recon = lam_ref * sqrt((tshift / plasma%spec(0)%T(j_ref)) * &
+                                       (plasma%spec(0)%n(j_ref) / nshift))
+            tol_per = 1.0e-6_dp
+            rel = abs(lam_recon - lam_ref) / max(abs(lam_ref), tiny(1.0_dp))
+            if (rel >= tol_per) then
+                print *, 'FAIL: lambda_D not L-periodic'
+                print *, '  lambda_D(r_ref)     = ', lam_ref, ' at r=', r_ref
+                print *, '  lambda_D(r_ref + L) = ', lam_recon, ' at r=', r_ref + L
+                print *, '  rel diff = ', rel
+                error stop
+            end if
+            print *, 'PASS: lambda_D is L-periodic (rel diff = ', rel, ')'
+        end block
+
+        ! (4) Resonance: kp ~ 0 at the window point nearest rm (q = 3 there).
+        j_rm = minloc(abs(rg_grid%xb - rm), dim=1)
+        ! Scale for "small": kp away from resonance is O(n_mode/R0) ~ O(1e-2).
+        kp_scale = maxval(abs(plasma%kp))
+        tol_kp = 1.0e-3_dp * max(kp_scale, tiny(1.0_dp))
+        print *, 'kp scale (max|kp|) = ', kp_scale
+        print *, 'kp at j_rm=', j_rm, ' (r=', rg_grid%xb(j_rm), ') = ', plasma%kp(j_rm)
+        if (abs(plasma%kp(j_rm)) >= tol_kp) then
+            print *, 'FAIL: kp not ~0 at rm'
+            print *, '  |kp(j_rm)| = ', abs(plasma%kp(j_rm)), ' tol = ', tol_kp
+            error stop
+        end if
+        print *, 'PASS: kp ~ 0 at window point nearest rm (resonance q=3 confirmed)'
+
+        ! (5) Global finiteness sweep of the load-bearing derived arrays.
+        do j = 1, gs
+            if (.not. ieee_is_finite(plasma%kp(j)) .or. &
+                .not. ieee_is_finite(plasma%B0(j)) .or. &
+                .not. ieee_is_finite(plasma%om_E(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(0)%vT(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(0)%nu(j))) then
+                print *, 'FAIL: non-finite derived quantity at j=', j
+                error stop
+            end if
+        end do
+        print *, 'PASS: all derived quantities finite across the window'
+    end subroutine test_build_periodic
+
+    real(dp) function rho_L_near(r) result(val)
+        !> Return the electron Larmor radius of the global plasma at the grid
+        !> point nearest radius r (the plasma is still on the global grid here).
+        use species_m, only: plasma
+        real(dp), intent(in) :: r
+        integer :: jn
+        jn = minloc(abs(plasma%r_grid - r), dim=1)
+        val = plasma%spec(0)%rho_L(jn)
+    end function rho_L_near
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm. q rises monotonically through 3
+        ! inside the solver domain [r_min, r_plas] = [10, 50] so that the
+        ! (m,n) = (-6, 2) mode (|m/n| = 3) has a resonance there.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            ! q: 1.5 at r=2 to 4.0 at r=60  ->  crosses 3 near r=36 cm.
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration on a coarse grid.
+        ! m_mode = -6, n_mode = 2 makes q resonant at q = 3.
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_build_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_periodic_background_build

--- a/KIM/tests/test_periodic_background_build.f90
+++ b/KIM/tests/test_periodic_background_build.f90
@@ -12,7 +12,8 @@ program test_periodic_background_build
     ! The (m,n) = (-6, 2) mode makes q resonant at q = |m/n| = 3, so the
     ! q-profile is built to cross 3 inside the solver domain [r_min, r_plas].
     !
-    ! Assertions on the window:
+    ! The fixture contains D plus a Z=6 impurity with distinct density and
+    ! temperature profiles. Assertions on the window:
     !   (1) rho_L, lambda_D finite and > 0 everywhere,
     !   (2) I00(j,0) finite everywhere (susceptibility recomputed),
     !   (3) as-is fidelity: inside the as-is core the BUILT derived quantities
@@ -20,10 +21,13 @@ program test_periodic_background_build
     !       (the periodized primitives equal the true primitives in the core),
     !   (4) resonance: parallel wavenumber kp ~ 0 at the window point nearest rm
     !       (confirms q = 3 there and a correct kp recompute),
-    !   (5) all finite (no NaN/Inf).
+    !   (5) each ion profile survives independently and quasineutrality holds,
+    !   (6) all finite (no NaN/Inf).
 
     use KIM_kinds_m, only: dp
-    use periodic_background_m, only: build_periodic_plasma
+    use periodic_background_m, only: build_periodic_plasma, &
+                                     sample_periodic_species_profiles, &
+                                     PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE
 
     implicit none
 
@@ -51,8 +55,11 @@ contains
 
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm
         real(dp) :: r_asis, rho_L_true, lambda_D_true, rho_L_built, lambda_D_built
+        real(dp) :: n_D_true, n_C_true, T_D_true, T_C_true
+        real(dp) :: n_D_built, n_C_built, T_D_built, T_C_built
+        real(dp) :: qn_residual, density_scale
         integer :: n_rg
-        integer :: j, gs, j_rm
+        integer :: j, gs, j_rm, sp
         real(dp) :: kp_scale, tol_kp, tol_asis, rel
         logical :: any_bad
 
@@ -66,6 +73,7 @@ contains
         call kim_init()
         call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
                                       q_prof, Er_prof, npts)
+        call set_distinct_two_ion_profiles()
 
         call from_kim_factory_get_kim('electrostatic', kim_instance)
         call kim_instance%init()
@@ -78,6 +86,8 @@ contains
         end if
         rm = r_res
         print *, 'resonant radius rm = ', rm
+
+        call test_multispecies_cache_refresh(rm)
 
         ! Representative Larmor radius near rm (electrons) on the global plasma.
         rho_L_rm = rho_L_near(rm)
@@ -107,6 +117,14 @@ contains
                                          plasma%grid_size, r_asis)
         lambda_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(0)%lambda_D, &
                                          plasma%grid_size, r_asis)
+        n_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(1)%n, &
+                                    plasma%grid_size, r_asis)
+        n_C_true = interp_lagrange4(plasma%r_grid, plasma%spec(2)%n, &
+                                    plasma%grid_size, r_asis)
+        T_D_true = interp_lagrange4(plasma%r_grid, plasma%spec(1)%T, &
+                                    plasma%grid_size, r_asis)
+        T_C_true = interp_lagrange4(plasma%r_grid, plasma%spec(2)%T, &
+                                    plasma%grid_size, r_asis)
 
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
 
@@ -181,6 +199,40 @@ contains
         end if
         print *, 'PASS: periodic build reproduces true rho_L, lambda_D in as-is core'
 
+        ! (5) Preserve every configured species independently. Species 1 is the
+        ! dependent main ion, while the impurity density is preserved and the
+        ! main-ion density enforces n_e = Z_D*n_D + Z_C*n_C. The fixture is
+        ! exactly quasineutral before periodization, so all four profiles must
+        ! reproduce the true as-is values to interpolation accuracy.
+        n_D_built = interp_lagrange4(rg_grid%xb, plasma%spec(1)%n, gs, r_asis)
+        n_C_built = interp_lagrange4(rg_grid%xb, plasma%spec(2)%n, gs, r_asis)
+        T_D_built = interp_lagrange4(rg_grid%xb, plasma%spec(1)%T, gs, r_asis)
+        T_C_built = interp_lagrange4(rg_grid%xb, plasma%spec(2)%T, gs, r_asis)
+
+        call assert_relative_close('D density', n_D_built, n_D_true, tol_asis)
+        call assert_relative_close('C density', n_C_built, n_C_true, tol_asis)
+        call assert_relative_close('D temperature', T_D_built, T_D_true, tol_asis)
+        call assert_relative_close('C temperature', T_C_built, T_C_true, tol_asis)
+
+        density_scale = maxval(plasma%spec(0)%n)
+        qn_residual = maxval(abs(plasma%spec(1)%n + &
+                                 6.0_dp*plasma%spec(2)%n - plasma%spec(0)%n))
+        if (qn_residual > 50.0_dp*epsilon(1.0_dp)*density_scale) then
+            print *, 'FAIL: periodic multispecies background is not quasineutral'
+            print *, '  max residual = ', qn_residual, ' density scale = ', density_scale
+            error stop
+        end if
+        do j = 1, gs
+            if (any([plasma%spec(0)%n(j), plasma%spec(1)%n(j), &
+                     plasma%spec(2)%n(j)] <= 0.0_dp) .or. &
+                any([plasma%spec(0)%T(j), plasma%spec(1)%T(j), &
+                     plasma%spec(2)%T(j)] <= 0.0_dp)) then
+                print *, 'FAIL: non-positive multispecies primitive at j=', j
+                error stop
+            end if
+        end do
+        print *, 'PASS: distinct two-ion profiles preserved and quasineutral'
+
         ! (4) Resonance: kp ~ 0 at the window point nearest rm (q = 3 there).
         j_rm = minloc(abs(rg_grid%xb - rm), dim=1)
         ! Scale for "small": kp away from resonance is O(n_mode/R0) ~ O(1e-2).
@@ -195,7 +247,7 @@ contains
         end if
         print *, 'PASS: kp ~ 0 at window point nearest rm (resonance q=3 confirmed)'
 
-        ! (5) Global finiteness sweep of the load-bearing derived arrays.
+        ! (6) Global finiteness sweep of the load-bearing derived arrays.
         do j = 1, gs
             if (.not. ieee_is_finite(plasma%kp(j)) .or. &
                 .not. ieee_is_finite(plasma%B0(j)) .or. &
@@ -205,9 +257,177 @@ contains
                 print *, 'FAIL: non-finite derived quantity at j=', j
                 error stop
             end if
+            if (.not. ieee_is_finite(plasma%spec(1)%vT(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(1)%nu(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(1)%rho_L(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%vT(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%nu(j)) .or. &
+                .not. ieee_is_finite(plasma%spec(2)%rho_L(j))) then
+                print *, 'FAIL: non-finite ion-derived quantity at j=', j
+                error stop
+            end if
+            do sp = 0, 2
+                if (.not. ieee_is_finite(plasma%spec(sp)%omega_c(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%lambda_D(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%A1(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%A2(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%x1(j)) .or. &
+                    .not. ieee_is_finite(plasma%spec(sp)%x2(j, 0)) .or. &
+                    .not. ieee_is_finite(real(plasma%spec(sp)%I00(j, 0), dp)) .or. &
+                    .not. ieee_is_finite(aimag(plasma%spec(sp)%I00(j, 0)))) then
+                    print *, 'FAIL: incomplete derived pipeline at j=', j, ' species=', sp
+                    error stop
+                end if
+            end do
         end do
         print *, 'PASS: all derived quantities finite across the window'
+
+        call test_multispecies_periodicity(rm, dx_asis, dx_tr)
+        call test_negative_dependent_density_rejected(rm, dx_asis, dx_tr, n_rg)
     end subroutine test_build_periodic
+
+    subroutine test_multispecies_periodicity(rm, dx_asis, dx_tr)
+        real(dp), intent(in) :: rm, dx_asis, dx_tr
+        real(dp) :: n_left(0:2), T_left(0:2), n_shift(0:2), T_shift(0:2)
+        real(dp) :: q_left, Er_left, q_shift, Er_shift
+        real(dp) :: x_values(5), x, period_length
+        integer :: k, sp
+
+        period_length = 2.0_dp*(dx_asis + dx_tr)
+        x_values = [rm - dx_asis - dx_tr, rm - dx_asis, rm, &
+                    rm + dx_asis, rm + dx_asis + dx_tr]
+        do k = 1, size(x_values)
+            x = x_values(k)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, x, &
+                                                  n_left, T_left, q_left, Er_left)
+            call sample_periodic_species_profiles(rm, dx_asis, dx_tr, &
+                x + period_length, n_shift, T_shift, q_shift, Er_shift)
+            do sp = 0, 2
+                call assert_relative_close('periodic species density', &
+                                           n_shift(sp), n_left(sp), 1.0e-10_dp)
+                call assert_relative_close('periodic species temperature', &
+                                           T_shift(sp), T_left(sp), 1.0e-10_dp)
+            end do
+            call assert_relative_close('periodic q', q_shift, q_left, 1.0e-10_dp)
+            call assert_relative_close('periodic Er', Er_shift, Er_left, 1.0e-10_dp)
+        end do
+        print *, 'PASS: all species primitives are periodic across the seam'
+    end subroutine test_multispecies_periodicity
+
+    subroutine test_negative_dependent_density_rejected(rm, dx_asis, dx_tr, n_rg)
+        use species_m, only: plasma, profiles_generation
+        use grid_m, only: rg_grid
+
+        real(dp), intent(in) :: rm, dx_asis, dx_tr
+        integer, intent(in) :: n_rg
+        real(dp) :: old_grid_start, old_grid_end
+        integer :: info, old_n_rg
+
+        ! Z_C*n_C = 1.2*n_e leaves no positive density for the dependent
+        ! deuterium species. The builder must report a profile error rather than
+        ! advancing into logarithms, collision frequencies, or susceptibilities.
+        old_n_rg = rg_grid%npts_b
+        old_grid_start = rg_grid%xb(1)
+        old_grid_end = rg_grid%xb(old_n_rg)
+        plasma%spec(2)%n = 0.2_dp*plasma%spec(0)%n
+        profiles_generation = profiles_generation + 1
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg + 7, info)
+        if (info /= PERIODIC_BACKGROUND_NONPHYSICAL_PROFILE) then
+            print *, 'FAIL: negative dependent density status = ', info
+            error stop
+        end if
+        if (rg_grid%npts_b /= old_n_rg .or. &
+            abs(rg_grid%xb(1) - old_grid_start) > epsilon(1.0_dp) .or. &
+            abs(rg_grid%xb(old_n_rg) - old_grid_end) > epsilon(1.0_dp)) then
+            print *, 'FAIL: rejected profile mutated the global radial grid'
+            error stop
+        end if
+        print *, 'PASS: negative dependent-ion density rejected as a profile error'
+    end subroutine test_negative_dependent_density_rejected
+
+    subroutine test_multispecies_cache_refresh(rm)
+        ! Model two successive in-process profile cases. The generation bump is
+        ! the same invalidation signal emitted by the profile adapter; case B
+        ! keeps total ion pressure unchanged so the already-computed geometry
+        ! remains a valid true background for the rest of this test.
+        use species_m, only: plasma, profiles_generation
+
+        real(dp), intent(in) :: rm
+        real(dp) :: n_before(0:2), T_before(0:2), n_after(0:2), T_after(0:2)
+        real(dp) :: q_sample, Er_sample, radius_fraction, impurity_fraction
+        real(dp) :: ion_pressure, expected
+        integer :: j
+
+        call sample_periodic_species_profiles(rm, 1.0_dp, 2.0_dp, rm, &
+                                              n_before, T_before, q_sample, Er_sample)
+
+        do j = 1, plasma%grid_size
+            radius_fraction = (plasma%r_grid(j) - plasma%r_grid(1)) / &
+                              (plasma%r_grid(plasma%grid_size) - plasma%r_grid(1))
+            ion_pressure = plasma%spec(1)%n(j)*plasma%spec(1)%T(j) + &
+                           plasma%spec(2)%n(j)*plasma%spec(2)%T(j)
+            impurity_fraction = 0.018_dp + 0.003_dp*radius_fraction
+            plasma%spec(2)%n(j) = impurity_fraction*plasma%spec(0)%n(j)
+            plasma%spec(1)%n(j) = plasma%spec(0)%n(j) - &
+                                  6.0_dp*plasma%spec(2)%n(j)
+            plasma%spec(2)%T(j) = 1050.0_dp + 100.0_dp*radius_fraction
+            plasma%spec(1)%T(j) = (ion_pressure - &
+                                    plasma%spec(2)%n(j)*plasma%spec(2)%T(j)) / &
+                                   plasma%spec(1)%n(j)
+        end do
+        profiles_generation = profiles_generation + 1
+
+        call sample_periodic_species_profiles(rm, 1.0_dp, 2.0_dp, rm, &
+                                              n_after, T_after, q_sample, Er_sample)
+
+        expected = interp_lagrange4(plasma%r_grid, plasma%spec(2)%n, &
+                                    plasma%grid_size, rm)
+        call assert_relative_close('refreshed C density', n_after(2), expected, 1.0e-10_dp)
+        expected = interp_lagrange4(plasma%r_grid, plasma%spec(2)%T, &
+                                    plasma%grid_size, rm)
+        call assert_relative_close('refreshed C temperature', T_after(2), expected, 1.0e-10_dp)
+        if (abs(n_after(2) - n_before(2)) <= 0.1_dp*abs(n_before(2)) .or. &
+            abs(T_after(2) - T_before(2)) <= 0.1_dp*abs(T_before(2))) then
+            print *, 'FAIL: multispecies cache retained the first profile case'
+            error stop
+        end if
+        print *, 'PASS: multispecies cache refreshed for a second profile case'
+    end subroutine test_multispecies_cache_refresh
+
+    subroutine set_distinct_two_ion_profiles()
+        ! Construct an exactly quasineutral D + C background. The carbon
+        ! concentration and both ion temperatures have distinct radial shapes,
+        ! so a single shared ion profile cannot satisfy this fixture.
+        use species_m, only: plasma
+
+        integer :: j
+        real(dp) :: impurity_fraction, radius_fraction
+
+        do j = 1, plasma%grid_size
+            radius_fraction = (plasma%r_grid(j) - plasma%r_grid(1)) / &
+                              (plasma%r_grid(plasma%grid_size) - plasma%r_grid(1))
+            impurity_fraction = 0.010_dp + 0.005_dp*radius_fraction
+            plasma%spec(2)%n(j) = impurity_fraction*plasma%spec(0)%n(j)
+            plasma%spec(1)%n(j) = plasma%spec(0)%n(j) - &
+                                  6.0_dp*plasma%spec(2)%n(j)
+            plasma%spec(1)%T(j) = 700.0_dp + 80.0_dp*radius_fraction
+            plasma%spec(2)%T(j) = 1400.0_dp - 120.0_dp*radius_fraction
+        end do
+    end subroutine set_distinct_two_ion_profiles
+
+    subroutine assert_relative_close(label, actual, expected, tolerance)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected, tolerance
+        real(dp) :: relative_error
+
+        relative_error = abs(actual - expected) / max(abs(expected), tiny(1.0_dp))
+        print *, trim(label), ': true =', expected, ' built =', actual, &
+                 ' rel =', relative_error
+        if (relative_error >= tolerance) then
+            print *, 'FAIL: ', trim(label), ' not preserved in as-is core'
+            error stop
+        end if
+    end subroutine assert_relative_close
 
     real(dp) function rho_L_near(r) result(val)
         !> Return the electron Larmor radius of the global plasma at the grid
@@ -269,11 +489,11 @@ contains
 
         open(newunit=iunit, file=path, status='replace', action='write')
         write(iunit, '(A)') '&KIM_CONFIG'
-        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' number_of_ion_species = 2'
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
-        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' read_species_from_namelist = .true.'
         write(iunit, '(A)') ' turn_off_ions = .false.'
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
@@ -336,6 +556,10 @@ contains
         write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_species'
+        write(iunit, '(A)') ' ai = 2, 12'
+        write(iunit, '(A)') ' zi = 1, 6'
         write(iunit, '(A)') '/'
         close(iunit)
     end subroutine write_test_namelist

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -25,6 +25,7 @@ program test_periodic_convergence
 
     implicit none
 
+    call test_reference_scale_validation()
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
     call test_M_convergence()
@@ -35,10 +36,48 @@ program test_periodic_convergence
 
 contains
 
+    subroutine test_reference_scale_validation()
+        use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+        use species_m, only: plasma_t
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_NO_ACTIVE, &
+                                               PERIODIC_SCALE_INVALID_RHO
+
+        type(plasma_t) :: test_plasma
+        real(dp) :: rho_ref
+        integer :: sp, reference_species, info
+
+        test_plasma%n_species = 3
+        test_plasma%grid_size = 4
+        allocate(test_plasma%r_grid(4), test_plasma%spec(0:2))
+        test_plasma%r_grid = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        do sp = 0, 2
+            allocate(test_plasma%spec(sp)%rho_L(4))
+            test_plasma%spec(sp)%rho_L = 0.1_dp * real(sp + 1, dp)
+        end do
+
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .false., .false., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_NO_ACTIVE) then
+            print *, 'FAIL: selector did not reject a plasma with no active species'
+            error stop
+        end if
+
+        test_plasma%spec(2)%rho_L(2) = ieee_value(0.0_dp, ieee_quiet_nan)
+        call select_periodic_reference_scale(test_plasma, 1.5_dp, .true., .true., &
+                                             rho_ref, reference_species, info)
+        if (info /= PERIODIC_SCALE_INVALID_RHO) then
+            print *, 'FAIL: selector accepted a non-finite active-species rho_L'
+            print *, '  info =', info, ' reference species =', reference_species
+            error stop
+        end if
+        print *, 'PASS: reference-scale selector rejects invalid active species'
+    end subroutine test_reference_scale_validation
+
     subroutine test_core_on_fixed_grid()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: plasma, set_profiles_from_arrays
+        use species_m, only: set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
@@ -79,14 +118,15 @@ contains
         rm = r_res
         print *, 'resonant radius rm = ', rm
 
-        ! Representative electron Larmor radius at rm, via the SAME 4-point
-        ! Lagrange stencil the run-type uses to size its window.
+        ! Reference Larmor radius at rm, selected from the same active species
+        ! set used by the production run type.
         rhoL_rm = interp_rho_L(rm)
         if (.not. (rhoL_rm > 0.0_dp)) then
             print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
             error stop
         end if
-        print *, 'rho_L(rm) [electron] = ', rhoL_rm
+        call assert_convergence_uses_reference_scale(rm, rhoL_rm)
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
@@ -128,6 +168,33 @@ contains
         end if
         print *, 'PASS: dPhi non-zero, max|dPhi| =', maxval(abs(dPhi))
     end subroutine test_core_on_fixed_grid
+
+    subroutine assert_convergence_uses_reference_scale(rm, convergence_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, convergence_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: convergence harness could not select a physical scale'
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(convergence_rho - selected_rho) > tol) then
+            print *, 'FAIL: convergence scans do not use the selected species scale'
+            print *, '  convergence rho_L =', convergence_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_convergence_uses_reference_scale
 
     !> Phase-3 Task 2: r_g QUADRATURE convergence of the periodic solver.
     !>
@@ -193,7 +260,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED window (M and dx_asis / dx_tr do NOT change with n_rg): the only
         ! knob refined here is the r_g quadrature node count.
@@ -272,16 +339,16 @@ contains
     !> Phase-3 Task 3: FOURIER BASIS truncation convergence of the periodic
     !> solver.
     !>
-    !> With the r_g quadrature (n_rg = 192, converged in P3.2) and the window
+    !> With the r_g quadrature (n_rg = 512, converged in P3.2) and the window
     !> (dx_asis, dx_tr) FIXED, refine only the number of Fourier modes M (the
     !> basis has 2M+1 modes) and reconstruct delta-Phi on a FIXED diagnostic
     !> grid. The localized solution's Fourier coefficients decay for
     !> |k_m| >> 1/rho_L, so the Cauchy residual between successive M must fall
-    !> and beat 1e-2 by M ~ 24-32. A failure to converge is a real finding about
+    !> and beat 1e-2 at the finest tested M. A failure to converge is a real finding about
     !> the basis truncation or the k-resolution, not a reason to loosen the
     !> tolerance (bump n_rg first: the exp(i(k_m - k_m')r) quadrature is exact
-    !> for |m - m'| < n_rg by Nyquist, and 2M = 64 < 192, so n_rg = 192 resolves
-    !> M up to 32).
+    !> for |m - m'| < n_rg by Nyquist, and 2M = 256 < 512, so n_rg = 512 resolves
+    !> M up to 128).
     subroutine test_M_convergence()
         use config_m, only: profiles_in_memory, nml_config_path
         use species_m, only: set_profiles_from_arrays
@@ -291,8 +358,8 @@ contains
         use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
 
         integer, parameter :: npts = 201
-        integer, parameter :: n_rg = 192, ndiag = 41, nseq = 4
-        integer, parameter :: M_seq(nseq) = [8, 16, 24, 32]
+        integer, parameter :: n_rg = 512, ndiag = 41, nseq = 5
+        integer, parameter :: M_seq(nseq) = [32, 48, 64, 96, 128]
 
         real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -337,11 +404,10 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
-        ! FIXED quadrature and window (only M is refined here). n_rg = 192 is the
-        ! P3.2-converged node count; it resolves the k-modes for M up to 32
-        ! (2M = 64 < 192, Nyquist).
+        ! FIXED quadrature and window (only M is refined here). n_rg = 512 is the
+        ! P3.2-converged node count; it resolves the k-modes for M up to 128.
         dx_asis =  5.0_dp * rhoL_rm
         dx_tr   = 10.0_dp * rhoL_rm
         print *, 'FIXED n_rg               = ', n_rg
@@ -372,7 +438,7 @@ contains
             end if
             dphi_k(:, k) = dPhi
         end do
-        print *, 'PASS: all four solves returned info == 0'
+        print *, 'PASS: all Fourier-refinement solves returned info == 0'
 
         ! Cauchy relative residual between successive refinements.
         res_L2  = 0.0_dp
@@ -394,18 +460,21 @@ contains
         print *, '-----------------------------------------------------------'
 
         ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
-        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
+        decreasing = .true.
+        do k = 3, nseq
+            decreasing = decreasing .and. (res_L2(k) < res_L2(k - 1))
+        end do
         if (.not. decreasing) then
             print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> real finding about basis truncation / k-resolution;'
             print *, '      investigate (bump n_rg first), do NOT loosen the'
             print *, '      threshold blindly.'
             error stop 'test_M_convergence: residual not decreasing'
         end if
-        if (.not. (res_L2(4) < 1.0e-2_dp)) then
-            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
-            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+        if (.not. (res_L2(nseq) < 1.0e-2_dp)) then
+            print *, 'FAIL: finest res_L2 =', res_L2(nseq), ' not < 1.0e-2'
+            print *, '   res_L2 =', res_L2(2:nseq)
             print *, '   -> Fourier basis has NOT converged; investigate (bump'
             print *, '      n_rg first), do NOT loosen the threshold blindly.'
             error stop 'test_M_convergence: basis not converged'
@@ -426,12 +495,14 @@ contains
     !>
     !> CRITICAL (design section 4.1): the NUMERICAL resolution is held constant
     !> across the scan so the residual measures PHYSICAL deformation, not
-    !> numerical under-resolution. As dx_asis grows, L = 2*(dx_asis + dx_tr)
-    !> grows, so M and n_rg are SCALED with L:
-    !>   M    = ceiling( (5/rhoL) * L / (2 pi) )  -> fixed k_max = 5/rhoL
-    !>   n_rg = ceiling( 16 * L / rhoL )          -> fixed 16 points per rho_L
-    !> The M formula matches the run-type's own sizing (periodic_kmax_scale = 5),
-    !> and n_rg sits well above the P3.2-converged density.
+    !> numerical under-resolution. Hold dx_tr fixed at 10 rho_L so dx_asis is
+    !> the only physical knob. As dx_asis grows, L = 2*(dx_asis + dx_tr) grows,
+    !> so M and n_rg are SCALED with L:
+    !>   M    = ceiling( (27/rhoL) * L / (2 pi) ) -> fixed converged k_max
+    !>   n_rg = max(ceiling(16 L/rhoL), 4 M)      -> converged quadrature/Nyquist
+    !> The cutoff follows the preceding M scan, where M=128 on the 15-rho_L
+    !> half-window reduced the Cauchy residual below 1e-2. This scan therefore
+    !> measures deformation rather than the known under-resolution at k_max=5/rho_L.
     !>
     !> SOFT GATE (this REPORTS the error bar, it does NOT tightly pass/fail): the
     !> test error-stops ONLY on a genuine defect -- non-finite / all-zero dPhi, a
@@ -500,7 +571,7 @@ contains
             error stop
         end if
         print *, 'resonant radius rm       = ', rm
-        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+        print *, 'rho_L(rm) [active-species reference] = ', rhoL_rm
 
         ! FIXED diagnostic grid: 41 equidistant points on [rm - 2 rho_L,
         ! rm + 2 rho_L]. The SAME physical grid is used for EVERY dx_asis, so the
@@ -513,16 +584,17 @@ contains
                       + 4.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
         end do
 
-        ! Scan the as-is half-width. Memo ratio dx_tr = 2*dx_asis => L = 6*dx_asis.
-        ! Hold the NUMERICAL resolution constant by scaling M and n_rg with L:
-        ! fixed k_max = 5/rho_L (matches the run-type) and fixed 16 pts / rho_L.
+        ! Scan ONLY the as-is half-width. Keep dx_tr fixed at the run-type's
+        ! configured 10-rho_L transition scale, and hold numerical resolution
+        ! constant by scaling M and n_rg with L. The fixed k_max = 27/rho_L is
+        ! justified by test_M_convergence above.
         do k = 1, nseq
             dx_asis = dx_asis_scale(k) * rhoL_rm
-            dx_tr   = 2.0_dp * dx_asis
+            dx_tr   = 10.0_dp * rhoL_rm
             L       = 2.0_dp * (dx_asis + dx_tr)
-            k_max   = 5.0_dp / rhoL_rm
+            k_max   = 27.0_dp / rhoL_rm
             M_seq(k)    = ceiling(k_max * L / (2.0_dp * pi))
-            n_rg_seq(k) = ceiling(16.0_dp * L / rhoL_rm)
+            n_rg_seq(k) = max(ceiling(16.0_dp * L / rhoL_rm), 4 * M_seq(k))
 
             print '(A,F6.1,A,ES14.6,A,I5,A,I6)', &
                 '   dx_asis = ', dx_asis_scale(k), ' rho_L  (=', dx_asis, &
@@ -620,25 +692,22 @@ contains
         print *, '=== test_dr_deformation_scan PASSED ==='
     end subroutine test_dr_deformation_scan
 
-    !> 4-point Lagrange interpolation of the global electron Larmor radius
-    !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.
+    !> Active-species reference scale selected by the production run type.
     real(dp) function interp_rho_L(x) result(rhoLx)
+        use config_m, only: turn_off_electrons, turn_off_ions
         use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
         real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
+        integer :: reference_species, info
 
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr/2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
+        call select_periodic_reference_scale(plasma, x, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoLx, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select convergence reference scale, info =', info
+            error stop
         end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
     end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -1,0 +1,248 @@
+program test_periodic_convergence
+    ! Phase-3 Task 1: exercises the reusable periodic core
+    ! rt_electrostatic_periodic_m::compute_periodic_delta_phi extracted from the
+    ! electrostatic_periodic run-type.
+    !
+    ! The convergence harness (P3.2-3.4) needs to evaluate delta-Phi on a FIXED
+    ! diagnostic grid independent of the window discretization (n_rg, M, dx), so
+    ! that Cauchy residuals are comparable across parameter refinements. This
+    ! test pins the contract of that core: given explicit window parameters, a
+    ! constant Br drive, and an explicit output grid, it builds -> assembles ->
+    ! solves -> reconstructs and returns delta-Phi on the SUPPLIED grid.
+    !
+    ! Setup mirrors test_kim_solver_periodic.f90 / test_periodic_assembly.f90:
+    ! in-memory analytic profiles, (m,n) = (-6, 2) so q is resonant at q = 3,
+    ! type_br_field = 12 (constant Br over the window).
+    !
+    ! Assertions on compute_periodic_delta_phi with a FIXED 41-point diagnostic
+    ! grid (independent of n_rg = 96 / M = 24):
+    !   info == 0 (non-singular solve);
+    !   size(dPhi) == size(r_diag) == 41 (evaluated on the SUPPLIED grid);
+    !   all dPhi finite;
+    !   maxval(abs(dPhi)) > 0 (constant Br drives a response).
+
+    use KIM_kinds_m, only: dp
+
+    implicit none
+
+    call test_core_on_fixed_grid()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine test_core_on_fixed_grid()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
+
+        integer, parameter :: npts = 201
+        integer, parameter :: M = 24, n_rg = 96, ndiag = 41
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: dPhi(:)
+        real(dp) :: r_diag(ndiag)
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr
+        integer :: i, info
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_conv_test.nml')
+        nml_config_path = './KIM_config_periodic_conv_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        ! Locate the resonance (q = |m/n| = 3) on the global plasma.
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+        print *, 'resonant radius rm = ', rm
+
+        ! Representative electron Larmor radius at rm, via the SAME 4-point
+        ! Lagrange stencil the run-type uses to size its window.
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
+            error stop
+        end if
+        print *, 'rho_L(rm) [electron] = ', rhoL_rm
+
+        dx_asis =  5.0_dp * rhoL_rm
+        dx_tr   = 10.0_dp * rhoL_rm
+
+        ! FIXED diagnostic grid: 41 equidistant points on [rm - 3 rho_L, rm + 3 rho_L],
+        ! chosen INDEPENDENTLY of n_rg / M / dx (the whole point of the core).
+        do i = 1, ndiag
+            r_diag(i) = (rm - 3.0_dp * rhoL_rm) &
+                      + 6.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
+        end do
+
+        call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, &
+                                        (1.0_dp, 0.0_dp), r_diag, dPhi, info)
+
+        if (info /= 0) then
+            print *, 'FAIL: compute_periodic_delta_phi info /= 0:', info
+            error stop
+        end if
+        print *, 'PASS: compute_periodic_delta_phi info == 0'
+
+        if (size(dPhi) /= ndiag) then
+            print *, 'FAIL: size(dPhi) /=', ndiag, ' got ', size(dPhi)
+            error stop
+        end if
+        print *, 'PASS: dPhi evaluated on the supplied grid, size ', ndiag
+
+        do i = 1, ndiag
+            if (.not. ieee_is_finite(real(dPhi(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(dPhi(i)))) then
+                print *, 'FAIL: non-finite dPhi at', i
+                error stop
+            end if
+        end do
+        print *, 'PASS: all dPhi finite'
+
+        if (.not. (maxval(abs(dPhi)) > 0.0_dp)) then
+            print *, 'FAIL: dPhi all zero (constant Br should drive response)'
+            error stop
+        end if
+        print *, 'PASS: dPhi non-zero, max|dPhi| =', maxval(abs(dPhi))
+    end subroutine test_core_on_fixed_grid
+
+    !> 4-point Lagrange interpolation of the global electron Larmor radius
+    !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.
+    real(dp) function interp_rho_L(x) result(rhoLx)
+        use species_m, only: plasma
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+        call binsrc(plasma%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr/2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
+    end function interp_rho_L
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm; q crosses 3 inside [10, 50] so
+        ! the (m,n) = (-6, 2) mode (|m/n| = 3) has a resonance there.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration; m_mode = -6,
+        ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_conv_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_periodic_convergence

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -27,6 +27,7 @@ program test_periodic_convergence
 
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
+    call test_M_convergence()
 
     print *, 'All tests PASSED'
     stop 0
@@ -266,6 +267,152 @@ contains
         print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
         print *, '=== test_nrg_convergence PASSED ==='
     end subroutine test_nrg_convergence
+
+    !> Phase-3 Task 3: FOURIER BASIS truncation convergence of the periodic
+    !> solver.
+    !>
+    !> With the r_g quadrature (n_rg = 192, converged in P3.2) and the window
+    !> (dx_asis, dx_tr) FIXED, refine only the number of Fourier modes M (the
+    !> basis has 2M+1 modes) and reconstruct delta-Phi on a FIXED diagnostic
+    !> grid. The localized solution's Fourier coefficients decay for
+    !> |k_m| >> 1/rho_L, so the Cauchy residual between successive M must fall
+    !> and beat 1e-2 by M ~ 24-32. A failure to converge is a real finding about
+    !> the basis truncation or the k-resolution, not a reason to loosen the
+    !> tolerance (bump n_rg first: the exp(i(k_m - k_m')r) quadrature is exact
+    !> for |m - m'| < n_rg by Nyquist, and 2M = 64 < 192, so n_rg = 192 resolves
+    !> M up to 32).
+    subroutine test_M_convergence()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
+
+        integer, parameter :: npts = 201
+        integer, parameter :: n_rg = 192, ndiag = 41, nseq = 4
+        integer, parameter :: M_seq(nseq) = [8, 16, 24, 32]
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: dPhi(:)
+        complex(dp) :: dphi_k(ndiag, nseq)
+        real(dp) :: r_diag(ndiag)
+        real(dp) :: res_L2(nseq), res_max(nseq)
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr
+        real(dp) :: denom_L2, denom_max
+        integer :: i, k, info
+        logical :: decreasing
+
+        print *, ''
+        print *, '=== test_M_convergence: Fourier basis truncation convergence ==='
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_conv_test.nml')
+        nml_config_path = './KIM_config_periodic_conv_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
+            error stop
+        end if
+        print *, 'resonant radius rm       = ', rm
+        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+
+        ! FIXED quadrature and window (only M is refined here). n_rg = 192 is the
+        ! P3.2-converged node count; it resolves the k-modes for M up to 32
+        ! (2M = 64 < 192, Nyquist).
+        dx_asis =  5.0_dp * rhoL_rm
+        dx_tr   = 10.0_dp * rhoL_rm
+        print *, 'FIXED n_rg               = ', n_rg
+        print *, 'FIXED dx_asis (5 rho_L)  = ', dx_asis
+        print *, 'FIXED dx_tr  (10 rho_L)  = ', dx_tr
+        print *, 'window L/2 (15 rho_L)    = ', dx_asis + dx_tr
+
+        ! FIXED diagnostic grid: 41 equidistant points on [rm - 3 rho_L,
+        ! rm + 3 rho_L], INDEPENDENT of M, so the Cauchy residuals are
+        ! comparable across basis refinements.
+        do i = 1, ndiag
+            r_diag(i) = (rm - 3.0_dp * rhoL_rm) &
+                      + 6.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
+        end do
+
+        ! Refine M only; store delta-Phi on the fixed grid for each M.
+        do k = 1, nseq
+            call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M_seq(k), n_rg, &
+                                            (1.0_dp, 0.0_dp), r_diag, dPhi, info)
+            if (info /= 0) then
+                print *, 'FAIL: compute_periodic_delta_phi info /= 0 at M =', &
+                    M_seq(k), ' info =', info
+                error stop
+            end if
+            if (size(dPhi) /= ndiag) then
+                print *, 'FAIL: size(dPhi) /=', ndiag, ' got ', size(dPhi)
+                error stop
+            end if
+            dphi_k(:, k) = dPhi
+        end do
+        print *, 'PASS: all four solves returned info == 0'
+
+        ! Cauchy relative residual between successive refinements.
+        res_L2  = 0.0_dp
+        res_max = 0.0_dp
+        do k = 2, nseq
+            denom_L2  = sqrt(sum(abs(dphi_k(:, k))**2))
+            denom_max = maxval(abs(dphi_k(:, k)))
+            res_L2(k)  = sqrt(sum(abs(dphi_k(:, k) - dphi_k(:, k-1))**2)) / denom_L2
+            res_max(k) = maxval(abs(dphi_k(:, k) - dphi_k(:, k-1))) / denom_max
+        end do
+
+        print *, ''
+        print *, '--- M convergence (fixed n_rg, window, diagnostic grid) ---'
+        print '(A)', '   M pair             res_L2            res_max'
+        do k = 2, nseq
+            print '(3X,I5," ->",I5,4X,ES16.8,2X,ES16.8)', &
+                M_seq(k-1), M_seq(k), res_L2(k), res_max(k)
+        end do
+        print *, '-----------------------------------------------------------'
+
+        ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
+        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
+        if (.not. decreasing) then
+            print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
+            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   -> real finding about basis truncation / k-resolution;'
+            print *, '      investigate (bump n_rg first), do NOT loosen the'
+            print *, '      threshold blindly.'
+            error stop 'test_M_convergence: residual not decreasing'
+        end if
+        if (.not. (res_L2(4) < 1.0e-2_dp)) then
+            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
+            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   -> Fourier basis has NOT converged; investigate (bump'
+            print *, '      n_rg first), do NOT loosen the threshold blindly.'
+            error stop 'test_M_convergence: basis not converged'
+        end if
+
+        print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
+        print *, '=== test_M_convergence PASSED ==='
+    end subroutine test_M_convergence
 
     !> 4-point Lagrange interpolation of the global electron Larmor radius
     !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -28,6 +28,7 @@ program test_periodic_convergence
     call test_core_on_fixed_grid()
     call test_nrg_convergence()
     call test_M_convergence()
+    call test_dr_deformation_scan()
 
     print *, 'All tests PASSED'
     stop 0
@@ -413,6 +414,211 @@ contains
         print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
         print *, '=== test_M_convergence PASSED ==='
     end subroutine test_M_convergence
+
+    !> Phase-3 Task 4: PERIODIZATION-DEFORMATION error bar (design section 5.1).
+    !>
+    !> This is the payoff of Phase 3: it quantifies the PHYSICAL error introduced
+    !> by periodizing the background, distinct from the numerical convergence
+    !> pinned by Tasks 2-3. As the as-is half-width dx_asis grows, LESS of the
+    !> background is deformed near the resonant layer, so the resonant-layer
+    !> delta-Phi approaches the true (undeformed) solution. The Cauchy residual
+    !> between successive dx_asis is the periodization-deformation error bar.
+    !>
+    !> CRITICAL (design section 4.1): the NUMERICAL resolution is held constant
+    !> across the scan so the residual measures PHYSICAL deformation, not
+    !> numerical under-resolution. As dx_asis grows, L = 2*(dx_asis + dx_tr)
+    !> grows, so M and n_rg are SCALED with L:
+    !>   M    = ceiling( (5/rhoL) * L / (2 pi) )  -> fixed k_max = 5/rhoL
+    !>   n_rg = ceiling( 16 * L / rhoL )          -> fixed 16 points per rho_L
+    !> The M formula matches the run-type's own sizing (periodic_kmax_scale = 5),
+    !> and n_rg sits well above the P3.2-converged density.
+    !>
+    !> SOFT GATE (this REPORTS the error bar, it does NOT tightly pass/fail): the
+    !> test error-stops ONLY on a genuine defect -- non-finite / all-zero dPhi, a
+    !> non-finite residual, or a residual sequence that GROWS without bound (a
+    !> growing residual means the deformation is NOT converging: a real finding).
+    !> A decreasing / plateauing residual is the physical expectation; the plateau
+    !> value (residual at the largest dx_asis) is the reported deformation error
+    !> bar. A small-but-finite plateau does NOT hard-fail.
+    subroutine test_dr_deformation_scan()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
+
+        integer, parameter :: npts = 201
+        integer, parameter :: ndiag = 41, nseq = 4
+        real(dp), parameter :: dx_asis_scale(nseq) = &
+            [3.0_dp, 5.0_dp, 8.0_dp, 12.0_dp]
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: dPhi(:)
+        complex(dp) :: dphi_k(ndiag, nseq)
+        real(dp) :: r_diag(ndiag)
+        real(dp) :: res_L2(nseq), res_max(nseq)
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max, pi
+        real(dp) :: denom_L2, denom_max
+        integer :: M_seq(nseq), n_rg_seq(nseq)
+        integer :: i, k, info
+        logical :: growing
+
+        pi = acos(-1.0_dp)
+
+        print *, ''
+        print *, '=== test_dr_deformation_scan: PERIODIZATION-DEFORMATION error bar ==='
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_conv_test.nml')
+        nml_config_path = './KIM_config_periodic_conv_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
+            error stop
+        end if
+        print *, 'resonant radius rm       = ', rm
+        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+
+        ! FIXED diagnostic grid: 41 equidistant points on [rm - 2 rho_L,
+        ! rm + 2 rho_L]. The SAME physical grid is used for EVERY dx_asis, so the
+        ! Cauchy residuals are directly comparable. 2 rho_L is safely INSIDE the
+        ! as-is region for ALL dx_asis in the scan (the smallest dx_asis =
+        ! 3 rho_L > 2 rho_L), so the diagnostic layer always sees the undeformed
+        ! background and the residual isolates the periodization deformation.
+        do i = 1, ndiag
+            r_diag(i) = (rm - 2.0_dp * rhoL_rm) &
+                      + 4.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
+        end do
+
+        ! Scan the as-is half-width. Memo ratio dx_tr = 2*dx_asis => L = 6*dx_asis.
+        ! Hold the NUMERICAL resolution constant by scaling M and n_rg with L:
+        ! fixed k_max = 5/rho_L (matches the run-type) and fixed 16 pts / rho_L.
+        do k = 1, nseq
+            dx_asis = dx_asis_scale(k) * rhoL_rm
+            dx_tr   = 2.0_dp * dx_asis
+            L       = 2.0_dp * (dx_asis + dx_tr)
+            k_max   = 5.0_dp / rhoL_rm
+            M_seq(k)    = ceiling(k_max * L / (2.0_dp * pi))
+            n_rg_seq(k) = ceiling(16.0_dp * L / rhoL_rm)
+
+            print '(A,F6.1,A,ES14.6,A,I5,A,I6)', &
+                '   dx_asis = ', dx_asis_scale(k), ' rho_L  (=', dx_asis, &
+                ')  ->  M = ', M_seq(k), '  n_rg = ', n_rg_seq(k)
+
+            call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M_seq(k), &
+                                            n_rg_seq(k), (1.0_dp, 0.0_dp), &
+                                            r_diag, dPhi, info)
+            if (info /= 0) then
+                print *, 'FAIL: compute_periodic_delta_phi info /= 0 at dx_asis =', &
+                    dx_asis_scale(k), ' rho_L, info =', info
+                error stop
+            end if
+            if (size(dPhi) /= ndiag) then
+                print *, 'FAIL: size(dPhi) /=', ndiag, ' got ', size(dPhi)
+                error stop
+            end if
+            do i = 1, ndiag
+                if (.not. ieee_is_finite(real(dPhi(i), dp)) .or. &
+                    .not. ieee_is_finite(aimag(dPhi(i)))) then
+                    print *, 'FAIL: non-finite dPhi at i =', i, &
+                        ' dx_asis =', dx_asis_scale(k), ' rho_L'
+                    error stop 'test_dr_deformation_scan: non-finite dPhi'
+                end if
+            end do
+            if (.not. (maxval(abs(dPhi)) > 0.0_dp)) then
+                print *, 'FAIL: dPhi all zero at dx_asis =', dx_asis_scale(k), ' rho_L'
+                error stop 'test_dr_deformation_scan: all-zero dPhi'
+            end if
+            dphi_k(:, k) = dPhi
+        end do
+        print *, 'PASS: all solves returned info == 0 with finite, non-zero dPhi'
+
+        ! Cauchy relative residual between successive dx_asis (k = 2, 3, 4).
+        res_L2  = 0.0_dp
+        res_max = 0.0_dp
+        do k = 2, nseq
+            denom_L2  = sqrt(sum(abs(dphi_k(:, k))**2))
+            denom_max = maxval(abs(dphi_k(:, k)))
+            res_L2(k)  = sqrt(sum(abs(dphi_k(:, k) - dphi_k(:, k-1))**2)) / denom_L2
+            res_max(k) = maxval(abs(dphi_k(:, k) - dphi_k(:, k-1))) / denom_max
+            if (.not. ieee_is_finite(res_L2(k)) .or. &
+                .not. ieee_is_finite(res_max(k))) then
+                print *, 'FAIL: non-finite residual at k =', k, &
+                    ' res_L2 =', res_L2(k), ' res_max =', res_max(k)
+                error stop 'test_dr_deformation_scan: non-finite residual'
+            end if
+        end do
+
+        print *, ''
+        print *, '==================================================================='
+        print *, '   PERIODIZATION-DEFORMATION ERROR BAR (design section 5.1)'
+        print *, '   fixed diagnostic layer [rm-2 rho_L, rm+2 rho_L]; M, n_rg scaled'
+        print *, '   with L so k_max and r_g spacing are constant across the scan'
+        print *, '==================================================================='
+        print '(A)', '   dx_asis pair [rho_L]      res_L2            res_max'
+        do k = 2, nseq
+            print '(3X,F5.1," ->",F5.1,6X,ES16.8,2X,ES16.8)', &
+                dx_asis_scale(k-1), dx_asis_scale(k), res_L2(k), res_max(k)
+        end do
+        print *, '-------------------------------------------------------------------'
+        print '(A,ES16.8)', &
+            '   DEFORMATION ERROR BAR (plateau, res_L2 at largest dx_asis)  = ', &
+            res_L2(nseq)
+        print '(A,ES16.8)', &
+            '   DEFORMATION ERROR BAR (plateau, res_max at largest dx_asis) = ', &
+            res_max(nseq)
+        print *, '==================================================================='
+
+        ! SOFT GATE: only error-stop on a genuinely GROWING residual sequence (the
+        ! deformation is NOT converging -- a finding to investigate). Non-finite /
+        ! all-zero / non-finite-residual defects are already caught above. A
+        ! decreasing / plateauing sequence is the physical expectation and is
+        ! reported, NOT failed, however small the finite plateau.
+        growing = (res_L2(3) > res_L2(2)) .and. (res_L2(4) > res_L2(3))
+        if (growing) then
+            print *, 'FINDING: res_L2 sequence GROWS across the dx_asis scan:'
+            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   -> periodization deformation is NOT converging as the'
+            print *, '      as-is window grows; this is a real finding to'
+            print *, '      investigate, not a numerical-resolution artifact'
+            print *, '      (M and n_rg were scaled with L to hold resolution).'
+            error stop 'test_dr_deformation_scan: deformation residual growing'
+        end if
+
+        if (res_L2(nseq) <= res_L2(2)) then
+            print *, 'PASS: deformation residual decreases / plateaus (converging);'
+            print '(A,ES14.6)', &
+                '       reported periodization-deformation error bar = ', res_L2(nseq)
+        else
+            print *, 'NOTE: non-monotone but non-growing residual; plateau reported'
+            print '(A,ES14.6)', &
+                '       reported periodization-deformation error bar = ', res_L2(nseq)
+        end if
+        print *, '=== test_dr_deformation_scan PASSED ==='
+    end subroutine test_dr_deformation_scan
 
     !> 4-point Lagrange interpolation of the global electron Larmor radius
     !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.

--- a/KIM/tests/test_periodic_convergence.f90
+++ b/KIM/tests/test_periodic_convergence.f90
@@ -26,6 +26,7 @@ program test_periodic_convergence
     implicit none
 
     call test_core_on_fixed_grid()
+    call test_nrg_convergence()
 
     print *, 'All tests PASSED'
     stop 0
@@ -125,6 +126,146 @@ contains
         end if
         print *, 'PASS: dPhi non-zero, max|dPhi| =', maxval(abs(dPhi))
     end subroutine test_core_on_fixed_grid
+
+    !> Phase-3 Task 2: r_g QUADRATURE convergence of the periodic solver.
+    !>
+    !> With M and the window (dx_asis, dx_tr) FIXED, refine only the number of
+    !> radial quadrature nodes n_rg and reconstruct delta-Phi on a FIXED
+    !> diagnostic grid. The periodic-trapezoidal rule is spectrally accurate for
+    !> the near-periodic window integrand, so the Cauchy residual between
+    !> successive refinements must fall fast and beat 1e-2. A failure to converge
+    !> is a real finding about the quadrature / seam handling, not a reason to
+    !> loosen the tolerance.
+    subroutine test_nrg_convergence()
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use rt_electrostatic_periodic_m, only: compute_periodic_delta_phi
+
+        integer, parameter :: npts = 201
+        integer, parameter :: M = 32, ndiag = 41, nseq = 4
+        integer, parameter :: n_rg_seq(nseq) = [48, 96, 192, 384]
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: dPhi(:)
+        complex(dp) :: dphi_k(ndiag, nseq)
+        real(dp) :: r_diag(ndiag)
+        real(dp) :: res_L2(nseq), res_max(nseq)
+        real(dp) :: rm, rhoL_rm, dx_asis, dx_tr
+        real(dp) :: denom_L2, denom_max
+        integer :: i, k, info
+        logical :: decreasing
+
+        print *, ''
+        print *, '=== test_nrg_convergence: r_g quadrature convergence ==='
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_conv_test.nml')
+        nml_config_path = './KIM_config_periodic_conv_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, 'FAIL: rho_L(rm) not positive, = ', rhoL_rm
+            error stop
+        end if
+        print *, 'resonant radius rm       = ', rm
+        print *, 'rho_L(rm) [electron]     = ', rhoL_rm
+
+        ! FIXED window (M and dx_asis / dx_tr do NOT change with n_rg): the only
+        ! knob refined here is the r_g quadrature node count.
+        dx_asis =  5.0_dp * rhoL_rm
+        dx_tr   = 10.0_dp * rhoL_rm
+        print *, 'FIXED M                  = ', M
+        print *, 'FIXED dx_asis (5 rho_L)  = ', dx_asis
+        print *, 'FIXED dx_tr  (10 rho_L)  = ', dx_tr
+        print *, 'window L/2 (15 rho_L)    = ', dx_asis + dx_tr
+
+        ! FIXED diagnostic grid: 41 equidistant points on [rm - 3 rho_L,
+        ! rm + 3 rho_L], well inside L/2 = 15 rho_L and INDEPENDENT of n_rg, so
+        ! the Cauchy residuals are comparable across refinements.
+        do i = 1, ndiag
+            r_diag(i) = (rm - 3.0_dp * rhoL_rm) &
+                      + 6.0_dp * rhoL_rm * real(i - 1, dp) / real(ndiag - 1, dp)
+        end do
+
+        ! Refine n_rg only; store delta-Phi on the fixed grid for each n_rg.
+        do k = 1, nseq
+            call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg_seq(k), &
+                                            (1.0_dp, 0.0_dp), r_diag, dPhi, info)
+            if (info /= 0) then
+                print *, 'FAIL: compute_periodic_delta_phi info /= 0 at n_rg =', &
+                    n_rg_seq(k), ' info =', info
+                error stop
+            end if
+            if (size(dPhi) /= ndiag) then
+                print *, 'FAIL: size(dPhi) /=', ndiag, ' got ', size(dPhi)
+                error stop
+            end if
+            dphi_k(:, k) = dPhi
+        end do
+        print *, 'PASS: all four solves returned info == 0'
+
+        ! Cauchy relative residual between successive refinements.
+        res_L2  = 0.0_dp
+        res_max = 0.0_dp
+        do k = 2, nseq
+            denom_L2  = sqrt(sum(abs(dphi_k(:, k))**2))
+            denom_max = maxval(abs(dphi_k(:, k)))
+            res_L2(k)  = sqrt(sum(abs(dphi_k(:, k) - dphi_k(:, k-1))**2)) / denom_L2
+            res_max(k) = maxval(abs(dphi_k(:, k) - dphi_k(:, k-1))) / denom_max
+        end do
+
+        print *, ''
+        print *, '--- n_rg convergence (fixed M, window, diagnostic grid) ---'
+        print '(A)', '   n_rg pair          res_L2            res_max'
+        do k = 2, nseq
+            print '(3X,I5," ->",I5,4X,ES16.8,2X,ES16.8)', &
+                n_rg_seq(k-1), n_rg_seq(k), res_L2(k), res_max(k)
+        end do
+        print *, '-----------------------------------------------------------'
+
+        ! Assert: the residual sequence DECREASES and the finest beats 1e-2.
+        decreasing = (res_L2(4) < res_L2(3)) .and. (res_L2(3) < res_L2(2))
+        if (.not. decreasing) then
+            print *, 'FAIL: res_L2 sequence does not decrease monotonically:'
+            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   -> real finding about r_g quadrature / seam handling;'
+            print *, '      investigate, do NOT loosen the threshold blindly.'
+            error stop 'test_nrg_convergence: residual not decreasing'
+        end if
+        if (.not. (res_L2(4) < 1.0e-2_dp)) then
+            print *, 'FAIL: finest res_L2(4) =', res_L2(4), ' not < 1.0e-2'
+            print *, '   res_L2 =', res_L2(2), res_L2(3), res_L2(4)
+            print *, '   -> quadrature has NOT converged; investigate, do NOT'
+            print *, '      loosen the threshold blindly.'
+            error stop 'test_nrg_convergence: quadrature not converged'
+        end if
+
+        print *, 'PASS: res_L2 decreasing and res_L2(finest) < 1.0e-2'
+        print *, '=== test_nrg_convergence PASSED ==='
+    end subroutine test_nrg_convergence
 
     !> 4-point Lagrange interpolation of the global electron Larmor radius
     !> plasma%spec(0)%rho_L at radius x, matching the run-type's interp_rho_L.

--- a/KIM/tests/test_periodic_solve.f90
+++ b/KIM/tests/test_periodic_solve.f90
@@ -30,11 +30,13 @@ program test_periodic_solve
     use KIM_kinds_m, only: dp
     use constants_m, only: pi, com_unit
     use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, dense_solve
+    use periodic_solve_m, only: reconstruct_jpar
 
     implicit none
 
     call test_dense_solve_roundtrip()
     call test_inverse_dft()
+    call test_reconstruct_jpar()
     call test_end_to_end()
 
     print *, 'All tests PASSED'
@@ -138,6 +140,93 @@ contains
                  maxval(abs(dPhi - expected))
     end subroutine test_inverse_dft
 
+    !> j_par reconstruction (thesis 11.7): j_m = Kjphi . Phi_m + KjB . Br_m with
+    !> Br_m = Br_const*delta_{m',0} for a constant window drive, then inverse-DFT.
+    !> Manufactured matrices keep this independent of any plasma.
+    subroutine test_reconstruct_jpar()
+        integer, parameter :: M = 3
+        integer, parameter :: dim = 2 * M + 1
+        integer, parameter :: nr = 5
+        real(dp), parameter :: L = 4.0_dp
+        complex(dp) :: Kjphi(dim, dim), KjB(dim, dim), Phi_m(dim)
+        complex(dp) :: jpar(nr), expected(nr), Br_const
+        real(dp) :: r_out(nr), k1
+        integer :: i, im
+
+        do i = 1, nr
+            r_out(i) = -1.5_dp + 0.7_dp * real(i - 1, dp)
+        end do
+        k1 = 2.0_dp * pi * 1.0_dp / L
+
+        ! (a) Phi path alone: Kjphi = I, KjB = 0, Phi_m = delta_{m,1}.
+        ! Then j_m = delta_{m,1} and j_par(r) = exp(i k_1 r).
+        Kjphi = (0.0_dp, 0.0_dp)
+        do im = 1, dim
+            Kjphi(im, im) = (1.0_dp, 0.0_dp)
+        end do
+        KjB = (0.0_dp, 0.0_dp)
+        Phi_m = (0.0_dp, 0.0_dp)
+        Phi_m(1 + M + 1) = (1.0_dp, 0.0_dp)
+        Br_const = (0.0_dp, 0.0_dp)
+
+        jpar = reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out)
+        do i = 1, nr
+            expected(i) = exp(com_unit * k1 * r_out(i))
+        end do
+        if (maxval(abs(jpar - expected)) >= 1.0e-12_dp) then
+            print *, 'FAIL: j_par Phi-path /= exp(i k_1 r), err =', &
+                     maxval(abs(jpar - expected))
+            error stop
+        end if
+        print *, 'PASS: j_par Phi path = Kjphi . Phi_m, max err =', &
+                 maxval(abs(jpar - expected))
+
+        ! (b) Br path alone, and the m'=0 column convention. Kjphi = 0 (so an
+        ! arbitrary Phi_m must be killed); KjB carries junk everywhere EXCEPT a
+        ! clean m'=0 column. A constant drive has Br_m = Br_const*delta_{m',0},
+        ! so only that column may contribute -- if the junk leaks, j_par blows up.
+        Kjphi = (0.0_dp, 0.0_dp)
+        KjB = (99.0_dp, -99.0_dp)
+        KjB(:, 0 + M + 1) = (0.0_dp, 0.0_dp)
+        KjB(0 + M + 1, 0 + M + 1) = (2.0_dp, 0.0_dp)
+        Phi_m = (7.0_dp, 3.0_dp)
+        Br_const = (0.5_dp, 0.0_dp)
+
+        ! j_m = 2*0.5 = 1 at m = 0 only -> j_par(r) = 1 everywhere.
+        jpar = reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out)
+        expected = (1.0_dp, 0.0_dp)
+        if (maxval(abs(jpar - expected)) >= 1.0e-12_dp) then
+            print *, 'FAIL: j_par Br-path /= 1 (m''=0 column leak?), err =', &
+                     maxval(abs(jpar - expected))
+            print *, '  jpar =', jpar
+            error stop
+        end if
+        print *, 'PASS: j_par Br path uses the m''=0 column only, max err =', &
+                 maxval(abs(jpar - expected))
+
+        ! (c) Additivity: both paths on together must superpose.
+        Kjphi = (0.0_dp, 0.0_dp)
+        do im = 1, dim
+            Kjphi(im, im) = (1.0_dp, 0.0_dp)
+        end do
+        KjB = (0.0_dp, 0.0_dp)
+        KjB(0 + M + 1, 0 + M + 1) = (2.0_dp, 0.0_dp)
+        Phi_m = (0.0_dp, 0.0_dp)
+        Phi_m(1 + M + 1) = (1.0_dp, 0.0_dp)
+        Br_const = (0.5_dp, 0.0_dp)
+
+        jpar = reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out)
+        do i = 1, nr
+            expected(i) = exp(com_unit * k1 * r_out(i)) + (1.0_dp, 0.0_dp)
+        end do
+        if (maxval(abs(jpar - expected)) >= 1.0e-12_dp) then
+            print *, 'FAIL: j_par superposition err =', maxval(abs(jpar - expected))
+            error stop
+        end if
+        print *, 'PASS: j_par superposes the Phi and Br paths, max err =', &
+                 maxval(abs(jpar - expected))
+    end subroutine test_reconstruct_jpar
+
     !> (c) End-to-end sanity with the REAL assembled matrices. Mirrors
     !> test_periodic_assembly's setup: build the (m,n)=(-6,2) periodic plasma,
     !> assemble Kphi/KB with M=6, solve with a constant Br drive, and check the
@@ -161,7 +250,7 @@ contains
         real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
         class(kim_t), allocatable :: kim_instance
 
-        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:)
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:), Phi_m(:)
         complex(dp), allocatable :: dPhi(:)
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
         integer :: n_rg, N, dim, info, i
@@ -200,7 +289,7 @@ contains
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
         N = rg_grid%npts_b
 
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
 
         call solve_periodic(Kphi, KB, L, M, (1.0_dp, 0.0_dp), Phi_m, info)
 

--- a/KIM/tests/test_periodic_solve.f90
+++ b/KIM/tests/test_periodic_solve.f90
@@ -1,0 +1,349 @@
+program test_periodic_solve
+    ! Validates periodic_solve_m (Phase-2.5): the dense zgesv solve of the
+    ! periodic electrostatic system and the inverse-DFT reconstruction of the
+    ! potential.
+    !
+    ! System over Fourier modes m = -M..M (k_m = 2*pi*m/L):
+    !   [ D_m delta_{m,m'} + 4*pi K^{rhoPhi}_{m,m'} ] Phi_{m'}
+    !                                        = -4*pi K^{rhoB}_{m,m'} Br_{m'},
+    ! with D_m = -k_m^2 the (diagonal) Fourier-space radial Poisson operator
+    ! (matching solve_poisson.f90, whose FEM Laplace operator is the radial
+    ! second derivative only), the (2M+1)^2 matrices Kphi/KB from Phase-2.4,
+    ! and for type_br_field = 12 a constant Br over the window whose Fourier
+    ! coefficient is nonzero only at m' = 0:  Br_{m'} = Br_const*delta_{m',0}.
+    ! Hence  b_m = -4*pi*Br_const*KB(m, m'=0) = -4*pi*Br_const*KB(:, M+1).
+    ! Solve A Phi = b via LAPACK zgesv, then reconstruct
+    !   dPhi(r) = sum_{m=-M}^{M} Phi_m exp(i k_m r).
+    !
+    ! Assertions:
+    !   (a) solver round-trip: a manufactured, diagonally-dominant complex
+    !       (2M+1)^2 system solved through the SAME zgesv wiring as
+    !       solve_periodic (via the exposed private dense_solve) recovers a
+    !       known solution to < 1e-10;
+    !   (b) inverse-DFT correctness: reconstruct_delta_phi of a single-mode
+    !       coefficient gives exp(i k_m r) to 1e-12, and a two-mode case
+    !       confirms superposition;
+    !   (c) end-to-end: the REAL assembled (M=6) periodic matrices give a
+    !       non-singular solve (info==0), a finite non-zero Phi_m response to a
+    !       constant Br drive, and a finite reconstructed dPhi on the window.
+
+    use KIM_kinds_m, only: dp
+    use constants_m, only: pi, com_unit
+    use periodic_solve_m, only: solve_periodic, reconstruct_delta_phi, dense_solve
+
+    implicit none
+
+    call test_dense_solve_roundtrip()
+    call test_inverse_dft()
+    call test_end_to_end()
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    !> (a) Manufactured round-trip through the raw zgesv wiring. Isolates the
+    !> LAPACK argument pattern shared with solve_periodic: build a well-
+    !> conditioned diagonally-dominant complex A0, pick a known Phi, form
+    !> b0 = A0*Phi, solve, and assert recovery to < 1e-10.
+    subroutine test_dense_solve_roundtrip()
+        integer, parameter :: M = 3
+        integer, parameter :: dim = 2 * M + 1
+        complex(dp) :: A0(dim, dim), Phi_known(dim), b0(dim), x(dim)
+        integer :: i, j, info
+        real(dp) :: re, im
+
+        do j = 1, dim
+            do i = 1, dim
+                ! Deterministic, small off-diagonal entries.
+                re = 0.1_dp * real(i - j, dp)
+                im = 0.05_dp * real(i + j, dp)
+                A0(i, j) = cmplx(re, im, dp)
+            end do
+            ! Diagonal dominance -> well-conditioned.
+            A0(j, j) = cmplx(10.0_dp + real(j, dp), 1.0_dp, dp)
+            Phi_known(j) = cmplx(real(j, dp), real(dim - j, dp), dp)
+        end do
+
+        b0 = matmul(A0, Phi_known)
+        x = b0
+        call dense_solve(A0, x, info)
+
+        if (info /= 0) then
+            print *, 'FAIL: dense_solve info /= 0:', info
+            error stop
+        end if
+        if (maxval(abs(x - Phi_known)) >= 1.0e-10_dp) then
+            print *, 'FAIL: dense_solve round-trip error =', &
+                     maxval(abs(x - Phi_known))
+            error stop
+        end if
+        print *, 'PASS: dense_solve round-trip, max err =', &
+                 maxval(abs(x - Phi_known))
+    end subroutine test_dense_solve_roundtrip
+
+    !> (b) Inverse DFT correctness. A single nonzero coefficient at m=1 must
+    !> reconstruct exp(i k_1 r); a two-mode case confirms linear superposition.
+    subroutine test_inverse_dft()
+        integer, parameter :: M = 3
+        integer, parameter :: dim = 2 * M + 1
+        integer, parameter :: nr = 5
+        real(dp), parameter :: L = 4.0_dp
+        complex(dp) :: Phi_m(dim), dPhi(nr), expected(nr)
+        real(dp) :: r_out(nr), k1, k2
+        integer :: i
+
+        do i = 1, nr
+            r_out(i) = -1.5_dp + 0.7_dp * real(i - 1, dp)
+        end do
+
+        k1 = 2.0_dp * pi * 1.0_dp / L
+        k2 = 2.0_dp * pi * (-2.0_dp) / L
+
+        ! Single-mode: Phi_m = delta_{m,1}.
+        Phi_m = (0.0_dp, 0.0_dp)
+        Phi_m(1 + M + 1) = (1.0_dp, 0.0_dp)
+        dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+        do i = 1, nr
+            expected(i) = exp(com_unit * k1 * r_out(i))
+        end do
+        if (maxval(abs(abs(dPhi) - 1.0_dp)) >= 1.0e-12_dp) then
+            print *, 'FAIL: single-mode |dPhi| /= 1, err =', &
+                     maxval(abs(abs(dPhi) - 1.0_dp))
+            error stop
+        end if
+        if (maxval(abs(dPhi - expected)) >= 1.0e-12_dp) then
+            print *, 'FAIL: single-mode dPhi /= exp(i k_1 r), err =', &
+                     maxval(abs(dPhi - expected))
+            error stop
+        end if
+        print *, 'PASS: inverse DFT single-mode = exp(i k_1 r), max err =', &
+                 maxval(abs(dPhi - expected))
+
+        ! Two-mode superposition: Phi_1 = (1,0), Phi_{-2} = (0.5, -0.25).
+        Phi_m = (0.0_dp, 0.0_dp)
+        Phi_m(1 + M + 1)    = (1.0_dp, 0.0_dp)
+        Phi_m((-2) + M + 1) = (0.5_dp, -0.25_dp)
+        dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+        do i = 1, nr
+            expected(i) = (1.0_dp, 0.0_dp) * exp(com_unit * k1 * r_out(i)) &
+                        + (0.5_dp, -0.25_dp) * exp(com_unit * k2 * r_out(i))
+        end do
+        if (maxval(abs(dPhi - expected)) >= 1.0e-12_dp) then
+            print *, 'FAIL: two-mode superposition err =', &
+                     maxval(abs(dPhi - expected))
+            error stop
+        end if
+        print *, 'PASS: inverse DFT two-mode superposition, max err =', &
+                 maxval(abs(dPhi - expected))
+    end subroutine test_inverse_dft
+
+    !> (c) End-to-end sanity with the REAL assembled matrices. Mirrors
+    !> test_periodic_assembly's setup: build the (m,n)=(-6,2) periodic plasma,
+    !> assemble Kphi/KB with M=6, solve with a constant Br drive, and check the
+    !> solve is non-singular, the response is finite and non-zero, and the
+    !> reconstructed dPhi on the window grid is finite.
+    subroutine test_end_to_end()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: plasma, set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use grid_m, only: rg_grid
+        use periodic_background_m, only: build_periodic_plasma
+        use periodic_assembly_m, only: assemble_periodic_matrices
+
+        integer, parameter :: npts = 201
+        integer, parameter :: M = 6
+
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        class(kim_t), allocatable :: kim_instance
+
+        complex(dp), allocatable :: Kphi(:,:), KB(:,:), Phi_m(:)
+        complex(dp), allocatable :: dPhi(:)
+        real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
+        integer :: n_rg, N, dim, info, i
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_solve_test.nml')
+        nml_config_path = './KIM_config_periodic_solve_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_instance)
+        call kim_instance%init()
+
+        call prepare_resonances
+        if (.not. (r_res > 0.0_dp)) then
+            print *, 'FAIL: resonance not found, r_res = ', r_res
+            error stop
+        end if
+        rm = r_res
+
+        rho_L_rm = rho_L_near(rm)
+        dx_asis =  5.0_dp * rho_L_rm
+        dx_tr   = 10.0_dp * rho_L_rm
+        if (dx_asis < 1.0e-3_dp) then
+            dx_asis = 1.0_dp
+            dx_tr   = 2.0_dp
+        end if
+        n_rg = 96
+        L = 2.0_dp * (dx_asis + dx_tr)
+
+        call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
+        N = rg_grid%npts_b
+
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB)
+
+        call solve_periodic(Kphi, KB, L, M, (1.0_dp, 0.0_dp), Phi_m, info)
+
+        dim = 2 * M + 1
+        if (info /= 0) then
+            print *, 'FAIL: solve_periodic info /= 0:', info
+            error stop
+        end if
+        if (size(Phi_m) /= dim) then
+            print *, 'FAIL: Phi_m size /=', dim, ' got ', size(Phi_m)
+            error stop
+        end if
+        do i = 1, dim
+            if (.not. ieee_is_finite(real(Phi_m(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(Phi_m(i)))) then
+                print *, 'FAIL: non-finite Phi_m at', i
+                error stop
+            end if
+        end do
+        if (maxval(abs(Phi_m)) <= 0.0_dp) then
+            print *, 'FAIL: Phi_m all zero (constant Br should drive response)'
+            error stop
+        end if
+        print *, 'PASS: end-to-end solve info==0, Phi_m finite & non-zero, ', &
+                 'max|Phi_m| =', maxval(abs(Phi_m))
+
+        ! Reconstruct on the window grid and assert finite.
+        dPhi = reconstruct_delta_phi(Phi_m, L, M, rg_grid%xb)
+        do i = 1, size(dPhi)
+            if (.not. ieee_is_finite(real(dPhi(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(dPhi(i)))) then
+                print *, 'FAIL: non-finite dPhi at', i
+                error stop
+            end if
+        end do
+        print *, 'PASS: end-to-end reconstruct dPhi on window finite, ', &
+                 'max|dPhi| =', maxval(abs(dPhi))
+    end subroutine test_end_to_end
+
+    real(dp) function rho_L_near(r) result(val)
+        use species_m, only: plasma
+        real(dp), intent(in) :: r
+        integer :: jn
+        jn = minloc(abs(plasma%r_grid - r), dim=1)
+        val = plasma%spec(0)%rho_L(jn)
+    end function rho_L_near
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm; q crosses 3 inside [10, 50] so
+        ! the (m,n) = (-6, 2) mode (|m/n| = 3) has a resonance there.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path)
+        ! Minimal electrostatic FokkerPlanck configuration; m_mode = -6,
+        ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
+        character(len=*), intent(in) :: path
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = 'electrostatic'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_solve_test/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_periodic_solve

--- a/KIM/tests/test_periodic_vs_global.f90
+++ b/KIM/tests/test_periodic_vs_global.f90
@@ -47,6 +47,7 @@ program test_periodic_vs_global
 
     call run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                     r_global, phi_global, rm, rhoL_rm)
+    call assert_diagnostic_uses_reference_scale(rm, rhoL_rm)
     call run_periodic(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                       r_periodic, phi_periodic)
 
@@ -58,18 +59,48 @@ program test_periodic_vs_global
 
 contains
 
+    subroutine assert_diagnostic_uses_reference_scale(rm, diagnostic_rho)
+        use config_m, only: turn_off_electrons, turn_off_ions
+        use species_m, only: plasma
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
+
+        real(dp), intent(in) :: rm, diagnostic_rho
+        real(dp) :: selected_rho, tol
+        integer :: reference_species, info
+
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, selected_rho, &
+                                             reference_species, info)
+        if (info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: could not select the physical diagnostic scale, info =', info
+            error stop
+        end if
+        tol = 1.0e-10_dp * selected_rho
+        if (abs(diagnostic_rho - selected_rho) > tol) then
+            print *, 'FAIL: cross-check interval does not use the selected species scale'
+            print *, '  diagnostic rho_L =', diagnostic_rho
+            print *, '  selected species =', reference_species
+            print *, '  selected rho_L =', selected_rho
+            error stop
+        end if
+    end subroutine assert_diagnostic_uses_reference_scale
+
     subroutine run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
                           r_out, phi_out, rm, rhoL_rm)
         ! Global electrostatic (FokkerPlanck, hat-basis) run. Captures deep
         ! copies of EBdat%Phi and EBdat%r_grid (the FIELD grid xl_grid%xb), and
         ! reads rm = r_res and rho_L(rm) off the GLOBAL plasma so the periodic
         ! run can be compared on the same resonant layer.
-        use config_m, only: profiles_in_memory, nml_config_path
-        use species_m, only: set_profiles_from_arrays
+        use config_m, only: profiles_in_memory, nml_config_path, &
+                            turn_off_electrons, turn_off_ions
+        use species_m, only: plasma, set_profiles_from_arrays
         use kim_base_m, only: kim_t
         use kim_mod_m, only: from_kim_factory_get_kim
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
+        use rt_electrostatic_periodic_m, only: select_periodic_reference_scale, &
+                                               PERIODIC_SCALE_OK
 
         real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
         real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
@@ -78,7 +109,7 @@ contains
         real(dp), intent(out) :: rm, rhoL_rm
 
         class(kim_t), allocatable :: kim_g
-        integer :: N
+        integer :: N, reference_species, scale_info
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                 q_prof, Er_prof)
@@ -103,9 +134,11 @@ contains
             print *, 'FAIL: global run -- resonance not found, r_res = ', rm
             error stop
         end if
-        rhoL_rm = interp_rho_L(rm)
-        if (.not. (rhoL_rm > 0.0_dp)) then
-            print *, 'FAIL: global run -- rho_L(rm) not positive, = ', rhoL_rm
+        call select_periodic_reference_scale(plasma, rm, .not. turn_off_electrons, &
+                                             .not. turn_off_ions, rhoL_rm, &
+                                             reference_species, scale_info)
+        if (scale_info /= PERIODIC_SCALE_OK) then
+            print *, 'FAIL: global run -- invalid reference rho_L, info = ', scale_info
             error stop
         end if
 
@@ -132,7 +165,8 @@ contains
 
         print *, 'GLOBAL: max|Phi| = ', maxval(abs(phi_out)), &
                  ' on r in [', r_out(1), ',', r_out(N), '], N = ', N
-        print *, 'GLOBAL: rm = ', rm, ' rho_L(rm) = ', rhoL_rm
+        print *, 'GLOBAL: rm = ', rm, ' reference species = ', reference_species, &
+                 ' rho_L(rm) = ', rhoL_rm
 
         ! The global potential is expected to be finite; whether it is non-zero
         ! is a FINDING reported by cross_check (on this coarse in-memory
@@ -288,6 +322,9 @@ contains
                                 sqrt(sum(abs(pg_dc)**2)))
         rel_max_dc = safe_ratio(maxval(abs(diff_dc)), maxval(abs(pg_dc)))
 
+        call write_curve_data('periodic_vs_global_curve.dat', r_c(1:nc), &
+                              pg_c(1:nc), pp_c(1:nc), pg_dc, pp_dc)
+
         ! Soft gate: bail only on non-finite results, never on a large finite one.
         if (.not. ieee_is_finite(rel_L2) .or. .not. ieee_is_finite(rel_max) .or. &
             .not. ieee_is_finite(rel_L2_dc) .or. &
@@ -346,6 +383,29 @@ contains
         end if
         print *, ''
     end subroutine cross_check
+
+    subroutine write_curve_data(path, r, phi_global, phi_periodic, &
+                                phi_global_dc, phi_periodic_dc)
+        character(len=*), intent(in) :: path
+        real(dp), intent(in) :: r(:)
+        complex(dp), intent(in) :: phi_global(:), phi_periodic(:)
+        complex(dp), intent(in) :: phi_global_dc(:), phi_periodic_dc(:)
+        integer :: i, io_unit
+
+        open(newunit=io_unit, file=path, status='replace', action='write')
+        write(io_unit, '(A)') &
+            '# r_cm global_re global_im periodic_re periodic_im ' // &
+            'global_dc_re global_dc_im periodic_dc_re periodic_dc_im'
+        do i = 1, size(r)
+            write(io_unit, '(9(ES24.16,1X))') r(i), &
+                real(phi_global(i), dp), aimag(phi_global(i)), &
+                real(phi_periodic(i), dp), aimag(phi_periodic(i)), &
+                real(phi_global_dc(i), dp), aimag(phi_global_dc(i)), &
+                real(phi_periodic_dc(i), dp), aimag(phi_periodic_dc(i))
+        end do
+        close(io_unit)
+        print *, '  curve data                  = ', path
+    end subroutine write_curve_data
 
     real(dp) function safe_ratio(num, den) result(ratio)
         ! num/den, guarding against a zero (or tiny) denominator so an all-zero
@@ -420,28 +480,6 @@ contains
             end if
         end do
     end subroutine assert_finite
-
-    real(dp) function interp_rho_L(x) result(rhoLx)
-        ! 4-point Lagrange interpolation of the global electron Larmor radius
-        ! plasma%spec(0)%rho_L at radius x -- same stencil as the periodic
-        ! run-type uses to size its window, so rm/Delta match the solver.
-        use species_m, only: plasma
-        real(dp), intent(in) :: x
-        integer, parameter :: nlagr = 4, nder = 0
-        real(dp) :: coef(0:nder, nlagr)
-        integer :: gs, ir, ibeg, iend
-
-        gs = plasma%grid_size
-        call binsrc(plasma%r_grid, 1, gs, x, ir)
-        ibeg = max(1, ir - nlagr / 2)
-        iend = ibeg + nlagr - 1
-        if (iend > gs) then
-            iend = gs
-            ibeg = iend - nlagr + 1
-        end if
-        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
-        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
-    end function interp_rho_L
 
     subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                   q_prof, Er_prof)

--- a/KIM/tests/test_periodic_vs_global.f90
+++ b/KIM/tests/test_periodic_vs_global.f90
@@ -1,0 +1,548 @@
+program test_periodic_vs_global
+    ! Phase-2.7 cross-check: periodic vs global electrostatic delta-Phi.
+    !
+    ! On the SAME in-memory (m, n) = (-6, 2) case (q resonant at q = 3,
+    ! type_br_field = 12, constant Br), run BOTH the global `electrostatic`
+    ! run-type (FokkerPlanck, hat-basis) and the new `electrostatic_periodic`
+    ! run-type, then compare their reconstructed delta_Phi(r) on the resonant
+    ! layer.
+    !
+    ! This is a VALIDATION/DIAGNOSTIC task (design 5.2): approx-vs-approx, so
+    ! the deliverable is a measured cross-check number, not a brittle hard
+    ! pass/fail. The global electrostatic solver writes EBdat%Phi on the FIELD
+    ! grid (xl_grid%xb); the periodic solver writes it on the window grid
+    ! (rg_grid%xb). We build a common equidistant grid over a few Larmor radii
+    ! around rm = r_res, intersect it with BOTH solutions' radial ranges,
+    ! interpolate both potentials onto it (4-pt Lagrange, real/imag separately),
+    ! and report the relative L2 and max differences -- both raw and with the DC
+    ! (mean) removed, since a constant gauge/offset in Phi is physically
+    ! irrelevant.
+    !
+    ! Soft gate: error stop ONLY if a solution is missing / all-zero / NaN, or
+    ! if a computed relative difference is non-finite. A large-but-finite
+    ! discrepancy is a Phase-2 finding, not a test failure: it is printed in a
+    ! CROSS-CHECK DIAGNOSTIC block (with a WARNING when rel_L2 > 0.5) and the
+    ! test still exits 0 so CI stays green -- the number is the diagnostic.
+
+    use KIM_kinds_m, only: dp
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+
+    integer, parameter :: npts = 201
+    integer, parameter :: n_common = 21
+    real(dp), parameter :: n_larmor = 3.0_dp   ! window half-width = n_larmor * rho_L(rm)
+
+    real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+    real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+
+    ! Global-run captures (deep copies; the periodic run overwrites the globals).
+    real(dp),    allocatable :: r_global(:)
+    complex(dp), allocatable :: phi_global(:)
+    ! Periodic-run captures.
+    real(dp),    allocatable :: r_periodic(:)
+    complex(dp), allocatable :: phi_periodic(:)
+
+    real(dp) :: rm, rhoL_rm, Delta
+
+    call run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
+                    r_global, phi_global, rm, rhoL_rm)
+    call run_periodic(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
+                      r_periodic, phi_periodic)
+
+    Delta = n_larmor * rhoL_rm
+    call cross_check(r_global, phi_global, r_periodic, phi_periodic, rm, Delta)
+
+    print *, 'All tests PASSED'
+    stop 0
+
+contains
+
+    subroutine run_global(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
+                          r_out, phi_out, rm, rhoL_rm)
+        ! Global electrostatic (FokkerPlanck, hat-basis) run. Captures deep
+        ! copies of EBdat%Phi and EBdat%r_grid (the FIELD grid xl_grid%xb), and
+        ! reads rm = r_res and rho_L(rm) off the GLOBAL plasma so the periodic
+        ! run can be compared on the same resonant layer.
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use kim_resonances_m, only: r_res
+        use fields_m, only: EBdat
+
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp), allocatable, intent(out) :: r_out(:)
+        complex(dp), allocatable, intent(out) :: phi_out(:)
+        real(dp), intent(out) :: rm, rhoL_rm
+
+        class(kim_t), allocatable :: kim_g
+        integer :: N
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+
+        call write_test_namelist('./KIM_config_periodic_vs_global.nml', &
+                                 'electrostatic')
+        nml_config_path = './KIM_config_periodic_vs_global.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        call from_kim_factory_get_kim('electrostatic', kim_g)
+        call kim_g%init()
+        call kim_g%run()
+
+        ! rm = resonant radius (q = |m/n| = 3) located on the global plasma.
+        call prepare_resonances
+        rm = r_res
+        if (.not. (rm > 0.0_dp)) then
+            print *, 'FAIL: global run -- resonance not found, r_res = ', rm
+            error stop
+        end if
+        rhoL_rm = interp_rho_L(rm)
+        if (.not. (rhoL_rm > 0.0_dp)) then
+            print *, 'FAIL: global run -- rho_L(rm) not positive, = ', rhoL_rm
+            error stop
+        end if
+
+        ! Global electrostatic writes EBdat%Phi on the field grid (xl_grid%xb)
+        ! and sets EBdat%r_grid = xl_grid%xb, so the captured r matches Phi.
+        if (.not. allocated(EBdat%Phi)) then
+            print *, 'FAIL: global run produced no EBdat%Phi'
+            error stop
+        end if
+        if (.not. allocated(EBdat%r_grid)) then
+            print *, 'FAIL: global run produced no EBdat%r_grid'
+            error stop
+        end if
+        N = size(EBdat%Phi)
+        if (size(EBdat%r_grid) /= N) then
+            print *, 'FAIL: global size(Phi) /= size(r_grid); ', &
+                     N, size(EBdat%r_grid)
+            error stop
+        end if
+
+        ! Deep copies -- the periodic run overwrites the globals.
+        r_out   = EBdat%r_grid
+        phi_out = EBdat%Phi
+
+        print *, 'GLOBAL: max|Phi| = ', maxval(abs(phi_out)), &
+                 ' on r in [', r_out(1), ',', r_out(N), '], N = ', N
+        print *, 'GLOBAL: rm = ', rm, ' rho_L(rm) = ', rhoL_rm
+
+        ! The global potential is expected to be finite; whether it is non-zero
+        ! is a FINDING reported by cross_check (on this coarse in-memory
+        ! FokkerPlanck case the global electrostatic Poisson solve returns
+        ! Phi == 0, so the cross-check reference is degenerate -- see below),
+        ! not a reason to abort the diagnostic.
+        call assert_finite('global', r_out, phi_out)
+    end subroutine run_global
+
+    subroutine run_periodic(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, &
+                            r_out, phi_out)
+        ! Re-establish the in-memory profiles (the global run mutated global
+        ! state) and reset EBdat, then run the electrostatic_periodic run-type.
+        ! Captures EBdat%Phi and EBdat%r_grid (the window grid rg_grid%xb).
+        use config_m, only: profiles_in_memory, nml_config_path
+        use species_m, only: set_profiles_from_arrays
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use fields_m, only: EBdat, EBdat_t
+
+        real(dp), intent(in) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(in) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        real(dp), allocatable, intent(out) :: r_out(:)
+        complex(dp), allocatable, intent(out) :: phi_out(:)
+
+        class(kim_t), allocatable :: kim_p
+        integer :: N
+
+        call write_test_namelist('./KIM_config_periodic_vs_global.nml', &
+                                 'electrostatic_periodic')
+        nml_config_path = './KIM_config_periodic_vs_global.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+
+        ! The global run left EBdat components allocated; the periodic run-type
+        ! deallocates Phi/r_grid before writing, but reset the whole record so
+        ! no stale buffer from the global solve can leak in.
+        EBdat = EBdat_t()
+
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_p)
+        call kim_p%init()
+        call kim_p%run()
+
+        if (.not. allocated(EBdat%Phi)) then
+            print *, 'FAIL: periodic run produced no EBdat%Phi'
+            error stop
+        end if
+        if (.not. allocated(EBdat%r_grid)) then
+            print *, 'FAIL: periodic run produced no EBdat%r_grid'
+            error stop
+        end if
+        N = size(EBdat%Phi)
+        if (size(EBdat%r_grid) /= N) then
+            print *, 'FAIL: periodic size(Phi) /= size(r_grid); ', &
+                     N, size(EBdat%r_grid)
+            error stop
+        end if
+
+        r_out   = EBdat%r_grid
+        phi_out = EBdat%Phi
+
+        call assert_solution_ok('periodic', r_out, phi_out)
+
+        print *, 'PERIODIC: max|Phi| = ', maxval(abs(phi_out)), &
+                 ' on r in [', r_out(1), ',', r_out(N), '], N = ', N
+    end subroutine run_periodic
+
+    subroutine cross_check(r_g, phi_g, r_p, phi_p, rm, Delta)
+        ! Build a common equidistant grid of n_common points over
+        ! [rm - Delta, rm + Delta], keep only points covered by BOTH solutions'
+        ! radial ranges, interpolate both potentials onto it (4-pt Lagrange,
+        ! real/imag separately), and report relative L2 / max differences, both
+        ! raw and DC-removed. Soft gate only on missing/all-zero/NaN.
+        real(dp), intent(in) :: r_g(:), r_p(:), rm, Delta
+        complex(dp), intent(in) :: phi_g(:), phi_p(:)
+
+        real(dp) :: r_lo, r_hi, r_pt
+        real(dp) :: g_lo, g_hi, p_lo, p_hi
+        real(dp), allocatable :: r_c(:)
+        complex(dp), allocatable :: pg_c(:), pp_c(:), diff(:)
+        complex(dp) :: mean_g, mean_p
+        complex(dp), allocatable :: pg_dc(:), pp_dc(:), diff_dc(:)
+        real(dp) :: rel_L2, rel_max, rel_L2_dc, rel_max_dc
+        real(dp) :: norm_g, norm_diff, max_g, max_diff
+        real(dp) :: max_phi_g, max_phi_p
+        logical :: global_degenerate
+        integer :: i, nc
+
+        ! Radial coverage of each solution (grids are ascending).
+        g_lo = r_g(1);  g_hi = r_g(size(r_g))
+        p_lo = r_p(1);  p_hi = r_p(size(r_p))
+
+        ! Common grid over the resonant layer, intersected with both ranges so
+        ! interpolation never extrapolates.
+        r_lo = max(rm - Delta, g_lo, p_lo)
+        r_hi = min(rm + Delta, g_hi, p_hi)
+        if (.not. (r_hi > r_lo)) then
+            print *, 'FAIL: no overlap between global range [', g_lo, ',', &
+                     g_hi, '] and periodic range [', p_lo, ',', p_hi, ']'
+            print *, '  resonant layer [', rm - Delta, ',', rm + Delta, ']'
+            error stop
+        end if
+
+        ! Points strictly inside both ranges (n_common candidates over the
+        ! overlap; all are covered by construction, but keep the guard explicit).
+        allocate(r_c(n_common), pg_c(n_common), pp_c(n_common))
+        nc = 0
+        do i = 1, n_common
+            r_pt = r_lo + (r_hi - r_lo) * real(i - 1, dp) / real(n_common - 1, dp)
+            if (r_pt < g_lo .or. r_pt > g_hi) cycle
+            if (r_pt < p_lo .or. r_pt > p_hi) cycle
+            nc = nc + 1
+            r_c(nc)  = r_pt
+            pg_c(nc) = lagrange4_complex(r_g, phi_g, r_pt)
+            pp_c(nc) = lagrange4_complex(r_p, phi_p, r_pt)
+        end do
+        if (nc < 2) then
+            print *, 'FAIL: fewer than 2 common points (nc = ', nc, ')'
+            error stop
+        end if
+
+        max_phi_g = maxval(abs(phi_g))
+        max_phi_p = maxval(abs(phi_p))
+
+        ! A degenerate global reference (identically zero) makes every relative
+        ! difference meaningless (num/0). Report it as a FINDING, not a number.
+        global_degenerate = .not. (max_phi_g > 0.0_dp)
+
+        ! Raw relative differences on the common grid.
+        allocate(diff(nc))
+        diff = pp_c(1:nc) - pg_c(1:nc)
+        norm_g    = sqrt(sum(abs(pg_c(1:nc))**2))
+        norm_diff = sqrt(sum(abs(diff)**2))
+        max_g     = maxval(abs(pg_c(1:nc)))
+        max_diff  = maxval(abs(diff))
+        rel_L2  = safe_ratio(norm_diff, norm_g)
+        rel_max = safe_ratio(max_diff, max_g)
+
+        ! DC-removed: subtract each solution's mean over the common grid (a
+        ! constant gauge/offset in Phi is physically irrelevant, and the
+        ! periodic delta-Phi carries a DC aligned-potential component the
+        ! hat-basis solve may treat differently).
+        mean_g = sum(pg_c(1:nc)) / cmplx(real(nc, dp), 0.0_dp, dp)
+        mean_p = sum(pp_c(1:nc)) / cmplx(real(nc, dp), 0.0_dp, dp)
+        allocate(pg_dc(nc), pp_dc(nc), diff_dc(nc))
+        pg_dc   = pg_c(1:nc) - mean_g
+        pp_dc   = pp_c(1:nc) - mean_p
+        diff_dc = pp_dc - pg_dc
+        rel_L2_dc  = safe_ratio(sqrt(sum(abs(diff_dc)**2)), &
+                                sqrt(sum(abs(pg_dc)**2)))
+        rel_max_dc = safe_ratio(maxval(abs(diff_dc)), maxval(abs(pg_dc)))
+
+        ! Soft gate: bail only on non-finite results, never on a large finite one.
+        if (.not. ieee_is_finite(rel_L2) .or. .not. ieee_is_finite(rel_max) .or. &
+            .not. ieee_is_finite(rel_L2_dc) .or. &
+            .not. ieee_is_finite(rel_max_dc)) then
+            print *, 'FAIL: non-finite relative difference'
+            print *, '  rel_L2 = ', rel_L2, ' rel_max = ', rel_max
+            print *, '  rel_L2_dc = ', rel_L2_dc, ' rel_max_dc = ', rel_max_dc
+            error stop
+        end if
+
+        print *, ''
+        print *, '======================================================================'
+        print *, ' CROSS-CHECK DIAGNOSTIC: periodic vs global electrostatic delta-Phi'
+        print *, '======================================================================'
+        print *, '  rm (resonant radius) [cm]  = ', rm
+        print *, '  Delta (= ', n_larmor, ' * rho_L(rm)) [cm] = ', Delta
+        print *, '  resonant layer [cm]        = [', rm - Delta, ',', rm + Delta, ']'
+        print *, '  common overlap [cm]        = [', r_lo, ',', r_hi, ']'
+        print *, '  number of common points    = ', nc
+        print *, '  ----------------------------------------------------------'
+        print *, '  max|phi_global|            = ', max_phi_g
+        print *, '  max|phi_periodic|          = ', max_phi_p
+        if (.not. global_degenerate) &
+            print *, '  magnitude ratio (p/g)      = ', max_phi_p / max_phi_g
+        print *, '  ----------------------------------------------------------'
+
+        if (global_degenerate) then
+            print *, '  rel_L2  (raw)              = N/A (global reference is 0)'
+            print *, '  rel_max (raw)              = N/A (global reference is 0)'
+            print *, '  rel_L2_dc_removed          = N/A (global reference is 0)'
+            print *, '  rel_max_dc_removed         = N/A (global reference is 0)'
+            print *, '======================================================================'
+            print *, ' FINDING: the GLOBAL electrostatic solve returned Phi == 0 on this'
+            print *, '   coarse (32-pt) in-memory FokkerPlanck (m,n)=(-6,2) case, despite a'
+            print *, '   nonzero Poisson RHS (b_vec is O(10) in kernel/b_vec.dat). The'
+            print *, '   electrostatic Poisson solve (solve_poisson -> SuiteSparse) is the'
+            print *, '   only path that returns zero here; the periodic solver produces a'
+            print *, '   healthy localized delta-Phi (max|Phi| = ', max_phi_p, ').'
+            print *, '   No meaningful periodic-vs-global relative difference can be formed'
+            print *, '   until the global reference is non-degenerate -- this is a Phase-2'
+            print *, '   cross-check finding to investigate (electrostatic Poisson solve),'
+            print *, '   NOT a failure of the periodic solver or of this diagnostic.'
+            print *, '======================================================================'
+        else
+            print *, '  rel_L2  (raw)              = ', rel_L2
+            print *, '  rel_max (raw)              = ', rel_max
+            print *, '  rel_L2_dc_removed          = ', rel_L2_dc
+            print *, '  rel_max_dc_removed         = ', rel_max_dc
+            print *, '======================================================================'
+            if (rel_L2 > 0.5_dp) then
+                print *, ' WARNING: periodic vs global differ by >50% -- investigate'
+                print *, '   (candidates: k_s^2 D_m convention, DC/gauge,'
+                print *, '    periodization deformation, normalization)'
+                print *, '======================================================================'
+            end if
+        end if
+        print *, ''
+    end subroutine cross_check
+
+    real(dp) function safe_ratio(num, den) result(ratio)
+        ! num/den, guarding against a zero (or tiny) denominator so an all-zero
+        ! reference cannot poison the diagnostic with a NaN. A zero denominator
+        ! with a nonzero numerator yields a large (but finite, reported) ratio.
+        real(dp), intent(in) :: num, den
+        if (den > tiny(1.0_dp)) then
+            ratio = num / den
+        else if (num > tiny(1.0_dp)) then
+            ratio = num / tiny(1.0_dp)
+        else
+            ratio = 0.0_dp
+        end if
+    end function safe_ratio
+
+    complex(dp) function lagrange4_complex(r, f, x) result(fx)
+        ! 4-point Lagrange interpolation of a complex profile f on the ascending
+        ! grid r at x, interpolating real and imaginary parts with the same
+        ! stencil (binsrc + plag_coeff), matching KIM's interp_local_complex.
+        real(dp), intent(in) :: r(:), x
+        complex(dp), intent(in) :: f(:)
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        real(dp) :: re, im
+        integer :: n, ir, ibeg, iend
+
+        n = size(r)
+        call binsrc(r, 1, n, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > n) then
+            iend = n
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, r(ibeg:iend), coef)
+        re = sum(coef(0, :) * real(f(ibeg:iend), dp))
+        im = sum(coef(0, :) * aimag(f(ibeg:iend)))
+        fx = cmplx(re, im, dp)
+    end function lagrange4_complex
+
+    subroutine assert_solution_ok(label, r, phi)
+        ! A solution is usable iff its grid and potential are finite and the
+        ! potential is not identically zero.
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: r(:)
+        complex(dp), intent(in) :: phi(:)
+
+        call assert_finite(label, r, phi)
+        if (.not. (maxval(abs(phi)) > 0.0_dp)) then
+            print *, 'FAIL: ', label, ' Phi all zero'
+            error stop
+        end if
+    end subroutine assert_solution_ok
+
+    subroutine assert_finite(label, r, phi)
+        ! Grid and potential must be finite (no NaN/Inf); zero magnitude is
+        ! permitted (reported as a finding by cross_check, not aborted here).
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: r(:)
+        complex(dp), intent(in) :: phi(:)
+        integer :: i
+
+        do i = 1, size(phi)
+            if (.not. ieee_is_finite(real(phi(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(phi(i)))) then
+                print *, 'FAIL: non-finite ', label, ' Phi at ', i
+                error stop
+            end if
+            if (.not. ieee_is_finite(r(i))) then
+                print *, 'FAIL: non-finite ', label, ' r_grid at ', i
+                error stop
+            end if
+        end do
+    end subroutine assert_finite
+
+    real(dp) function interp_rho_L(x) result(rhoLx)
+        ! 4-point Lagrange interpolation of the global electron Larmor radius
+        ! plasma%spec(0)%rho_L at radius x -- same stencil as the periodic
+        ! run-type uses to size its window, so rm/Delta match the solver.
+        use species_m, only: plasma
+        real(dp), intent(in) :: x
+        integer, parameter :: nlagr = 4, nder = 0
+        real(dp) :: coef(0:nder, nlagr)
+        integer :: gs, ir, ibeg, iend
+
+        gs = plasma%grid_size
+        call binsrc(plasma%r_grid, 1, gs, x, ir)
+        ibeg = max(1, ir - nlagr / 2)
+        iend = ibeg + nlagr - 1
+        if (iend > gs) then
+            iend = gs
+            ibeg = iend - nlagr + 1
+        end if
+        call plag_coeff(nlagr, nder, x, plasma%r_grid(ibeg:iend), coef)
+        rhoLx = sum(coef(0, :) * plasma%spec(0)%rho_L(ibeg:iend))
+    end function interp_rho_L
+
+    subroutine make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                  q_prof, Er_prof)
+        ! Analytic profiles on r in [2, 60] cm; q crosses 3 inside [10, 50] so
+        ! the (m, n) = (-6, 2) mode (|m/n| = 3) has a resonance there. Mirrors
+        ! test_kim_solver_periodic.f90 so both run-types see the same case.
+        integer, intent(in) :: npts
+        real(dp), intent(out) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp), intent(out) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        integer :: i
+
+        do i = 1, npts
+            r_prof(i) = 2.0_dp + 58.0_dp * real(i - 1, dp) / real(npts - 1, dp)
+            n_prof(i) = 2.0e13_dp * (1.1_dp - r_prof(i) / 100.0_dp)
+            Te_prof(i) = 1.0e3_dp * (1.2_dp - r_prof(i) / 100.0_dp)
+            Ti_prof(i) = Te_prof(i)
+            q_prof(i) = 1.5_dp + 2.5_dp * (r_prof(i) - 2.0_dp) / 58.0_dp
+            Er_prof(i) = -0.5_dp
+        end do
+    end subroutine make_test_profiles
+
+    subroutine write_test_namelist(path, run_type)
+        ! Minimal FokkerPlanck configuration parameterised by run-type so the
+        ! global (electrostatic) and periodic (electrostatic_periodic) runs
+        ! share every other setting; m_mode = -6, n_mode = 2 makes q resonant at
+        ! q = 3, type_br_field = 12 (constant Br). Mirrors
+        ! test_kim_solver_periodic.f90.
+        character(len=*), intent(in) :: path, run_type
+        integer :: iunit
+
+        open(newunit=iunit, file=path, status='replace', action='write')
+        write(iunit, '(A)') '&KIM_CONFIG'
+        write(iunit, '(A)') ' number_of_ion_species = 1'
+        write(iunit, '(A)') ' artificial_debye_case = 0'
+        write(iunit, '(A)') " type_of_run = '"//trim(run_type)//"'"
+        write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        write(iunit, '(A)') ' read_species_from_namelist = .false.'
+        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A)') ' turn_off_electrons = .false.'
+        write(iunit, '(A)') " plasma_type = 'D'"
+        write(iunit, '(A)') ' rescale_density = .false.'
+        write(iunit, '(A)') ' number_density_rescale = 1.0'
+        write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&WKB_DISPERSION'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_IO'
+        write(iunit, '(A)') " profile_location = './'"
+        write(iunit, '(A)') " output_path = './out_periodic_vs_global/'"
+        write(iunit, '(A)') ' hdf5_input = .false.'
+        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A)') ' log_level = 3'
+        write(iunit, '(A)') ' data_verbosity = 0'
+        write(iunit, '(A)') ' calculate_asymptotics = .false.'
+        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') ' write_diagnostics_dat = .false.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_SETUP'
+        write(iunit, '(A)') ' btor = -18000.0'
+        write(iunit, '(A)') ' R0 = 165.0'
+        write(iunit, '(A)') ' m_mode = -6'
+        write(iunit, '(A)') ' n_mode = 2'
+        write(iunit, '(A)') ' omega = 0.0'
+        write(iunit, '(A)') ' spline_base = 1'
+        write(iunit, '(A)') ' type_br_field = 12'
+        write(iunit, '(A)') ' collisions_off = .false.'
+        write(iunit, '(A)') ' set_profiles_constant = 0'
+        write(iunit, '(A)') ' bc_type = 3'
+        write(iunit, '(A)') ' mphi_max = 0'
+        write(iunit, '(A)') ' Br_boundary_re = 1.0'
+        write(iunit, '(A)') ' Br_boundary_im = 0.0'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_GRID'
+        write(iunit, '(A)') " grid_spacing_rg = 'equidistant'"
+        write(iunit, '(A)') " grid_spacing_xl = 'equidistant'"
+        write(iunit, '(A)') ' l_space_dim = 32'
+        write(iunit, '(A)') ' rg_space_dim = 32'
+        write(iunit, '(A)') " theta_integration = 'GaussLegendre'"
+        write(iunit, '(A)') " theta_integration_method = ''"
+        write(iunit, '(A)') ' Larmor_skip_factor = 5'
+        write(iunit, '(A)') ' gauss_int_nodes_Ntheta = 17'
+        write(iunit, '(A)') ' gauss_int_nodes_Nx = 31'
+        write(iunit, '(A)') ' gauss_int_nodes_Nxp = 30'
+        write(iunit, '(A)') ' r_plas = 50.0'
+        write(iunit, '(A)') ' r_min = 10.0'
+        write(iunit, '(A)') ' width_res = 0.5'
+        write(iunit, '(A)') ' ampl_res = 15.0'
+        write(iunit, '(A)') ' hrmax_scaling = 1.0'
+        write(iunit, '(A)') ' rkf45_atol = 1.0e-9'
+        write(iunit, '(A)') ' rkf45_rtol = 1.0e-6'
+        write(iunit, '(A)') ' kernel_taper_skip_threshold = 1.0e-6'
+        write(iunit, '(A)') " quadpack_algorithm = 'QAG'"
+        write(iunit, '(A)') ' quadpack_key = 6'
+        write(iunit, '(A)') ' quadpack_limit = 500'
+        write(iunit, '(A)') ' quadpack_epsabs = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_epsrel = 1.0e-10'
+        write(iunit, '(A)') ' quadpack_use_u_substitution = .true.'
+        write(iunit, '(A)') '/'
+        write(iunit, '(A)') '&KIM_PROFILES'
+        write(iunit, '(A)') '/'
+        close(iunit)
+    end subroutine write_test_namelist
+
+end program test_periodic_vs_global

--- a/KIM/tests/test_periodization.f90
+++ b/KIM/tests/test_periodization.f90
@@ -1,0 +1,123 @@
+module test_periodization_helpers_m
+    !> Helper module hosting the toy aperiodic-function callback used by the
+    !> periodization regression test. Defining it as a module procedure (rather
+    !> than a contained/internal one) makes it a safe actual argument for the
+    !> procedure(aperfuns_i) dummy across all Fortran compilers.
+    use KIM_kinds_m, only: dp
+    implicit none
+    private
+    public :: toy_aperfuns
+
+contains
+
+    !> Aperiodic sample functions: funs(1)=x, funs(2)=x**2. Matches aperfuns_i.
+    subroutine toy_aperfuns(nfuns, x, funs)
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+        funs(1) = x
+        funs(2) = x**2
+    end subroutine toy_aperfuns
+
+end module test_periodization_helpers_m
+
+program test_periodization
+    !> Regression test for the vendored periodization utility
+    !> (KIM/src/background_equilibrium/periodization.f90). Pins make_periodic
+    !> against the known reference-program output (fort.3) for
+    !> aperfuns=[x, x**2], x_mid=0.5, dx_asis=0.25, dx_tr=0.5 (period L=1.5),
+    !> plus periodicity and as-is-region fidelity checks.
+    use KIM_kinds_m, only: dp
+    use periodization_m, only: make_periodic
+    use test_periodization_helpers_m, only: toy_aperfuns
+    implicit none
+
+    logical :: all_passed
+    all_passed = .true.
+
+    call test_reference_rows(all_passed)
+    call test_periodicity(all_passed)
+    call test_as_is_region(all_passed)
+
+    if (all_passed) then
+        print *, 'All tests PASSED'
+        stop 0
+    else
+        print *, 'Some periodization tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    !> Known reference rows from the reference test_driver output (fort.3).
+    subroutine test_reference_rows(passed)
+        logical, intent(inout) :: passed
+        call check_row(-0.99_dp, 0.51_dp, 0.2601_dp, passed)
+        call check_row(-0.98_dp, 0.52_dp, 0.2704_dp, passed)
+        call check_row(-0.95_dp, 0.55_dp, 0.3025_dp, passed)
+        call check_row(0.30_dp, 0.30_dp, 0.09_dp, passed)
+        call check_row(0.70_dp, 0.70_dp, 0.49_dp, passed)
+        call check_row(1.99_dp, 0.49_dp, 0.2401_dp, passed)
+        call check_row(2.00_dp, 0.50_dp, 0.25_dp, passed)
+    end subroutine test_reference_rows
+
+    !> make_periodic must be L-periodic in x with L = 2*(dx_asis+dx_tr) = 1.5.
+    subroutine test_periodicity(passed)
+        logical, intent(inout) :: passed
+        real(dp), parameter :: L = 1.5_dp
+        real(dp) :: funs0(2), funsL(2)
+        real(dp) :: xs(4)
+        integer :: i
+        xs = [-0.87_dp, 0.13_dp, 0.62_dp, 1.41_dp]
+        do i = 1, size(xs)
+            call make_periodic(toy_aperfuns, 2, 0.5_dp, 0.25_dp, 0.5_dp, xs(i), funs0)
+            call make_periodic(toy_aperfuns, 2, 0.5_dp, 0.25_dp, 0.5_dp, xs(i) + L, funsL)
+            call report('periodicity: f(x) == f(x+L)', &
+                        maxval(abs(funs0 - funsL)) < 1.0e-12_dp, passed)
+        end do
+    end subroutine test_periodicity
+
+    !> In the as-is region |x-x_mid| <= dx_asis the periodized functions must
+    !> equal the aperiodic ones exactly ([x, x**2]).
+    subroutine test_as_is_region(passed)
+        logical, intent(inout) :: passed
+        real(dp) :: funs(2)
+        real(dp) :: xs(3)
+        integer :: i
+        real(dp) :: x
+        xs = [0.30_dp, 0.50_dp, 0.70_dp]
+        do i = 1, size(xs)
+            x = xs(i)
+            call make_periodic(toy_aperfuns, 2, 0.5_dp, 0.25_dp, 0.5_dp, x, funs)
+            call report('as-is fidelity: funs == [x, x**2]', &
+                        abs(funs(1) - x) < 1.0e-12_dp .and. &
+                        abs(funs(2) - x**2) < 1.0e-12_dp, passed)
+        end do
+    end subroutine test_as_is_region
+
+    !> Evaluate make_periodic at x and compare against the reference values.
+    subroutine check_row(x, ref1, ref2, passed)
+        real(dp), intent(in) :: x, ref1, ref2
+        logical, intent(inout) :: passed
+        real(dp) :: funs(2)
+        character(len=64) :: label
+        call make_periodic(toy_aperfuns, 2, 0.5_dp, 0.25_dp, 0.5_dp, x, funs)
+        write (label, '(a,f6.2)') 'reference row x=', x
+        call report(trim(label), &
+                    abs(funs(1) - ref1) < 1.0e-12_dp .and. &
+                    abs(funs(2) - ref2) < 1.0e-12_dp, passed)
+    end subroutine check_row
+
+    subroutine report(name, ok, passed)
+        character(*), intent(in) :: name
+        logical, intent(in) :: ok
+        logical, intent(inout) :: passed
+        if (ok) then
+            print *, 'PASS: ', name
+        else
+            print *, 'FAIL: ', name
+            passed = .false.
+        end if
+    end subroutine report
+
+end program test_periodization

--- a/docs/plans/2026-07-10-kim-forced-periodicity-design.md
+++ b/docs/plans/2026-07-10-kim-forced-periodicity-design.md
@@ -1,0 +1,347 @@
+# KIM Forced-Periodicity Solver — Design
+
+- **Date:** 2026-07-10
+- **Branch:** `feature/kim-forced-periodicity`
+- **Status:** Design (brainstormed + grilled); ready to turn into an implementation plan
+- **Primary spec:** `~/1_projects/KIM_forced_periodicity/forced_periodicity.pdf`
+- **Supporting theory:** `~/1_projects/PhD_Thesis.pdf` (M. Markl, 2024), Part III — esp. Ch. 13 (Krook kernels), Ch. 14 (Fokker–Planck kernels), Ch. 15 (variational implementation)
+
+---
+
+## 1. Motivation
+
+KIM currently solves the plasma-response problem *globally*: hat-function basis over the
+whole radius, the integral kernel built in Fourier space then transformed to the hat basis
+(thesis §15.2), giving a sparse-but-approximated matrix. In practice the observed solutions
+are **highly localized** at the resonant surface (localization scale ~ ion Larmor radius
+`ρ_L`), so the sparsity advantage is lost and the basis transform carries avoidable
+approximations.
+
+The **forced-periodicity** approach exploits the *locality* of the response: a few
+centimetres from the resonant surface, in the ideal region, the potential is the known
+aligned-MHD solution plus a small FLR2 correction, and it is decoupled from the resonant
+layer. This lets us:
+
+- represent the perturbation in a **periodic Fourier-harmonic basis** `e^{i k_m r}`,
+  `k_m = 2πm/L`, over a **finite radial window** centred on the resonant surface `rm`;
+- build the matrix elements directly from the analytic Fourier-space kernel
+  `G(k_r, k'_r, r_g)` (spec Eq. 15–16), **avoiding the hat-basis transform** entirely;
+- solve a small **dense** system instead of a large sparse one.
+
+### 1.1 Deviation from the spec: keep the true background
+
+The write-up periodizes the background profiles over the window (transition region
+`Δr_tr`, period `L = 2(Δr + Δr_tr)`). **We deliberately do *not* do this.** We keep the
+**true, non-periodic** background inside the window and only truncate the integration to a
+finite region. Consequences:
+
+- No background deformation, no transition region; `Δr_tr` disappears. The single geometric
+  knob is the **window half-width `W = L/2`**.
+- `G(k_r, k'_r, r_g)` is **no longer periodic** in `r_g`, so the spec's "cheap lowest-order
+  equidistant quadrature because `G` is periodic" (Eq. 16) is replaced by an ordinary
+  finite-interval quadrature.
+- The finite-window matrix element is now *itself* the approximation to the exact
+  infinite-domain element (spec Eq. 13). **This is precisely the error we quantify.** Its
+  interpretation is clean: the boundary/truncation term dropped when the periodicity
+  cancellation is not exact, controlled by `W` via kernel locality.
+
+This is more honest than deforming the background: rather than an uncontrolled deformation,
+we accept a truncation whose error is directly measurable.
+
+---
+
+## 2. Resolved design decisions
+
+| # | Topic | Decision |
+|---|-------|----------|
+| 1 | Deliverable | Working finite-periodic Fourier solver **and** a quantified periodization error. |
+| 2 | Integration | New `electrostatic_periodic_t` run-type behind the `kim_solver_t` seam; reuses config/grid/species/equilibrium and the FP susceptibility functions. |
+| 3 | System | **Electrostatic**, mirroring the existing `electrostatic` run-type: `(Δ + 4π K^{ρΦ}) Φ = −4π K^{ρB} Br`. |
+| 4 | Kernel | **Full FP** kernel `G(k_r,k'_r,r_g)` (thesis Eq. 14.3–14.4), evaluated at **`m_φ = 0` by default**. |
+| 5 | Kernel source | Fuse the FP susceptibility assembly (`calc_hatK_Phi_in_Fourier`) with the off-diagonal two-wavenumber structure (deprecated k-space integrand). |
+| 6 | Basis / window | Periodic Fourier harmonics on the finite window; `ρ_L`-anchored resolution; three-knob convergence. |
+| 7 | R1 | Solve for the deviation `ψ = δΦ − Φ_MA`; first-cut naive `Φ_MA` projection, then measure. |
+| 8 | Error strategy | **A** window-convergence + **B** cross-check vs the `electrostatic`-global solver; metric = resonant-layer `δΦ(r)`. |
+| 9 | Validation floor | Diagonal-collapse + homogeneous kernel unit tests; a frozen golden case. Approx-vs-approx for cross-check (no analytic anchor initially). |
+
+---
+
+## 3. Physics core
+
+### 3.1 The Fourier-space kernel `G(k_r, k'_r, r_g)`
+
+The charge-density response is `δρ(r) = ∫ dr' K^{ρΦ}(r,r') δΦ(r')` (spec Eq. 10). The kernel
+has the continuous Fourier-space representation (spec Eq. 14–15)
+
+```
+K^{ρΦ}_{k_r,k'_r} = ∫ dr_g G(k_r, k'_r, r_g),
+```
+
+so the finite-window matrix element in the periodic basis is (spec Eq. 16, but over the
+**true** non-periodic background):
+
+```
+K^{ρΦ}_{m,m'} = (2π/L) ∫_{rm−W}^{rm+W} dr_g  G(k_m, k_{m'}, r_g).
+```
+
+**Where `G` lives in the code (verified):**
+
+- **Diagonal `G(k_r, k_r, r_g)`** is already implemented in
+  `KIM/src/asymptotics/FLR2_asymptotics.f90 :: calc_hatK_Phi_in_Fourier`. It assembles all
+  four kernels (ρΦ, ρB, jΦ, jB) from the FP susceptibility functions
+  (`A1, A2, I00, I20, I01, I21, I11, I13, ν, vₜ, ω_c, λ_D`) at a *single* wavenumber
+  (`b = k_r² ρ_L²`). It is currently a **diagnostic** (loops over hardcoded
+  `k_r ∈ {0.1, 1, 5}`, writes to files), not a matrix builder.
+- **Off-diagonal two-wavenumber structure** (`b_+`, `b_×`, and the phase
+  `exp(i(k_r − k'_r) r_g)`) exists in git history in `src/deprecated/integrands.f90`
+  (`integrand_K_rho_phi_krp`, developed across commits
+  `9d78ee34 → 292eeb68 → 4f6b1adf → bfa9d70c`), but in the **plasma-Z (Krook)** flavour.
+
+**Neither source alone is the FP off-diagonal `G`.** The revival is a *fusion*: lift the FP
+susceptibility assembly (from `calc_hatK_Phi_in_Fourier`) to two wavenumbers using the
+off-diagonal FLR structure
+
+```
+b_+ = vₜ²/(2ω_c²) (2k_s² + k_r² + k'_r²)
+b_× = vₜ²/ω_c²  √(k_s² + k_r²) · √(k_s² + k'_r²)
+```
+
+with `exp(−b_+)`, `I₀(b_×)`, `I₋₁(b_×)` (full Bessel functions, plus the large-argument
+asymptotics already in the deprecated code), and the Fourier phase `exp(i(k_r − k'_r) r_g)`.
+In the deprecated code the two-wavenumber dependence enters *only* through these FLR factors
+and the phase, while the susceptibility coefficients stay local at `r_g` — so the lift is
+structurally well-defined.
+
+### 3.2 Cyclotron-harmonic truncation (`m_φ = 0`)
+
+Thesis Eq. 14.3–14.6 give the FP kernels with an **explicit, unresolved sum over cyclotron
+harmonics** `Σ_{m_φ}`, each carrying `I_{m_φ}(b_×)`, `I_{m_φ−1}(b_×)` and a harmonic-shifted
+collisionality `x₂ = −(ω_E + m_φ ω_c − ω)/ν_σ` (Eq. 14.2). The thesis leaves resolving this
+sum as future work.
+
+**Decision:** target the full FP kernel structure but evaluate **`m_φ = 0` only by default**.
+For `m_φ ≠ 0`, `x₂ ≈ m_φ ω_c / ν` is very large, and the FP susceptibility functions
+`I^{kl}(x₁, x₂)` are strongly suppressed (the cyclotron resonances are far off-resonance and
+collisionally damped). Keep `m_φ` as a structurally-present loop (default range `{0}`) so a
+harmonic can be switched on to *verify* its smallness, but it never runs by default.
+
+### 3.3 Gap-2 sign (resolved)
+
+At the diagonal (`m_φ = 0`, `b_+ = b_× = b`), `calc_hatK_Phi_in_Fourier` uses the coefficient
+`A₂·(1 − b)`, whereas thesis Eq. 14.3 reads `A₂·(1 + b_+)`. **The code sign is authoritative**
+(user-confirmed); `calc_hatK_Phi_in_Fourier` is the kernel source of truth, and the thesis
+`(1 + b_+)` is a documentation discrepancy — do **not** propagate it.
+
+### 3.4 The linear system (electrostatic)
+
+Mirroring the `electrostatic` run-type (`electrostatic_poisson/poisson.f90` +
+`solve_poisson.f90`), in the Fourier basis:
+
+```
+[ D_m δ_{m,m'} + 4π K^{ρΦ}_{m,m'} ] Φ_{m'} = −4π K^{ρB}_{m,m'} Br_{m'},
+```
+
+with `D_m` the Fourier-space Poisson operator (`−k_m²` up to the radial-operator convention)
+and `Br_{m'}` the Fourier coefficients of the external radial-field drive over the window
+(trivial for the default `type_br_field = 12`, a constant `Br` → `m = 0` only). Dense complex
+solve (LAPACK `zgesv`) for `Φ_m`, then reconstruct `δΦ(r) = Σ_m Φ_m e^{i k_m r}`.
+
+Only `K^{ρΦ}` and `K^{ρB}` are needed for the electrostatic solve. The current-diagnostic
+kernels `K^{jΦ}, K^{jB}` (Eq. 14.5–14.6) are deferred.
+
+### 3.5 R1 — solve for the deviation from the aligned potential
+
+A periodic Fourier basis implicitly forces `δΦ(rm−W) = δΦ(rm+W)`, but the true `δΦ` tends to
+the (non-periodic) aligned potential at the edges → Gibbs oscillations. Mitigation: solve for
+the **deviation** `ψ = δΦ − Φ_MA`, which is localized to the resonant layer and decays to ~0
+at the edges (periodic-basis-friendly). `Φ_MA` is already computed by
+`calc_flr2_asymptotic_Phi_MA` (output `EBdat%Phi_MA_asymptotic`).
+
+Substituting `Φ = Φ_MA + ψ` into `L Φ = g` (with `L = Δ + 4π K^{ρΦ}`,
+`g = −4π K^{ρB} Br`):
+
+```
+L ψ = g − L Φ_MA  ≡  s.
+```
+
+The source `s` is physically **localized** (Φ_MA solves the equation in the ideal region, so
+`s ≈ 0` there), hence its Fourier projection is clean. The only difficulty is computing
+`L Φ_MA = ΔΦ_MA + 4π K^{ρΦ} Φ_MA`: the `K^{ρΦ} Φ_MA` term needs `Φ_MA`'s Fourier
+coefficients, and `Φ_MA` is non-periodic at the edges.
+
+**Approach (tracer-bullet):** first-cut **naive projection** of `Φ_MA` with ample modes;
+get the pipeline running; use strategy A to measure whether the residual Gibbs actually
+degrades `ψ`-convergence for the (6,2) case. Escalate to (a) an analytic FLR2 localized-source
+derivation, or (b) polynomial/ramp subtraction, **only if measured necessary**.
+
+**Note:** R1 is new machinery — the existing `electrostatic` solver solves for the full `Φ`
+directly and uses `Φ_MA_asymptotic` only as a diagnostic.
+
+---
+
+## 4. Numerics
+
+### 4.1 Window and spectral resolution — `ρ_L`-anchored, three-knob
+
+Anchor length scale: the ion Larmor radius `ρ_L` at the resonant surface `rm`.
+
+- `k_max ≈ c_k / ρ_L` (default `c_k ≈ 5`) — resolve `ρ_L`-scale structure.
+- `W = L/2 ≈ c_W · ρ_L` (default `c_W ≈ 15`) — contain the decayed deviation `ψ`.
+- `M = k_max · W / π ≈ 24` → ~50 harmonics → a trivial dense `50×50` complex solve
+  (validates the write-up's "minutes" claim; the hypothetical "1000" basis functions is a
+  comfortable ceiling).
+- `N_rg` (r_g quadrature points): the window is exactly one period `L`, so the phase
+  `exp(i 2π(m−m') r_g / L)` completes whole cycles and equidistant sampling is *spectrally*
+  accurate for the smooth part → `N_rg ≳ 4M`.
+
+**Three convergence knobs** (used by strategy A):
+
+1. `M` / `k_max` — spectral/basis error → converge to negligible.
+2. `N_rg` — quadrature error → converge to negligible.
+3. `W` — physical domain-truncation error → **the periodization error knob**; its plateau
+   residual *is* the reported error bar.
+
+**Subtlety:** because the true susceptibility is not periodic over the window, the `r_g`
+quadrature residual is entangled with the physical truncation error — both stem from the same
+non-periodicity. Report `M` and `N_rg` convergence separately from the `W` scan so the
+physical error is not conflated with numerical error.
+
+### 4.2 Assembly
+
+For each `(m, m')`, evaluate `G(k_m, k_{m'}, r_g)` on the `N_rg` grid over the window (FP
+susceptibility coefficients local at `r_g` × two-wavenumber FLR factors × phase) and quadrature
+to `K^{ρΦ}_{m,m'}` / `K^{ρB}_{m,m'}`. Cost `~ M² · N_rg · n_species` susceptibility
+evaluations — negligible at `M ~ 50`. The matrix is dense and **not** Toeplitz (the FLR
+factors depend on both `k_m` and `k_{m'}`, not just their difference).
+
+### 4.3 Boundary conditions
+
+None imposed explicitly: the periodic Fourier basis is inherently periodic, and the deviation
+formulation (`ψ → 0` at the edges) provides well-posedness. No Dirichlet plumbing.
+
+---
+
+## 5. Error quantification
+
+### 5.1 Strategy A — window convergence (self-consistent error bar)
+
+Scan the three knobs. With `M` and `N_rg` converged, grow `W`, extract `δΦ(r)` on the
+resonant layer `|r − rm| ≤ Δr` (`Δr` = a few `ρ_L`, diagnostic-only), and report the Cauchy
+residual `‖δΦ_i − δΦ_{i−1}‖ / ‖δΦ_i‖` in both L2 and max-norm. The plateau value at the
+largest affordable `W` is the self-consistent periodization error bar.
+
+### 5.2 Strategy B — cross-check vs the `electrostatic`-global solver
+
+Run the existing `electrostatic` (global, hat-basis) run-type and the periodic run-type on the
+**same** (6,2) case (`m_mode = −6`, `n_mode = 2`, resonant at `q = 3`, constant `Br`);
+interpolate both `δΦ(r)` to a common resonant-layer grid; report
+`‖δΦ_periodic − δΦ_global‖ / ‖δΦ_global‖`. Same physics on both sides → isolates the
+finite-window + Fourier approximation.
+
+**Caveat (accepted):** the global solver carries its own approximations (the basis transform
+we are avoiding), so B is approx-vs-approx. An analytic anchor (homogeneous manufactured case)
+is deferred; a small `δΦ_periodic − δΦ_global` on the localized (6,2) case is nonetheless
+strong evidence.
+
+---
+
+## 6. Architecture
+
+New run-type `electrostatic_periodic_t` (module `rt_electrostatic_periodic_m`) implementing
+`class(kim_t)`, registered in the factory (`KIM/src/general/KIM_mod.f90 ::
+from_kim_factory_get_kim`) under `type_of_run = "electrostatic_periodic"`. It reuses,
+unchanged: config parsing, `grid_m`, `species_m`, `equilibrium_m`, and the FP susceptibility
+functions on the profile grid. Output `δΦ(r)` is packed into the same `kim_results_t`
+(`Es, Er, …, Phi`) so cross-check B and golden-record CI come almost for free.
+
+**Solve pipeline** for a given `rm` and `(m, n)`:
+
+1. Sample the **true** background on an equidistant `r_g` grid over `[rm−W, rm+W]`.
+2. Build the Fourier basis `k_m = 2πm/L`, `m = −M…M`.
+3. Assemble the dense `K^{ρΦ}_{m,m'}`, `K^{ρB}_{m,m'}` (§4.2).
+4. Form the R1 deviation source `s` (§3.5, naive-projection first-cut).
+5. Dense `zgesv` solve for `ψ_m`; reconstruct `ψ(r)`; add back `Φ_MA` → `δΦ(r)`.
+6. Pack into `kim_results_t`.
+
+---
+
+## 7. Testing & CI
+
+1. **Kernel unit tests.** The fused off-diagonal `G(k_r,k'_r,r_g)` must collapse to
+   `calc_hatK_Phi_in_Fourier` on the diagonal `k_r = k'_r` (exact regression anchor) and to
+   analytic limits (homogeneous background, `b → 0`).
+2. **Assembly test.** Matrix elements vs a brute-force quadrature reference.
+3. **Solver integration test.** Homogeneous case with a known `δΦ`.
+4. **Physics validation.** Strategies A and B as CI-tracked cases.
+5. **Golden record.** Freeze one periodic (6,2) case in `test/golden/kim` so the numbers are
+   pinned against regressions.
+
+Robustness: reuse the seam's status codes (`KIM_SOLVE_FAILED`, `KIM_GRID_COVERAGE`); report the
+dense-solve condition number; fail soft, never halt the host; handle resonance-near-edge and
+singular-matrix degeneracies explicitly.
+
+---
+
+## 8. Risks
+
+- **R1 — periodic-basis edge mismatch.** Mitigated by the deviation formulation; residual
+  handling escalates only if the first-cut naive projection is measured insufficient (§3.5).
+- **R2 — oscillatory `r_g` quadrature.** The phase oscillates fast for large `|k_r − k'_r|`;
+  managed by `N_rg ≳ 4M` (spectral accuracy over one period) plus the entanglement caveat
+  (§4.1).
+- **R3 — the magnetic drive.** `Br_{m'}` specification/normalization; trivial for the default
+  constant `Br`, needs care for richer field models.
+- **R4 — cost / conditioning** of the dense `(2M+1)²` solve as `M ∝ W`; expected trivial at
+  `M ~ 50`, monitored via condition number.
+- **R5 — kernel fusion correctness.** The FP off-diagonal `G` is derived by fusion, not copied;
+  the diagonal-collapse unit test is the primary guard.
+
+---
+
+## 9. Baked-in assumptions
+
+- **Kernel scope:** only `K^{ρΦ}` + `K^{ρB}`; current-diagnostic kernels `K^{jΦ}, K^{jB}`
+  deferred.
+- **Boundary conditions:** none explicit (periodic basis + `ψ → 0`).
+- **Drive:** `Br` projected onto the Fourier basis over the window; trivial for
+  `type_br_field = 12`.
+
+---
+
+## 10. Implementation phasing (tracer-bullet)
+
+1. **Kernel `G`** — fuse FP susceptibility assembly + off-diagonal structure; diagonal-collapse
+   unit test. Pure physics, no solver.
+2. **Assembly + dense solve** — `electrostatic_periodic_t`, direct-`Φ` first (no R1);
+   homogeneous sanity test.
+3. **Cross-check B** — wire the `δΦ(r)` comparison vs `electrostatic`-global on (6,2).
+4. **R1 deviation** — add the `ψ` formulation; measure Gibbs impact.
+5. **Strategy A + golden** — three-knob convergence harness; freeze the golden case; CI.
+
+---
+
+## 11. Out of scope / future work
+
+- **Toroidal geometry** (spec §C): the sub-integrand `G` is no longer a 1D integral; requires
+  numerical guiding-centre orbit integrals (POTATO infrastructure).
+- **Electromagnetic extension:** the same finite-window Fourier assembly applied to the coupled
+  `(Φ, A_par)` block (mirroring `electromagnetic_t`).
+- **Higher cyclotron harmonics** (`m_φ ≠ 0`): switch-on path exists for verification; not run by
+  default.
+- **Analytic anchor:** a homogeneous manufactured true-reference for strategy B.
+- **Full-FP harmonic sum:** resolving `Σ_{m_φ}` analytically (the thesis' open problem).
+
+---
+
+## 12. Key references (code + theory)
+
+- **Fourier kernel (diagonal, FP):** `KIM/src/asymptotics/FLR2_asymptotics.f90 ::
+  calc_hatK_Phi_in_Fourier`.
+- **Aligned potential `Φ_MA`:** same file, `calc_flr2_asymptotic_Phi_MA`.
+- **Off-diagonal k-space integrand (git history, Krook):** `src/deprecated/integrands.f90 ::
+  integrand_K_rho_phi_krp` @ `bfa9d70c` (and `9d78ee34 → 292eeb68 → 4f6b1adf`).
+- **Electrostatic solve to mirror:** `KIM/src/electrostatic_poisson/poisson.f90`,
+  `solve_poisson.f90`.
+- **Solver seam:** `KIM/src/general/kim_solver_m.f90`; factory `KIM/src/general/KIM_mod.f90`.
+- **Theory:** spec Eq. 9–16; thesis Ch. 13 (Krook kernels, §13.7 dispersion), Ch. 14 (FP
+  kernels Eq. 14.1–14.6), Ch. 15 (variational implementation).

--- a/docs/plans/2026-07-10-kim-forced-periodicity-design.md
+++ b/docs/plans/2026-07-10-kim-forced-periodicity-design.md
@@ -28,25 +28,33 @@ layer. This lets us:
   `G(k_r, k'_r, r_g)` (spec Eq. 15–16), **avoiding the hat-basis transform** entirely;
 - solve a small **dense** system instead of a large sparse one.
 
-### 1.1 Deviation from the spec: keep the true background
+### 1.1 Periodize the background (per the spec; REVISED 2026-07-10)
 
-The write-up periodizes the background profiles over the window (transition region
-`Δr_tr`, period `L = 2(Δr + Δr_tr)`). **We deliberately do *not* do this.** We keep the
-**true, non-periodic** background inside the window and only truncate the integration to a
-finite region. Consequences:
+**Earlier this design deviated from the spec by keeping the true, non-periodic background and
+truncating the integration (single knob `W = L/2`). That decision is REVERSED: we follow the
+spec and periodize the background**, reusing the author's existing periodization code
+(`~/1_projects/KIM_forced_periodicity/FORCED_PERIODICITY/SRC/make_periodic.f90`,
+`localizer.f90`).
 
-- No background deformation, no transition region; `Δr_tr` disappears. The single geometric
-  knob is the **window half-width `W = L/2`**.
-- `G(k_r, k'_r, r_g)` is **no longer periodic** in `r_g`, so the spec's "cheap lowest-order
-  equidistant quadrature because `G` is periodic" (Eq. 16) is replaced by an ordinary
-  finite-interval quadrature.
-- The finite-window matrix element is now *itself* the approximation to the exact
-  infinite-domain element (spec Eq. 13). **This is precisely the error we quantify.** Its
-  interpretation is clean: the boundary/truncation term dropped when the periodicity
-  cancellation is not exact, controlled by `W` via kernel locality.
+The background is made periodic over period `L = 2(Δr + Δr_tr)`: the **as-is** region
+`[rm − Δr, rm + Δr]` (`Δr = dx_asis`) keeps the true background, and a **transition** region
+of half-width `Δr_tr = dx_tr` on each side uses `localizer` — a C∞ transition
+`exp(−2π/(1−t)·exp(−√2/t))` — to blend smoothly into the periodic images so all derivatives
+stay continuous. Consequences:
 
-This is more honest than deforming the background: rather than an uncontrolled deformation,
-we accept a truncation whose error is directly measurable.
+- `G(k_r, k'_r, r_g)` **is** periodic in `r_g` (spec §; memo eq. `matelrhoPhi_discr`), so the
+  matrix element `K_{m,m'} = (2π/L) ∫_{rm−L/2}^{rm+L/2} dr_g G(k_m,k_{m'},r_g)` is evaluated
+  with **cheap lowest-order equidistant quadrature** that is spectrally exact over one period.
+- Two geometric knobs: `Δr` (as-is half-width — controls how much of the resonant layer is
+  kept true) and `Δr_tr` (transition half-width — controls smoothness of the periodic
+  extension); together `L = 2(Δr + Δr_tr)`.
+- The error to quantify is now the **periodization deformation** — how much periodizing the
+  background outside the as-is layer perturbs the resonant-layer solution — controlled by
+  `Δr` (larger `Δr` ⇒ less deformation). This replaces the truncation-error interpretation.
+
+The FP kernel `G` is unchanged by this choice (the memo assembles the matrix element from the
+same `G`); periodization affects only how the background is **sampled** and how the `r_g`
+integral is discretized.
 
 ---
 

--- a/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase1.md
+++ b/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase1.md
@@ -1,0 +1,419 @@
+# KIM Forced-Periodicity — Phase 1 (Fused FP Fourier Kernel) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan
+> task-by-task. Each code task is TDD (red → green → commit).
+
+**Goal:** Deliver a tested Fortran function giving the fused Fokker–Planck off-diagonal
+Fourier-space kernel integrand `Ĝ^{ρΦ}(k_r, k'_r, r_g)` (and `Ĝ^{ρB}`), which collapses
+**exactly** to the existing diagonal source-of-truth `calc_hatK_Phi_in_Fourier` when
+`k_r = k'_r`. Pure physics; no solver, no run-type yet (those are Phase 2+).
+
+**Architecture:** Extract the per-species diagonal integrand from
+`calc_hatK_Phi_in_Fourier` into a shared, reusable function, then generalize it to two
+wavenumbers by (a) replacing the FLR argument `b = k_r² ρ_L²` with the symmetric pair
+`b₊ = ρ_L²(k_r²+k'_r²)/2`, `b× = ρ_L²|k_r k'_r|`, and (b) multiplying by the Fourier phase
+`exp(i(k_r−k'_r) r_g)`. Because the generalized form reduces to the diagonal expression
+term-by-term at `k_r=k'_r` (phase → 1, `b₊=b×=b`), collapse is exact **by construction**;
+the collapse test is a regression guard. Everything reuses the KIM `plasma_t`/`species_t`
+backgrounds sampled on the guiding-centre grid `rg_grid%xb`.
+
+**Tech Stack:** Fortran (gfortran 14, `-O3 -fcheck=all`), `fortnum_special::bessel_in`
+(unscaled modified Bessel Iₙ), KIM custom `error stop`/`stop 1` unit-test harness under
+`KIM/tests/`, CTest. Build: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release &&
+cmake --build build`; test: `ctest --test-dir build --output-on-failure`.
+
+---
+
+## DECISION (ks² convention — RESOLVED 2026-07-10: keep k_s² behind a toggle)
+
+The diagonal source-of-truth `calc_hatK_Phi_in_Fourier`
+(`KIM/src/asymptotics/FLR2_asymptotics.f90:195-199`) deliberately uses the FLR argument
+
+```
+b = k_r² · ρ_L²          ! k_s² DROPPED — comment: "k_s diverges at r=0"
+```
+
+whereas the design doc (§3.1) and the deprecated Krook off-diagonal integrand
+(`bfa9d70c:src/deprecated/integrands.f90`) use the **full perpendicular** argument
+(`k_s²` KEPT). These disagree off-diagonal, and at the diagonal (`k_r=k'_r`) they agree
+**only if `k_s=0`**.
+
+**RESOLUTION (author decision): implement BOTH behind a toggle** `kern_include_ks2`
+(module variable in `flr2_fourier_kernel_m`, `logical, save, public`, **default `.false.`**):
+
+```
+kern_include_ks2 = .false.  (DEFAULT — drop k_s²; exact collapse to calc_hatK_Phi_in_Fourier)
+    b₊ = ρ_L² (k_r² + k'_r²)/2 ,          b× = ρ_L² |k_r k'_r|
+
+kern_include_ks2 = .true.   (design §3.1 full form)
+    b₊ = ρ_L² (2k_s² + k_r² + k'_r²)/2 ,  b× = ρ_L² √(k_s²+k_r²)·√(k_s²+k'_r²)
+```
+
+Both forms are expressed in terms of the diagonal's `ρ_L²` (which carries
+`ion_flr_scale_factor`, default `1.0`) — so the `k_s²` term is also scaled by that factor;
+acceptable and default-neutral. `k_s = plasma%ks(j)`.
+
+**Testing consequence:**
+- Default path (`.false.`): **exact** diagonal collapse to `calc_hatK_Phi_in_Fourier`
+  (Task 3). This is the primary R5 guard.
+- Toggle path (`.true.`): collapse cannot match the ks-dropped diagonal; instead assert (new
+  Task 3b) that at `k_r=k'_r` it equals the diagonal FP expression fed `b_full=(k_s²+k_r²)ρ_L²`
+  (a structural exact check via the shared `core_*_sp(bplus,bcross,j)` helper — no need to
+  manufacture `k_s=0`).
+
+---
+
+## Reconciliation with GitHub issue #175 (RESOLVED 2026-07-10)
+
+Issue #175 ("revive Fourier-space solver via enforced radial periodicity") covers the same
+goal from the Kasilov memo's angle. Two forks were decided by the author:
+
+- **Kernel flavor → stay Fokker–Planck** (design decision #4), NOT restore the issue's Krook
+  kernel. The recoverable `1ae0aeeb~1:KIM/src/kernels/kernel_mod.f90` (module `kernels_m`,
+  `kernel_rho_phi_of_kr_krp_rg`/`kernel_rho_B_of_kr_krp_rg`) is **Krook/plasma-Z**, normalized
+  `/(2³π²)`. We use it as a **reference only**, not restored:
+  - it **validates our `b₊/b×`**: `eval_bp = ρ_L²/2·(kperp²+kperpp²)`,
+    `eval_bt = ρ_L²·kperp·kperpp` — identical shape to `hatG_rho_phi`;
+  - it carries the **large-argument Bessel asymptotics** (`bessel_large_arg_limit` branch,
+    `exp(bt−bp)/√(2π bt)` etc.) — lift this for Task 6 (adapt `gsl_sf_bessel_In` → `bessel_in`);
+  - its `fill_rho_kernels` is the ready-made **Phase-2 assembly inner loop** (3-D
+    `(kr,krp,rg)` grid).
+- **Background → periodize** (REVISED 2026-07-10, superseding the earlier truncate decision).
+  Adopt the author's existing periodization code
+  (`~/1_projects/KIM_forced_periodicity/FORCED_PERIODICITY/SRC/`: `make_periodic.f90`,
+  `localizer.f90`) — sample the background *periodically* over one period
+  `L = 2(Δr + Δr_tr)` (`Δr` = as-is half-width `dx_asis`, `Δr_tr` = transition half-width
+  `dx_tr`), with `localizer` (a C∞ transition, `exp(-2π/(1-t)·exp(-√2/t))`) blending the
+  as-is layer into the periodic images so all derivatives stay continuous.
+
+  **Key consequence (memo eq. `matelrhoPhi_discr`):** the matrix element uses the SAME `G` we
+  built — `K^{ρΦ}_{m,m'} = (2π/L) ∫_{rm−L/2}^{rm+L/2} dr_g G(k_m, k_{m'}, r_g)` — and because
+  the periodized background makes `G(k_m,k_{m'},r_g+L)=G(k_m,k_{m'},r_g)` periodic, the `r_g`
+  integral over one period is spectrally exact with equidistant (lowest-order) quadrature.
+  **Phase-1 kernel work is therefore fully reused, unchanged.** What changes is Phase 2
+  (background sampling → periodic via `make_periodic`; equidistant one-period `r_g` grid) and
+  Phase 5 (error to quantify = periodization *deformation* controlled by `Δr`, not truncation;
+  strategy A scans `Δr`, and `Δr_tr` controls smoothness).
+
+**`k_s²` note:** the canonical `kernel_mod.f90` sets `kperp = √(ks²+kr²)` — i.e. it **includes
+`k_s²`** (= our `kern_include_ks2=.true.` path). Our FP diagonal source-of-truth drops `k_s²`
+(an r=0 diagnostic hack). We keep the toggle **default `.false.`** (exact diagonal collapse) as
+decided, but record that the physically-canonical form is `.true.`.
+
+**Adopt from the issue regardless:** the orphaned `test_kernel_rho_phi.f90` analytic Debye
+value `−1/(2³π²λ_D²)` is a concrete anchor — but that is the **Krook `/(2³π²)` normalization**;
+our FP kernel is `/(4π)` with a different adiabatic term, so the FP Debye limit differs. Our
+Task 4 (`b→0` closed form) is the FP analogue; a full FP Debye cross-check is a Phase-5 item.
+The Vaclavik cross-benchmark (issue) → Phase 5.
+
+## Ground truth captured during planning (so the executor has zero guesswork)
+
+- **Diagonal ρΦ integrand** — `FLR2_asymptotics.f90:189-249`, module `flr2_asymptotics_m`.
+  Per species `sp`, per rg-grid index `j`, with `b = kr²·plasma%spec(sp)%rho_L(j)²`:
+  - Debye term (if `artificial_debye_case <= 1`): `-1/λ_D(j)²`.
+  - FP term (if `artificial_debye_case == 0 .or. == 2`):
+    `(1/λ_D²)·i·vT²·ks/(ω_c·ν)·exp(-b)·[ I00(j,0)·(I₀(b)·(A1+A2·(1-b)) + A2·b·I₋₁(b)) + ½·I20(j,0)·A2·I₀(b) ]`
+    where `I₀=bessel_in(0,b)`, `I₋₁=bessel_in(-1,b)`, all `plasma%spec(sp)%…(j)`.
+  - Species-summed, then `kernel_phi = (Σ_sp …)/(4π)`.
+- **Diagonal ρB integrand** — same block, `FLR2_asymptotics.f90:216-224`: identical shape but
+  prefactor `-1/λ_D²·vT³/(ω_c·ν·sol)`, and susceptibility functions `I01(j,0)`, `I21(j,0)`
+  instead of `I00`, `I20`. Also `/(4π)`. (No `com_unit`, no `ks` factor, and negative sign.)
+- **`bessel_in`** is the *unscaled* modified Bessel Iₙ (diagonal multiplies by `exp(-b)`
+  explicitly). `bessel_in(-1,b) = bessel_in(1,b)`. Source: linked `fortnum_special`.
+- **`ρ_L = |vT/ω_c|·ion_flr_scale_factor`** (`species_mod.f90:482-484`);
+  `ion_flr_scale_factor` default `1.0` (`KIM/nmls/KIM_config.nml:14`).
+- **Susceptibility funcs** `I00,I20,I01,I21,I11,I13` are `complex(dp)`, live in `species_t`
+  (`species_mod.f90:49-57`), indexed `(rg-grid j, mphi)`; `mphi=0` is the default harmonic.
+  Populated by `calculate_thermodynamic_forces_and_susc` → `getIfunc(x1,x2,symbI)`, then
+  interpolated to `rg_grid%xb` via `interpolate_plasma_backs`.
+- **Callers of the diagnostic** — `poisson.f90:220`, `flr2_benchmark.f90:161` (both write
+  `hatK_*` files). Only the electromagnetic golden case runs in CI today, so a
+  behavior-preserving refactor of `calc_hatK_Phi_in_Fourier` disturbs no golden record.
+- **Test harness** — CTest programs in `KIM/tests/`, each a `program` that ends `error stop`
+  / `stop 1` on failure, registered in `KIM/tests/CMakeLists.txt` with
+  `target_link_libraries(<t> KIM_lib kilca_lib lapack cerf ddeabm slatec)`. In-memory plasma
+  setup recipe: `test_kim_diagnostics.f90:146-167`
+  (`make_test_profiles` → `write_test_namelist` → `nml_config_path=…` →
+  `profiles_in_memory=.true.` → `kim_init()` → `set_profiles_from_arrays(...)` →
+  `from_kim_factory_get_kim('electrostatic', kim)` → `kim%init()`), which leaves the global
+  `species_m::plasma` populated on the rg grid. The config must set
+  `collision_model = 'FokkerPlanck'` so the susceptibility functions are computed.
+- **New source registration** — add the new file to `set(KIM_asymptotics …)` in
+  `KIM/src/CMakeSources.in` (currently one line: `asymptotics/FLR2_asymptotics.f90`).
+
+---
+
+## Task 1: De-risk the test harness — new module + a test that gets a populated plasma
+
+Prove we can (a) create a new asymptotics module and link a new CTest program, and (b) obtain
+a fully-populated `plasma` (with rg-grid susceptibility functions) inside a unit test —
+BEFORE writing any kernel math.
+
+**Files:**
+- Create: `KIM/src/asymptotics/flr2_fourier_kernel.f90`
+- Modify: `KIM/src/CMakeSources.in` (append to `KIM_asymptotics`)
+- Create: `KIM/tests/test_flr2_fourier_kernel.f90`
+- Modify: `KIM/tests/CMakeLists.txt` (register the new test)
+
+**Step 1 — Create the module stub.**
+
+```fortran
+module flr2_fourier_kernel_m
+    ! Fused Fokker-Planck off-diagonal Fourier-space kernel integrand
+    ! G(k_r, k'_r, r_g) for the forced-periodicity solver. Collapses to the
+    ! diagonal source-of-truth calc_hatK_Phi_in_Fourier at k_r = k'_r.
+    use KIM_kinds_m, only: dp
+    use species_m, only: plasma_t
+    implicit none
+    private
+    public :: hatG_rho_phi, hatG_rho_B
+contains
+    complex(dp) function hatG_rho_phi(plasma_in, kr, krp, j) result(G)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        G = (0.0_dp, 0.0_dp)   ! stub — replaced in Task 3
+    end function hatG_rho_phi
+
+    complex(dp) function hatG_rho_B(plasma_in, kr, krp, j) result(G)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        G = (0.0_dp, 0.0_dp)   ! stub — replaced in Task 5
+    end function hatG_rho_B
+end module flr2_fourier_kernel_m
+```
+
+**Step 2 — Register the source.** In `KIM/src/CMakeSources.in`, change
+`set(KIM_asymptotics asymptotics/FLR2_asymptotics.f90)` to also list
+`asymptotics/flr2_fourier_kernel.f90`.
+
+**Step 3 — Write the harness test** `KIM/tests/test_flr2_fourier_kernel.f90`. Copy the
+in-memory setup helpers `make_test_profiles` and `write_test_namelist` from
+`test_kim_diagnostics.f90` (config must have `collision_model='FokkerPlanck'`,
+`type_of_run='electrostatic'`). The `main` program:
+1. runs the setup sequence (profiles → namelist → `kim_init` → `set_profiles_from_arrays` →
+   factory `'electrostatic'` → `kim%init()`);
+2. `use species_m, only: plasma`; picks an interior rg-grid index `j` (e.g. `rg_grid%npts_b/2`);
+3. asserts `plasma%spec(0)%I00(j,0)` is finite and `plasma%spec(0)%rho_L(j) > 0` and
+   `plasma%spec(0)%lambda_D(j) > 0` (i.e. the background really is populated);
+4. calls `hatG_rho_phi(plasma, 1.0_dp, 1.0_dp, j)` and prints it;
+5. prints `All tests PASSED`; `stop 0`.
+
+> If `kim%init()` alone does not populate `plasma%spec%I00` on the rg grid, trace the
+> electrostatic setup (`poisson.f90` init/run before line 220) to find the routine that runs
+> `calculate_thermodynamic_forces_and_susc` + `interpolate_plasma_backs`, and call up to that
+> point. Resolving this is the whole point of Task 1 — do not proceed to Task 2 until a unit
+> test can read a populated `plasma%spec(0)%I00(j,0)`.
+
+**Step 4 — Register the test** in `KIM/tests/CMakeLists.txt` (mirror an existing block):
+
+```cmake
+add_executable(test_flr2_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_fourier_kernel.f90)
+set_target_properties(test_flr2_fourier_kernel PROPERTIES
+                        OUTPUT_NAME test_flr2_fourier_kernel.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_flr2_fourier_kernel KIM_lib kilca_lib lapack cerf ddeabm slatec)
+add_test(NAME test_flr2_fourier_kernel
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_fourier_kernel.x)
+```
+
+**Step 5 — Build & run.**
+Run: `cmake --build build --target test_flr2_fourier_kernel.x && ctest --test-dir build -R test_flr2_fourier_kernel --output-on-failure`
+Expected: builds, PASS, prints a finite `I00` and a `(0,0)` kernel stub value.
+
+**Step 6 — Commit.**
+`git add KIM/src/asymptotics/flr2_fourier_kernel.f90 KIM/src/CMakeSources.in KIM/tests/test_flr2_fourier_kernel.f90 KIM/tests/CMakeLists.txt`
+`git commit -m "test(kim): scaffold fused FLR2 Fourier kernel + harness"`
+
+---
+
+## Task 2: Extract the diagonal integrand into a shared function (behavior-preserving)
+
+Make `calc_hatK_Phi_in_Fourier` delegate its per-`(sp,j,kr)` ρΦ and ρB integrand to new
+functions in `flr2_fourier_kernel_m`, so the diagonal math has exactly one home. This is a
+pure refactor — outputs must be byte-identical.
+
+**Files:**
+- Modify: `KIM/src/asymptotics/flr2_fourier_kernel.f90` (add `hatG_rho_phi_diag_sp`,
+  `hatG_rho_B_diag_sp` — per-species, at a single wavenumber `kr`, no phase, no `/(4π)`)
+- Modify: `KIM/src/asymptotics/FLR2_asymptotics.f90:189-249` (call the new functions)
+- Modify: `KIM/tests/test_flr2_fourier_kernel.f90` (add the characterization assertion)
+
+**Step 1 — Write the failing characterization test.** In the test program, after setup,
+add a subroutine `test_diagonal_matches_inline()` that, for `kr ∈ {0.1,1.0,5.0}` and a few
+`j`, computes the diagonal value **two ways**: (i) an inline copy of the exact expression
+from `FLR2_asymptotics.f90:200-248` (Debye + FP term, summed over species), and (ii)
+`sum over sp of hatG_rho_phi_diag_sp(plasma, sp, kr, j)`. Assert
+`abs(inline - fromfunc) < 1e-12 * (1 + abs(inline))`. (The inline copy is the anchor; it is
+deleted in Step 5 once the function is the single source.)
+
+**Step 2 — Run red.**
+Run: `ctest --test-dir build -R test_flr2_fourier_kernel --output-on-failure`
+Expected: FAIL (function returns 0 stub ≠ inline value).
+
+**Step 3 — Implement `hatG_rho_phi_diag_sp` / `hatG_rho_B_diag_sp`** in the module, copying
+the exact per-species Debye + FP expression (ρΦ: `I00`,`I20`; ρB: `I01`,`I21`, its own
+prefactor/sign), honoring `artificial_debye_case`, `turn_off_ions`, `turn_off_electrons`
+from `config_m`. `b = kr²·plasma%spec(sp)%rho_L(j)²`; `I₀=bessel_in(0,b)`,
+`I₋₁=bessel_in(-1,b)`. Do NOT apply `/(4π)` or phase here (caller does).
+
+**Step 4 — Run green.** Expected: PASS.
+
+**Step 5 — Refactor the caller.** Replace the inline bodies at
+`FLR2_asymptotics.f90:200-248` with
+`kernel_phi_temp = kernel_phi_temp + hatG_rho_phi_diag_sp(plasma_in, sp, kr, j)` and the ρB
+analogue (keep the `/(4π)` scaling and file writes untouched). Verify no golden/diagnostic
+change: build `KIM.x`, or if a quick check is unavailable, rely on the byte-identical math
+(the expression moved verbatim).
+
+**Step 6 — Run full KIM test suite.**
+Run: `ctest --test-dir build --output-on-failure`
+Expected: all previously-passing tests still PASS.
+
+**Step 7 — Commit.**
+`git commit -am "refactor(kim): extract diagonal FLR2 Fourier integrand to shared fn"`
+
+---
+
+## Task 3: Generalize to two wavenumbers (b₊, b×, phase) — default (drop k_s²) path
+
+**Prerequisite:** ks² convention resolved (keep-k_s²-behind-toggle; see top).
+
+**Files:**
+- Modify: `KIM/src/asymptotics/flr2_fourier_kernel.f90` (add `kern_include_ks2` module var,
+  private `core_rho_phi_sp(plasma,sp,bplus,bcross,j)`, implement `hatG_rho_phi`; refactor
+  `hatG_rho_phi_diag_sp` to call `core_rho_phi_sp` with `bplus=bcross=b`)
+- Modify: `KIM/tests/test_flr2_fourier_kernel.f90` (collapse + phase tests)
+
+This task implements ONLY the default path (`kern_include_ks2 = .false.`). Leave the variable
+declared and defaulted `.false.`; the `.true.` branch lands in Task 3b.
+
+**Step 1 — Write the failing collapse test.** `test_collapse_rho_phi()`
+(with `kern_include_ks2 = .false.`): for `kr ∈ {0.1,1.0,5.0}` and several `j`, assert
+`abs(hatG_rho_phi(plasma,kr,kr,j) - dref) < 1e-12*(1+abs(dref))`, where
+`dref = (Σ_sp hatG_rho_phi_diag_sp(plasma,sp,kr,j))/(4π)` (the diagonal value **with** the
+`/(4π)`, phase = 1). Also `test_phase_rho_phi()`: for `kr≠krp`, assert the two-wavenumber
+core is phase-only-different, i.e.
+`abs( hatG_rho_phi(plasma,kr,krp,j)*exp(-ci*(kr-krp)*rg) - hatG_rho_phi(plasma,krp,kr,j)*exp(-ci*(krp-kr)*rg) ) < 1e-12`
+(symmetric `b₊,b×` ⇒ equal cores), with `rg = rg_grid%xb(j)`, `ci=(0,1)`.
+
+**Step 2 — Run red.** Expected: FAIL (stub returns 0).
+
+**Step 3 — Implement the default path.** Introduce the private helper
+`core_rho_phi_sp(plasma,sp,bplus,bcross,j)` holding the per-species FP+Debye expression with
+`exp(-bplus)`, `bessel_in(0,bcross)`, `bessel_in(-1,bcross)`, and `(1-bplus)`. Refactor
+`hatG_rho_phi_diag_sp` (Task 2) to call it with `bplus=bcross = kr²·rho_L²`. Implement
+`hatG_rho_phi`: for each `sp`, compute (default branch)
+`b₊ = rho_L²·(kr²+krp²)/2`, `b× = rho_L²·abs(kr*krp)`, sum `core_rho_phi_sp(...,b₊,b×,j)`,
+then multiply the species sum by `exp(ci*(kr-krp)*rg_grid%xb(j))/(4π)`. Collapse is exact by
+construction (at `kr=krp`, `b₊=b×=kr²rho_L²`, phase=1).
+
+**Step 4 — Run green.** Expected: collapse + phase tests PASS.
+
+**Step 5 — Commit.**
+`git commit -am "feat(kim): fused two-wavenumber FP kernel G^rhoPhi (drop-k_s2 path)"`
+
+---
+
+## Task 3b: k_s²-inclusive path behind `kern_include_ks2` + structural collapse test
+
+**Files:**
+- Modify: `KIM/src/asymptotics/flr2_fourier_kernel.f90` (`hatG_rho_phi` `.true.` branch)
+- Modify: `KIM/tests/test_flr2_fourier_kernel.f90` (`test_collapse_rho_phi_ks2()`)
+
+**Step 1 — Write the failing test** `test_collapse_rho_phi_ks2()`. Set
+`kern_include_ks2 = .true.`. For `kr ∈ {0.1,1.0,5.0}` and several `j`, build the reference by
+calling the shared core at the **full** diagonal argument:
+`ref = (Σ_sp core_rho_phi_sp(plasma,sp,bf,bf,j))/(4π)` with `bf = (plasma%ks(j)²+kr²)*rho_L(j)²`
+per species. Assert `abs(hatG_rho_phi(plasma,kr,kr,j) - ref) < 1e-12*(1+abs(ref))`.
+(`core_rho_phi_sp` must be accessible to the test — either make it `public`, or expose a thin
+public test shim `core_rho_phi_sp_pub`.) Reset `kern_include_ks2 = .false.` at test end so
+later tests keep the default. **Guard:** the default-path tests from Task 3 must still pass
+with the toggle back off.
+
+**Step 2 — Run red** (the `.true.` branch not yet implemented → returns default-path value ≠ ref).
+
+**Step 3 — Implement the `.true.` branch** in `hatG_rho_phi`: with `ks = plasma%ks(j)`,
+`b₊ = rho_L²·(2*ks²+kr²+krp²)/2`, `b× = rho_L²·sqrt(ks²+kr²)*sqrt(ks²+krp²)`; same
+`core`/phase/`(4π)` assembly.
+
+**Step 4 — Run green.** Expected: `test_collapse_rho_phi_ks2` PASS and Task 3 tests still PASS.
+
+**Step 5 — Commit.**
+`git commit -am "feat(kim): k_s2-inclusive FP kernel path behind kern_include_ks2 toggle"`
+
+---
+
+## Task 4: Analytic b→0 / homogeneous limit test
+
+Validate the Bessel/exp assembly against a closed form, independent of the diagonal code.
+
+**Files:** Modify `KIM/tests/test_flr2_fourier_kernel.f90`.
+
+**Step 1 — Write the failing test** `test_zero_wavenumber_limit()`. At `kr=krp=0`:
+`b₊=b×=0`, `exp(0)=1`, `I₀(0)=1`, `I₋₁(0)=0`, phase `=1`. So the closed form per species is
+`debye + (1/λ_D²)·ci·vT²·ks/(ω_c·ν)·[ I00(j,0)·(A1+A2) + ½·I20(j,0)·A2 ]`, summed, `/(4π)`.
+Compute this inline from `plasma%spec` and assert
+`abs(hatG_rho_phi(plasma,0,0,j) - closed) < 1e-12*(1+abs(closed))` at several `j`.
+
+**Step 2 — Run red / Step 3 — (already implemented; should pass) / Step 4 — green.**
+If it fails, the bug is in the Bessel-argument generalization; fix in Task 3's code.
+
+**Step 5 — Commit.** `git commit -am "test(kim): b->0 analytic limit for fused FP kernel"`
+
+---
+
+## Task 5: ρB kernel `hatG_rho_B` — same generalization + tests
+
+**Files:** Modify `flr2_fourier_kernel.f90` (`hatG_rho_B` via shared `core_rho_B_sp`),
+`test_flr2_fourier_kernel.f90` (collapse + b→0 tests for ρB, mirroring Tasks 3–4).
+
+Steps mirror Task 3 **and Task 3b** (default drop-k_s² collapse test → implement default
+branch; then `kern_include_ks2=.true.` structural collapse test → implement `.true.` branch;
+reusing the shared `core_rho_B_sp(plasma,sp,bplus,bcross,j)` helper) and Task 4 (b→0:
+`I₋₁(0)=0`, `I₀(0)=1`). `hatG_rho_B` honors the same `kern_include_ks2` toggle. Commit:
+`git commit -am "feat(kim): fused two-wavenumber FP kernel G^rhoB + tests"`
+
+---
+
+## Task 6: Large-`b×` overflow guard (numerical robustness)
+
+Unscaled `bessel_in(0,b×)` overflows for large `b×` (large `k_r`), even though `exp(-b₊)`
+tames the product (`b₊ ≥ b×` by AM–GM). Lift the scaled/asymptotic branch from the canonical
+`1ae0aeeb~1:KIM/src/kernels/kernel_mod.f90` (`bessel_large_arg_limit` branch:
+`eval_besselI0 = exp(bt-bp)/√(2π bt)`, `eval_besselIm1 = exp(-bp + asinh(-1/bt) + bt√(1+1/bt²))/√(2π bt√(1+1/bt²))`)
+so `exp(-b₊)·I₀(b×)` and `exp(-b₊)·I₋₁(b×)` are evaluated without intermediate overflow. (Same
+form appears in `bfa9d70c:src/deprecated/integrands.f90:157-165`.)
+
+**Files:** Modify `flr2_fourier_kernel.f90` (`core_*_sp` helpers), `test_flr2_fourier_kernel.f90`.
+
+**Step 1 — Write the failing test** `test_large_kr_finite()`: assert
+`hatG_rho_phi(plasma, 50.0_dp, 50.0_dp, j)` is finite (`x == x` and `abs < huge`). With naive
+unscaled Bessel this is NaN/Inf → red.
+
+**Step 2 — Run red.** **Step 3 — Implement** the `if (b× > ~10) then <asymptotic> else
+<bessel_in>` branch computing the combined `exp(-b₊)·Iₙ(b×)` directly. **Step 4 — green.**
+Re-run the collapse test (Task 3) to confirm the branch still matches the diagonal in its
+overlap. **Step 5 — Commit** `git commit -am "fix(kim): overflow-safe Bessel in fused FP kernel"`
+
+---
+
+## Phase 1 exit criteria
+
+- `ctest --test-dir build -R test_flr2_fourier_kernel --output-on-failure` — all green.
+- `ctest --test-dir build --output-on-failure` — no regressions in the existing suite.
+- `hatG_rho_phi`, `hatG_rho_B` public in `flr2_fourier_kernel_m`; diagonal math has one home
+  (shared with `calc_hatK_Phi_in_Fourier`); default-path collapse exact to 1e-12;
+  `kern_include_ks2=.true.` path structurally verified; b→0 limit verified; overflow-safe.
+- `kern_include_ks2` module toggle present, default `.false.`, both paths tested.
+- **Checkpoint — report and wait before Phase 2** (assembly + dense `zgesv` solve + new
+  `electrostatic_periodic_t` run-type).
+
+## Deferred to later phases (recorded so Phase 1 stays scoped)
+
+- A/B convergence comparison of the two `kern_include_ks2` paths — Phase 5 (strategy A).
+- Wiring `kern_include_ks2` to the config namelist (module-var only for now) — Phase 2.
+- Interpolating variant of the kernel onto a window grid `[rm−W, rm+W]` — Phase 2.
+- `mφ ≠ 0` cyclotron harmonics — off by default (design §3.2); switch-on for verification only.
+- Current-diagnostic kernels `K^{jΦ}, K^{jB}` — out of scope (design §9).

--- a/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase2.md
+++ b/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase2.md
@@ -1,0 +1,296 @@
+# KIM Forced-Periodicity — Phase 2 (Periodization + Assembly + Solve) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or
+> subagent-driven-development) to implement this plan task-by-task. Each code task is TDD.
+
+**Goal:** Turn the Phase-1 fused FP kernel into a working forced-periodicity electrostatic
+solver: periodize the background over one period `L = 2(Δr + Δr_tr)`, assemble the dense
+Fourier matrix `K_{m,m'} = (2π/L) ∫ G dr_g`, solve `(D + 4π K^{ρΦ})Φ = −4π K^{ρB}Br` with
+LAPACK `zgesv`, reconstruct `δΦ(r)`, and expose it through a new `electrostatic_periodic`
+run-type.
+
+**Architecture:** Reuse KIM's equilibrium/background machinery on a **redirected grid**: build
+an equidistant window grid `[rm−L/2, rm+L/2]`, populate the plasma primitives (n, Te, Ti, Eᵣ, q)
+with their *periodized* values (via the vendored `make_periodic`), then re-run
+`calculate_equil`/`set_plasma_quantities`/`calculate_thermodynamic_forces_and_susc` so every
+derived quantity (`B0, kp, om_E, ρ_L, λ_D, I00…`) is periodic because it is *derived* from the
+periodic primitives. The Phase-1 kernel `hatG_rho_phi`/`hatG_rho_B` is reused unchanged.
+
+**Tech Stack:** Fortran (gfortran), LAPACK `zgesv`, the vendored `make_periodic`/`localizer`
+(from `~/1_projects/KIM_forced_periodicity/FORCED_PERIODICITY/SRC/`), KIM `plasma_t`/`grid_type`,
+KIM custom `error stop` CTest harness. Build/test as in Phase 1.
+
+---
+
+## DESIGN DECISIONS (baked in; flag at review if any should change)
+
+1. **Redirect `rg_grid`, don't refactor.** `calculate_thermodynamic_forces_and_susc` is
+   hardcoded to the global `rg_grid` (`species_mod.f90:326-445`). The periodic run-type is a
+   standalone run, so it **owns** `rg_grid`: it rebuilds `rg_grid` as the equidistant window and
+   runs the recompute chain on it. (Alternative — parameterize that routine by grid — is more
+   invasive and deferred.)
+2. **Periodize primitives, derive the rest.** Only n, Te, Ti, Eᵣ, q are periodized (via
+   `make_periodic`); `B0, kp, om_E, ρ_L, λ_D`, and the susceptibility functions follow from
+   KIM's existing recompute chain, so they are automatically periodic and mutually consistent.
+   Gradients `dndr, dTdr, dqdr` are recomputed on the window from the periodized profiles.
+3. **Direct `Φ`, no R1.** Periodization makes the solution genuinely `L`-periodic, so the
+   periodic-basis edge mismatch that motivated the R1 deviation formulation (design §3.5) does
+   not arise. Phase 2 solves for the full `Φ` directly. (R1 stays deferred unless a measured
+   Gibbs problem reappears.)
+4. **Expose `δΦ` via `kim_results_t`.** Add a `complex(dp), allocatable :: Phi(:)` field to
+   `kim_results_t` (`kim_solver_m.f90:39-53`) and copy it in `copy_results_from_globals`
+   (`kim_solver_m.f90:256-300`) — needed for cross-check B and golden records.
+5. **ρ_L-anchored defaults, memo-ratio** (config knobs, overridable): keep the memo Fig.1 ratio
+   `Δr : Δr_tr = 1 : 2` at ρ_L-anchored absolute size — `Δr = 5·ρ_L(rm)`, `Δr_tr = 10·ρ_L(rm)`
+   ⇒ `L = 2(Δr+Δr_tr) = 30·ρ_L(rm)`; `k_max = 5/ρ_L(rm)` ⇒
+   `M = ceil(k_max·L/(2π)) = ceil(150/2π) ≈ 24` (~49 modes, `2M+1`); `N_rg ≳ 4M ≈ 100` equidistant
+   `r_g` points. A trivial ~49×49 dense complex solve — comfortably below the memo's "~1000
+   modes, minutes" ceiling. (These are the Phase-3 strategy-A convergence knobs.)
+6. **Benchmark case:** `(m_mode,n_mode) = (−6, 2)`, resonant at `q = 3`, `type_br_field = 12`
+   (constant `Br`), matching the design's strategy-B case.
+
+---
+
+## Ground truth (from Phase-2 investigation; so the executor has zero re-discovery)
+
+**Periodization source** (`~/1_projects/KIM_forced_periodicity/FORCED_PERIODICITY/SRC/`):
+- `make_periodic(aperfuns, nfuns, x_mid, dx_asis, dx_tr, x, funs_per)` — `x_mid=rm`,
+  `dx_asis=Δr`, `dx_tr=Δr_tr`, period `L=2(Δr+Δr_tr)`; keeps `|x−rm|≤Δr` true, blends the
+  transition via `localizer`. `aperfuns(nfuns,x,funs)` is the true-background callback.
+- `localizer(sig, x1, x2, x, weight)` — C∞ transition `exp(-2π/(1-t)·exp(-√2/t))`.
+- Reference output `fort.3`: with `aperfuns=(x, x²)`, `rm=0.5, Δr=0.25, Δr_tr=0.5`, over
+  `x=-1+0.01i` (i=1..300). E.g. `x=-0.99 → (0.51, 0.2601)`, `x=2.0 → (0.5, 0.25)`. Use as the
+  Task-1 regression anchor.
+
+**KIM background machinery** (`KIM/src/background_equilibrium/species_mod.f90`):
+- Primitives: `plasma%spec(sp)%n/T/dndr/dTdr`, `plasma%q/Er/r_grid`, `plasma%grid_size`.
+- Evaluate a profile at arbitrary radius: `binsrc(r_grid,1,n,x,ir)` + `plag_coeff(4,nder,x,
+  r_grid(ibeg:iend),coef)` then `sum(coef(0,:)*f(ibeg:iend))` (`util/plag_coeff.f90`;
+  example `calculate_equil.f90:169-180`).
+- Recompute chain `set_plasma_quantities(plasma)` (`:250-276`): `calculate_plasma_backs(plasma)`
+  (grid-size-aware; `:447-561`) → `interpolate_plasma_backs(plasma, grid(:))` (grid-parameterized;
+  `:734-799`) → `calculate_thermodynamic_forces_and_susc(plasma)` (**hardcoded `rg_grid`**;
+  `:326-445`, `getIfunc` for `I00…`).
+- Grid `grid_type` (`grid/grid_mod.f90:44-63`): `%xb(:), %xc(:), %npts_b, %npts_c, %min_val,
+  %max_val`; build equidistant via `rg_grid%grid_init_equidistant(n, rmin, rmax, 'rg')` +
+  `grid_generate_equidistant()` (`grid/gengrid.f90:14-15`).
+- Resonant surface: `prepare_resonances` sets `kim_resonances_m::r_res` where `q(r_res)=|m/n|`
+  (`grid/prepare_resonances.f90`).
+
+**Run-type + solve + results:**
+- `kim_t` base (`general/KIM_base.f90`): deferred `init(this)`, `run(this)`.
+- Mirror `electrostatic_t` (`electrostatic_poisson/poisson.f90:9-48`): `init` =
+  create_output_directories → generate_grids → calculate_equil(.true.) → set_plasma_quantities →
+  interpolate_equil(rg_grid%xb). Simpler example: `WKB_dispersion_t` (`dispersion/wkb_dispersion.f90:36-109`).
+- Factory `KIM_mod.f90:20-33`: add `case("electrostatic_periodic")`.
+- `zgesv`: `call zgesv(n, 1, A, n, ipiv, b, n, info)`, solution overwrites `b`
+  (`electromagnetic/electromagnetic_solver.f90:241-250`). LAPACK already linked to KIM_lib.
+- `kim_results_t` (`general/kim_solver_m.f90:39-53`) — no `Phi`; copy logic
+  `copy_results_from_globals` (`:256-300`). `EBdat%Phi` exists (`electrostatic_poisson/fields_mod.f90:7-29`).
+- `Br` drive: `type_br_field=12` → constant `Br=(1,0)`, RHS `=−4π·K^{ρB}·Br`
+  (`solve_poisson.f90:98-131`, `fields_mod.f90:35-70`). Mode `(m,n,ω)` in `setup_m`.
+- Build registration: `KIM/src/CMakeSources.in`; tests in `KIM/tests/` + `KIM/tests/CMakeLists.txt`.
+
+---
+
+## Task 1: Vendor `make_periodic` + `localizer` into KIM (regression vs reference)
+
+**Files:**
+- Create: `KIM/src/background_equilibrium/periodization.f90` (module `periodization_m`).
+- Modify: `KIM/src/CMakeSources.in` (add to `KIM_background_equilibrium`).
+- Create: `KIM/tests/test_periodization.f90`; register in `KIM/tests/CMakeLists.txt`.
+
+**Step 1 — Port the code.** Translate `localizer.f90` and `make_periodic.f90` into
+`periodization_m` with `use KIM_kinds_m, only: dp`, `real(dp)`, and an ABSTRACT INTERFACE for
+the callback so `make_periodic` takes a procedure argument:
+```fortran
+abstract interface
+    subroutine aperfuns_i(nfuns, x, funs)
+        import :: dp
+        integer, intent(in) :: nfuns
+        real(dp), intent(in) :: x
+        real(dp), intent(out) :: funs(nfuns)
+    end subroutine
+end interface
+! public :: make_periodic, localizer
+subroutine make_periodic(aperfuns, nfuns, x_mid, dx_asis, dx_tr, x, funs_per)
+    procedure(aperfuns_i) :: aperfuns
+    ...  ! body transcribed verbatim from make_periodic.f90 (double precision -> real(dp))
+```
+Keep `localizer` as a module procedure. Transcribe the math EXACTLY (the `modulo` wrap, the two
+`localizer`-weighted blends).
+
+**Step 2 — Write the failing regression test** `test_periodization.f90`: define a module
+`test_aperfuns` (or a contained subroutine matching `aperfuns_i`) returning `funs=(x, x**2)`.
+For `rm=0.5, Δr=0.25, Δr_tr=0.5`, `x = -1 + 0.01*i` (i=1..300), call `make_periodic` and assert
+the results match a hardcoded subset of `fort.3` (embed ~6 reference rows: e.g.
+`x=-0.99 → (0.51, 0.2601)`, `x=0.30 → (0.30,0.09)` [as-is region], `x=2.0 → (0.5,0.25)`) to
+`< 1e-12`. Also assert periodicity: `make_periodic(...,x) == make_periodic(...,x+L)` for a few x
+(`L=1.5`), and that in the as-is region `|x-rm|≤Δr` the result equals `(x, x²)` exactly.
+
+**Step 3 — Run red / Step 4 — port until green / Step 5 — full suite / Step 6 — commit**
+`git commit` (explicit `git add` of the 4 files — NOT `git add -A`):
+`git commit -m "feat(kim): vendor make_periodic/localizer periodization utility"`.
+
+---
+
+## Task 2: KIM background `aperfuns` + periodic primitive sampling
+
+Provide the callback that evaluates KIM's TRUE primitives at arbitrary radius, and a routine
+that samples the PERIODIZED primitives on a grid.
+
+**Files:** Modify `periodization.f90` (or a new `periodic_background.f90` module); test in
+`test_periodization.f90` (or a new `test_periodic_background.f90`).
+
+**Step 1 — Failing test.** Using the Phase-1 in-memory plasma setup (profiles → namelist →
+`kim_init` → `set_profiles_from_arrays`; see `KIM/tests/test_flr2_fourier_kernel.f90`), obtain a
+populated `plasma`. Compute `rm` (call `prepare_resonances`; read `kim_resonances_m::r_res`).
+Choose `Δr, Δr_tr` (a few `ρ_L`), build an equidistant window grid over `[rm−L/2, rm+L/2]`
+(`N_rg` points). Call the new `sample_periodic_primitives(rm, Δr, Δr_tr, rg, prof_out)` for each
+grid point and assert: (a) in `|rg−rm|≤Δr` the sampled n/T/Er/q equal the true-profile
+interpolation to `<1e-10`; (b) periodicity `prof(rg) == prof(rg+L)`; (c) all finite.
+
+**Step 2 — Run red. Step 3 — Implement.** `sample_periodic_primitives` builds an `aperfuns`
+callback (a module procedure with access to the global `plasma`) that returns
+`funs = [n_e, Te, Ti, Er, q]` evaluated at `x` via `binsrc`+`plag_coeff` on `plasma%r_grid`
+(handle out-of-range x by clamping to the profile domain — `make_periodic` queries
+`x_inperiod ± L`, which may exceed the raw domain, so `aperfuns` must extrapolate/clamp
+sensibly; document the choice). Then call `make_periodic(aperfuns, 5, rm, Δr, Δr_tr, rg, funs)`.
+**Step 4 — green. Step 5 — commit** (explicit add).
+
+> Subtlety to resolve here: `make_periodic` evaluates `aperfuns` at `x_inperiod−L`, `x_inperiod`,
+> `x_inperiod+L`, which can fall outside the raw profile domain `[r_min, r_plas]`. Decide and
+> test the extrapolation policy (clamp to endpoint value is the safe default, since the ideal
+> region is flat-ish). This is why Task 2 exists separately from Task 3.
+
+---
+
+## Task 3 (CRUX): Periodic-background builder — recompute derived plasma on the window
+
+Redirect `rg_grid` to the window and produce a fully-populated PERIODIC `plasma` whose derived
+quantities (`ρ_L, λ_D, B0, kp, om_E, I00…`) the Phase-1 kernel can read.
+
+**Files:** New `periodic_background.f90` (`build_periodic_plasma(rm, Δr, Δr_tr, N_rg)`); test
+in `test_periodic_background.f90`.
+
+**Step 1 — Failing test.** After setup + `build_periodic_plasma(...)`, assert on the window
+grid: `plasma%spec(0)%rho_L`, `lambda_D`, `I00(:,0)` are finite and > 0 (rho_L, lambda_D);
+periodicity of a derived quantity (`rho_L(j)` at `rg` vs `rg+L` — pick indices one period apart);
+`kp ≈ 0` at the grid point nearest `rm` (resonance condition); and that in the as-is region the
+derived `rho_L` matches the non-periodic `rho_L` (recompute the global solver's value at the same
+radius, tol ~1e-6).
+
+**Step 2 — Run red. Step 3 — Implement `build_periodic_plasma`:**
+1. `prepare_resonances` → `rm`.
+2. `L = 2(Δr+Δr_tr)`; rebuild `rg_grid` as equidistant `[rm−L/2, rm+L/2]`, `N_rg` boundary pts
+   (`rg_grid%grid_init_equidistant` + `grid_generate_equidistant`).
+3. Overwrite `plasma%r_grid` = window `xb`, `plasma%grid_size = N_rg`; fill
+   `plasma%spec(sp)%n/T`, `plasma%Er`, `plasma%q` from `sample_periodic_primitives` (Task 2);
+   recompute gradients `dndr/dTdr/dqdr` on the window (finite-difference or the routine KIM
+   already uses — TRACE how the raw profiles' derivatives are computed in profile setup and reuse
+   it).
+4. Run `calculate_equil` (recompute `B0, kp, om_E` from periodized `q`, `btor`, `R0`) →
+   `calculate_plasma_backs(plasma)` → `calculate_thermodynamic_forces_and_susc(plasma)` on the
+   redirected `rg_grid`.
+**Step 4 — green. Step 5 — full suite. Step 6 — commit** (explicit add).
+
+> This is the highest-risk task. If `calculate_equil`/the derivative recompute cannot be cleanly
+> re-driven on the redirected grid, STOP and report what blocks it (the fallback is to
+> parameterize `calculate_thermodynamic_forces_and_susc` by grid — a bigger refactor). Do a small
+> spike first if needed. Do not fake derived values.
+
+---
+
+## Task 4: Discrete k-grid + dense matrix assembly `K_{m,m'}`
+
+**Files:** New `periodic_assembly.f90` (`assemble_periodic_matrices(...) -> Kphi(:,:), KB(:,:)`);
+test `test_periodic_assembly.f90`.
+
+**Step 1 — Failing test.** With a periodic plasma built (Task 3), for small `M` assemble
+`Kphi`, `KB` and assert: shape `(2M+1)×(2M+1)`; the `(m,m')` element equals a brute-force
+reference `(2π/L)·Σ_g hatG_rho_phi(plasma, k_m, k_{m'}, g)·Δrg` computed inline in the test
+(non-tautological only if the production routine is structured differently — otherwise this is a
+characterization test pinning the assembly); all finite. Check the `m=m'` diagonal is nonzero.
+
+**Step 2 — red. Step 3 — Implement:** `k_m = 2π m / L`, `m=−M..M`; equidistant `r_g` = window
+`xb`; `Kphi(m,m') = (2π/L)·Σ_g hatG_rho_phi(plasma, k_m, k_{m'}, g)·Δrg` (trapezoid/midpoint —
+equidistant over one period is spectrally exact), likewise `KB` with `hatG_rho_B`. Loop cost
+`~(2M+1)²·N_rg`. **Step 4 — green. Step 5 — commit** (explicit add).
+
+---
+
+## Task 5: Dense `zgesv` solve + inverse DFT → `δΦ(r)`
+
+**Files:** New `periodic_solve.f90` (`solve_periodic(Kphi, KB, ...) -> Phi_m(:)`,
+`reconstruct_delta_phi(Phi_m, r_out) -> dPhi(:)`); test `test_periodic_solve.f90`.
+
+**Step 1 — Failing test (manufactured):** build a small system with a KNOWN solution — e.g. set
+`Kphi = 0` so the operator is just the Fourier-Laplacian `D_m = −k_m²` and a chosen RHS, and
+assert `Phi_m` matches `−4π KB Br_m / D_m` (skip `m=0` or regularize). Assert `zgesv` `info==0`
+and the reconstructed `δΦ(r) = Σ_m Phi_m e^{i k_m r}` matches `Σ (analytic Phi_m) e^{i k_m r}`
+to `1e-10`.
+
+**Step 2 — red. Step 3 — Implement:** form `A = D_m δ_{m,m'} + 4π Kphi` (`D_m = −k_m²` up to the
+radial-operator convention — verify sign against `solve_poisson`), `b = −4π KB · Br_m` (for
+`type_br_field=12`, `Br_m` is the Fourier coefficient of a constant over the window ⇒ `m=0` only);
+`call zgesv(2M+1, 1, A, 2M+1, ipiv, b, 2M+1, info)`; check `info`; `Phi_m = b`; reconstruct on an
+output grid. Report the condition number (optional: `zgecon`). **Step 4 — green. Step 5 — commit**
+(explicit add).
+
+---
+
+## Task 6: New run-type `electrostatic_periodic_t` + config + results `Phi`
+
+**Files:**
+- New `KIM/src/electrostatic_poisson/poisson_periodic.f90` (module `rt_electrostatic_periodic_m`).
+- Modify `KIM/src/general/KIM_mod.f90` (factory `case`).
+- Modify `KIM/src/setup/config_mod.f90` + `general/read_config.f90` (knobs `dr_asis_scale`,
+  `dr_tr_scale`, `kmax_scale`, `n_rg_periodic` — or absolute `dr_asis`, `dr_tr`).
+- Modify `KIM/src/general/kim_solver_m.f90` (add `Phi(:)` to `kim_results_t` + copy).
+- Modify `KIM/src/CMakeSources.in`.
+- Test `KIM/tests/test_kim_solver_periodic.f90`.
+
+**Step 1 — Failing test (end-to-end):** in-memory (6,2) plasma; `type_of_run =
+'electrostatic_periodic'`; drive the `kim_solver_t` lifecycle (init/set_profiles/solve/results)
+OR `from_kim_factory_get_kim('electrostatic_periodic', kim); kim%init(); kim%run()`. Assert
+`results%Phi` (or `EBdat%Phi`) is allocated, finite, non-zero, and localized (|Phi| decays from
+the resonant layer toward the window edges).
+
+**Step 2 — red. Step 3 — Implement** `init_electrostatic_periodic` (mirror `electrostatic_t`
+init but call `build_periodic_plasma` with the config knobs instead of the global grid setup) and
+`run_electrostatic_periodic` (assemble → solve → reconstruct → pack `EBdat%Phi` + copy to
+`results%Phi`). Register in factory + CMake; add the `Phi` results field + copy in
+`copy_results_from_globals`. **Step 4 — green. Step 5 — full suite. Step 6 — commit** (explicit add).
+
+---
+
+## Task 7: Cross-check B — periodic vs global `electrostatic` on (6,2)
+
+**Files:** Test `KIM/tests/test_periodic_vs_global.f90` (or a golden case under
+`test/golden/kim/cases/electrostatic_periodic/`).
+
+**Step 1 — Test:** run the existing `electrostatic` (global) and the new
+`electrostatic_periodic` on the SAME (6,2) in-memory case; interpolate both `δΦ(r)` onto a common
+resonant-layer grid `|r−rm| ≤ Δr`; report `‖δΦ_periodic − δΦ_global‖ / ‖δΦ_global‖` in L2 and
+max-norm. Assert it is below a **loose** informational threshold (e.g. 20%) — this is
+approx-vs-approx (design §5.2), so treat a large deviation as a diagnostic to investigate, not a
+hard pass/fail initially. Log the number. **Commit** (explicit add).
+
+---
+
+## Phase 2 exit criteria
+
+- `electrostatic_periodic` run-type produces a finite, localized `δΦ(r)` on the (6,2) case.
+- `test_periodization`, `test_periodic_background`, `test_periodic_assembly`,
+  `test_periodic_solve`, `test_kim_solver_periodic` all green; full suite has no new failures
+  (only `test_rhs_balance` pre-existing).
+- Cross-check B number logged for (6,2).
+- **Checkpoint before Phase 3** (strategy-A `Δr`/`N_rg`/`M` convergence harness + golden record).
+
+## Deferred to later phases
+
+- **Strategy A** (Δr / Δr_tr / N_rg / M convergence → periodization-deformation error bar) +
+  frozen golden case — Phase 3.
+- **R1 deviation** — only if a Gibbs problem is measured (periodization is expected to remove it).
+- **Current-diagnostic kernels** `K^{jΦ}, K^{jB}`; electromagnetic extension; toroidal geometry.
+- Wiring `kern_include_ks2` to config; A/B of the two k_s² paths.

--- a/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase3.md
+++ b/docs/plans/2026-07-10-kim-forced-periodicity-impl-phase3.md
@@ -1,0 +1,200 @@
+# KIM Forced-Periodicity — Phase 3 (Strategy-A Convergence + Golden) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or
+> subagent-driven-development) to implement this plan task-by-task. Each code task is TDD.
+
+**Goal:** Validate the `electrostatic_periodic` solver on its OWN terms — three-knob
+convergence (`N_rg`, `M`, `Δr`) reporting the self-consistent periodization-deformation error
+bar — and freeze a golden `(6,2)` case so the numbers are pinned in CI.
+
+**Architecture:** Refactor the run-type's core (build → assemble → solve → reconstruct) into one
+reusable routine `compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, r_out) -> δΦ` that both
+the run-type and the convergence harness call. Convergence tests evaluate `δΦ` on a FIXED
+diagnostic resonant-layer grid across parameter refinements and report the Cauchy relative
+residual `‖δΦ_i − δΦ_{i−1}‖ / ‖δΦ_i‖` (L2 + max). `N_rg` (quadrature) and `M`/`k_max` (spectral)
+must converge toward zero; the `Δr` scan's plateau residual IS the reported periodization error.
+
+**Tech Stack:** Fortran, the Phase-2 modules (`periodic_background_m`, `periodic_assembly_m`,
+`periodic_solve_m`, `rt_electrostatic_periodic_m`), KIM `error stop` CTest harness, the golden
+harness under `test/golden/kim/`.
+
+**Baseline:** all KIM ctest pass except the pre-existing `test_rhs_balance`.
+
+---
+
+## Open item carried into Phase 3 (do NOT try to fix here)
+
+The strategy-B cross-check (periodic vs global) shows **~86% relative difference** on (6,2)
+(`max|Φ_global|=0.121` vs `max|Φ_periodic|=0.027`, ~4.5× magnitude gap; DC-removed larger).
+Leading suspects: **assembly/solve normalization** (the dominant ~4.5× factor), the **`k_s²`
+convention** (`kern_include_ks2` default `.false.`), and the **`D_m=−k_m²`** operator. Phase 3
+deliberately validates the periodic solver's *internal numerical convergence* independent of the
+global reference; the cross-check magnitude is a separate physics investigation (recorded in
+memory `kim-global-electrostatic-umfpack-bug` follow-on note). Strategy-A convergence is still
+meaningful even if an overall normalization factor is later corrected (a constant scale cancels in
+the *relative* Cauchy residual).
+
+---
+
+## Ground truth (Phase-2 pieces to reuse)
+
+- `periodic_background_m::build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)` — redirects `rg_grid`
+  to the window, populates the periodic derived plasma (with the `u0_seed` B0 fix).
+- `periodic_assembly_m::assemble_periodic_matrices(plasma, L, M, Kphi, KB)`.
+- `periodic_solve_m::solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)` and
+  `reconstruct_delta_phi(Phi_m, L, M, r_out)`.
+- `rt_electrostatic_periodic_m::run_electrostatic_periodic` (`KIM/src/electrostatic_poisson/poisson_periodic.f90`)
+  currently inlines: `prepare_resonances` → rm → interp `rho_L(rm)` → (`dx_asis, dx_tr, L,
+  k_max, M = ceil(k_max·L/2π), n_rg`) → build → assemble → solve → reconstruct on `rg_grid%xb` →
+  pack `EBdat%Phi`.
+- `Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)` (default (1,0)).
+- Golden harness: `test/golden/kim/cases/<case>/` with `KIM_config.nml` + profile `.dat`; runner
+  auto-discovers via `GR_INPUT=KIM_config.nml`; compared numerically (`gr_numcompare.py`, rtol
+  1e-7/atol 1e-12); runs in the GitHub `golden` job, not `make test`. Existing case:
+  `test/golden/kim/cases/electromagnetic/`.
+- In-memory (6,2) test setup pattern: `KIM/tests/test_kim_solver_periodic.f90` /
+  `test_periodic_assembly.f90` (profiles → namelist `m_mode=-6,n_mode=2,type_br_field=12,
+  collision_model='FokkerPlanck'` → `kim_init` → `set_profiles_from_arrays` → factory → `%init()`).
+
+---
+
+## Task 1: Extract a reusable `compute_periodic_delta_phi` core (refactor, no behavior change)
+
+Pull the run-type's build→assemble→solve→reconstruct into one routine taking EXPLICIT parameters,
+so both the run-type and the convergence harness share it.
+
+**Files:**
+- Modify: `KIM/src/electrostatic_poisson/poisson_periodic.f90` — add public
+  `compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, r_out, dPhi, info)` and make
+  `run_electrostatic_periodic` call it.
+- Test: `KIM/tests/test_kim_solver_periodic.f90` (existing) must still pass unchanged.
+
+**Step 1 — Write the failing test** (in a NEW `KIM/tests/test_periodic_convergence.f90`, which
+Task 2 extends): after the (6,2) setup + `%init()`, compute `rm` (`prepare_resonances`),
+`rhoL_rm` (interp), pick `dx_asis=5*rhoL_rm, dx_tr=10*rhoL_rm, M=24, n_rg=96`, a diagnostic grid
+`r_out` of 41 points over `[rm-3*rhoL_rm, rm+3*rhoL_rm]`, then
+`call compute_periodic_delta_phi(rm, dx_asis, dx_tr, 24, 96, (1.0_dp,0.0_dp), r_out, dPhi, info)`
+and assert `info==0`, `dPhi` finite, `maxval(abs(dPhi)) > 0`. `error stop` on failure.
+
+**Step 2 — Run red** (routine absent): `cmake -S . -B build && cmake --build build --target
+test_periodic_convergence.x && ctest --test-dir build -R test_periodic_convergence --output-on-failure`.
+
+**Step 3 — Implement** `compute_periodic_delta_phi`: body = the current `run_electrostatic_periodic`
+core (`build_periodic_plasma(rm,dx_asis,dx_tr,n_rg)` → `L=2*(dx_asis+dx_tr)` →
+`assemble_periodic_matrices(plasma,L,M,Kphi,KB)` → `solve_periodic(Kphi,KB,L,M,Br_const,Phi_m,info)`
+→ `dPhi = reconstruct_delta_phi(Phi_m,L,M,r_out)`), returning `dPhi(size(r_out))` and `info`.
+Refactor `run_electrostatic_periodic` to compute its params then call this with
+`r_out = rg_grid%xb` and pack the result into `EBdat%Phi` (behavior preserved — the existing
+end-to-end test must still pass).
+
+**Step 4 — Run green** + full suite (only `test_rhs_balance` fails).
+
+**Step 5 — Commit** (explicit `git add`; NEVER `git add -A`):
+`git commit -m "refactor(kim): extract compute_periodic_delta_phi core for convergence harness"`.
+
+---
+
+## Task 2: `N_rg` (quadrature) convergence test
+
+**Files:** Modify `KIM/tests/test_periodic_convergence.f90` (add `test_nrg_convergence`).
+
+**Step 1 — Write the test.** Fix `M=32` and `dx_asis=5*rhoL_rm, dx_tr=10*rhoL_rm`; fixed
+diagnostic grid `r_out` (41 pts over the resonant layer). For `n_rg ∈ {48, 96, 192, 384}` call
+`compute_periodic_delta_phi(...)` and collect `dPhi_k`. Compute the Cauchy relative residual
+`res_k = ‖dPhi_k − dPhi_{k-1}‖_2 / ‖dPhi_k‖_2` for k=2..4 (and the max-norm version). PRINT all
+residuals. ASSERT: the residual sequence is DECREASING and the finest residual `res_4 < 1e-2`
+(quadrature converges as `N_rg` grows). `error stop` if not monotonically converging or if
+`res_4` exceeds the threshold. (State the threshold; loosen only with justification if the
+periodization non-periodicity floor — the ~2.7e-5 `rho_L` deformation — sets a higher plateau.)
+
+**Step 2 — red / 3 — (already implemented core; run) / 4 — green** (this is a validation test; it
+may pass on first run). If it does NOT converge, that is a real finding — investigate the
+quadrature (seam handling, equidistant weight), don't loosen blindly.
+
+**Step 5 — Commit** `git commit -m "test(kim): N_rg quadrature convergence of periodic solver"`.
+
+---
+
+## Task 3: `M`/`k_max` (spectral) convergence test
+
+**Files:** Modify `KIM/tests/test_periodic_convergence.f90` (add `test_M_convergence`).
+
+**Step 1 — Write the test.** Fix `n_rg=192` (converged from Task 2) and the window
+`dx_asis/dx_tr`; fixed `r_out`. For `M ∈ {8, 16, 24, 32}` call `compute_periodic_delta_phi(...)`;
+compute the Cauchy residuals `res_k` (L2 + max). PRINT them. ASSERT the residual decreases and
+`res(last) < 1e-2` (the spectral basis converges as `M` grows). `error stop` on non-convergence.
+
+**Step 2-4** as Task 2 (validation; investigate real non-convergence). **Step 5 — Commit**
+`git commit -m "test(kim): M spectral convergence of periodic solver"`.
+
+---
+
+## Task 4: `Δr` deformation scan (the reported error bar)
+
+**Files:** Modify `KIM/tests/test_periodic_convergence.f90` (add `test_dr_deformation_scan`).
+
+**Step 1 — Write the test.** Fix `M=32`, `n_rg=192` (both converged). Keep the transition ratio
+`dx_tr = 2*dx_asis` (memo Fig.1). Scan `dx_asis ∈ {3, 5, 8, 12} * rhoL_rm` (so the window grows).
+Evaluate `δΦ` on a FIXED diagnostic resonant-layer grid `r_out` = 41 pts over
+`[rm - 3*rhoL_rm, rm + 3*rhoL_rm]` (the SAME physical grid for every `dx_asis`, i.e. the innermost
+layer common to all windows). Compute the Cauchy residual `res_k` between successive `dx_asis`.
+PRINT them prominently as the **periodization-deformation error bar** (this is the reported
+number, design §5.1). ASSERT only that all `δΦ` are finite and `res_k` is finite and does NOT
+GROW without bound (a converging/plateauing sequence is the physical expectation; a growing
+sequence is a finding to investigate). This task's output is a NUMBER (the plateau residual at the
+largest affordable `Δr`), logged — soft gate on finiteness, not a tight threshold.
+
+**Step 2-4** (validation). **Step 5 — Commit**
+`git commit -m "test(kim): Dr periodization-deformation error scan"`.
+
+---
+
+## Task 5: Freeze a golden `(6,2)` periodic case
+
+Pin the periodic solver's numbers against regression via the golden harness (CI-only).
+
+**Files:**
+- Create: `test/golden/kim/cases/electrostatic_periodic/KIM_config.nml` (mirror the
+  `electromagnetic` golden case's config, but `type_of_run='electrostatic_periodic'`,
+  `collision_model='FokkerPlanck'`, `m_mode=-6, n_mode=2, type_br_field=12`, and the
+  `&KIM_PERIODIC` scales `periodic_dr_asis_scale=5, periodic_dr_tr_scale=10, periodic_kmax_scale=5,
+  periodic_n_rg=96`).
+- Create: the profile `.dat` files the case needs (`n.dat, q.dat, Te.dat, Ti.dat` — copy/adapt
+  from `test/golden/kim/cases/electromagnetic/`, ensuring the profile makes q cross 3 for the
+  (6,2) resonance).
+
+**Step 1 — Author the case.** Copy `test/golden/kim/cases/electromagnetic/` to
+`.../electrostatic_periodic/`; edit `KIM_config.nml` per above; keep/adjust the profiles so the
+run resolves the (6,2) resonance and produces the localized `δΦ`.
+
+**Step 2 — Generate the baseline.** Follow `test/golden/kim/config.sh` / the golden README to
+build and run the case with the runner, producing the reference output (the `δΦ`/fields the
+comparator will pin). Confirm the run exits 0 and writes a nonzero `Phi`. (The golden runner uses
+`GR_EXE=KIM.x`, `GR_INPUT=KIM_config.nml`.)
+
+**Step 3 — Verify it re-compares clean.** Re-run the golden comparison (`gr_numcompare.py`, rtol
+1e-7/atol 1e-12) against the just-frozen baseline → identical. Confirm the case is discovered by
+`gr_dispatch.sh`.
+
+**Step 4 — Commit** the case + baseline (explicit `git add` of the case dir):
+`git commit -m "test(golden): freeze electrostatic_periodic (6,2) case"`. NOTE: golden `.dat`
+baselines are large/numeric — stage ONLY the new case directory; do not sweep other untracked
+golden trees (e.g. `test/ql-balance/`).
+
+---
+
+## Phase 3 exit criteria
+
+- `test_periodic_convergence` green: `N_rg` and `M` residuals converge (< 1e-2); the `Δr`
+  deformation scan reports a finite, plateauing error bar (the periodization error number).
+- A frozen `electrostatic_periodic` golden case in `test/golden/kim/cases/`, re-comparing clean.
+- Full suite unchanged (only `test_rhs_balance` fails).
+- **The periodic solver is self-validated** (internal numerical convergence + regression-pinned),
+  with the periodization-deformation error quantified.
+
+## Deferred / open
+
+- **Strategy-B cross-check discrepancy (~86%)** — the periodic-vs-global magnitude/shape mismatch;
+  investigate normalization (~4.5× factor), `kern_include_ks2`, and `D_m` separately.
+- R1 deviation formulation; current-diagnostic kernels; electromagnetic + toroidal extensions;
+  wiring `kern_include_ks2` to config.


### PR DESCRIPTION
## What changed

- add the forced-periodicity electrostatic run type, including background periodization, Fourier-kernel assembly, dense periodic Poisson solve, and convergence diagnostics
- reconstruct and output both the electrostatic potential perturbation and parallel current density
- size the periodic window from the largest active-species Larmor radius and preserve multispecies background state
- correct the Fourier phase and continuous-kernel normalization used by the periodic charge and current kernels
- make the global FEM kernel approximations optional through `periodic_match_global_kernel_approximations`, defaulting to `.false.`
- retain the collision-frequency scaling and collisionless-ion behavior from current `main`

## Why

The forced-periodicity solver provides a local Fourier-space alternative to the global finite-element electrostatic solve. Direct comparisons exposed convention and model differences: the Fourier phase sign, kernel normalization, parallel-current normalization, and two global-model approximations (`k_s^2` omission and zero electron FLR). This PR makes those distinctions explicit so the periodic solver uses its full kernel by default while still supporting controlled comparisons with the global model.

## Configuration

```fortran
&KIM_PERIODIC
  periodic_match_global_kernel_approximations = .false.
/
```

Setting the option to `.true.` omits `k_s^2` from the FLR arguments and applies the zero-electron-FLR approximation used by the global model.

## Validation

- `cmake -S . -B build`
- built `test_flr2_fourier_kernel`, `test_periodic_assembly`, `test_periodic_solve`, `test_kim_solver_periodic`, and `test_collision_scale_z0`
- focused CTest result: 5/5 passed
- repository pre-commit checks passed for the post-rebase compatibility commit
