### PR TITLE
Add collisionless ion kernels to forced periodicity

### DIFF
--- a/KIM/nmls/README.md
+++ b/KIM/nmls/README.md
@@ -4,10 +4,18 @@ KIM is configured via the namelist file KIM_config.nml containing multiple namel
 ## KIM_CONFIG
 - number_of_ion_species ... integer, number of ion species
 - read_species_from_namelist ... boolean, if false, initialize deuterium plasma
-- type_of_run ... string, specifies the type of run, options are: 'electrostatic', 'electromagnetic', 'WKB_dispersion', 'flr2_benchmark'
+- type_of_run ... string, specifies the type of run, options include: 'electrostatic', 'electrostatic_periodic', 'electromagnetic', 'WKB_dispersion', 'flr2_benchmark'
 - collision_model ... string, collision model to use, options are: 'Krook', 'FokkerPlanck'
+- ion_collision_model ... string, ion model used with `collision_model='FokkerPlanck'`: `FokkerPlanck` (default) or `collisionless`. In `electrostatic_periodic`, collisionless mode keeps FP electrons and uses the $m_\phi=0$ collisionless ion kernels for both charge and parallel current.
+- collisionless_kpar_epsilon ... real, positive causal-pole width in 1/cm required by `ion_collision_model='collisionless'`. KIM uses $k_{\parallel}+i\epsilon$ for signed inverse factors and $\sqrt{k_{\parallel}^2+\epsilon^2}$ for even charge-response factors.
+- ion_fp_collision_scale ... real, positive multiplier applied only to ion FP collision frequencies. It has no effect on collisionless ion kernels.
 - collision_frequency_scale ... real, positive multiplier applied to the calculated electron and ion collision frequencies before the Krook argument z0 and the Fokker-Planck susceptibility inputs are assembled; default 1.0 leaves the collision formulas unchanged
 - artificial_debye_case ... integer, if 0: full calculation of kernel, if 1: Debye case, if 2: exclude Debye case
+
+Collisionless forced periodicity currently requires `artificial_debye_case=0`,
+`theta_integration='GaussLegendre'`, and a positive
+`collisionless_kpar_epsilon`. Higher cyclotron harmonics are not included in
+this ion model; the implemented derivation uses $m_\phi=0$.
 
 ## KIM_IO
 - profile_location ... string, path to the profiles
@@ -85,3 +93,16 @@ Notes:
 ## KIM_SPECIES
 - zi ... integer array, ion charge numbers (e.g., zi = 1, 2 for H+ and He++)
 - ai ... integer array, ion mass numbers (e.g., ai = 2, 4 for D and He)
+
+## KIM_PERIODIC
+
+- periodic_dr_asis_scale ... real, half-width of the unchanged profile region in units of the selected reference Larmor radius
+- periodic_dr_tr_scale ... real, width of the transition buffer on each side in units of the selected reference Larmor radius
+- periodic_kmax_scale ... real, radial Fourier cutoff multiplied by the reference Larmor radius; the solver derives the integer harmonic count $M$ from this cutoff and the period
+- periodic_n_rg ... integer, number of endpoint-exclusive guiding-centre samples over one period
+- periodic_match_global_kernel_approximations ... boolean, if true drops $k_s^2$ from the FLR arguments and takes electrons in the zero-FLR limit for comparison with the simplified global model; default false
+
+For `ion_collision_model='collisionless'`, these settings control the same
+periodic window and Fourier basis as in FP mode. The assembled response is FP
+electrons plus collisionless ion charge and current. Both `Phi` and `jpar` are
+written through the standard forced-periodicity output path.

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -78,6 +78,7 @@ set(KIM_fokkerplanck ${CMAKE_SOURCE_DIR}/QL-Balance/src/base/getIfunc.f90
 
 set(KIM_asymptotics asymptotics/FLR2_asymptotics.f90
                     asymptotics/flr2_fourier_kernel.f90
+                    asymptotics/collisionless_fourier_kernel.f90
 )
 
 set(KIM_diagnostics diagnostics/kim_diagnostics_mod.f90

--- a/KIM/src/asymptotics/collisionless_fourier_kernel.f90
+++ b/KIM/src/asymptotics/collisionless_fourier_kernel.f90
@@ -1,0 +1,239 @@
+module collisionless_fourier_kernel_m
+    ! m_phi=0 collisionless ion response in the forced-periodicity Fourier
+    ! basis.  The four cores implement thesis equations (13.53)--(13.59),
+    ! (13.63), (13.67), (13.151), and (13.153), including the common
+    ! continuous-Fourier normalization 1/(8*pi^2), but excluding the radial
+    ! phase exp(-i*(kr-krp)*rg).  See docs/derivations for the reduction.
+    use KIM_kinds_m, only: dp
+    use species_m, only: plasma_t
+    implicit none
+    private
+
+    public :: collisionless_ion_cores
+    public :: configured_hatG_all
+    public :: configured_hatG_rho_phi, configured_hatG_rho_B
+    public :: configured_hatG_j_phi, configured_hatG_j_B
+
+contains
+
+    subroutine configured_hatG_all(plasma_in, kr, krp, j, rho_phi, rho_B, j_phi, j_B)
+        ! Select the configured ion model without changing the electron model.
+        ! In the default FP mode this delegates directly to the established
+        ! functions.  In collisionless mode, electrons remain FP while every
+        ! enabled ion species uses collisionless_ion_cores.
+        use config_m, only: collisionless_kpar_epsilon, ion_collision_model, &
+            turn_off_electrons, turn_off_ions
+        use constants_m, only: com_unit, pi
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, &
+            hatG_j_phi, hatG_j_B, flr_arg_pair_sp, core_rho_phi_sp, &
+            core_rho_B_sp, core_j_phi_sp, core_j_B_sp
+        use grid_m, only: rg_grid
+
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
+
+        integer :: sp
+        real(dp) :: bplus, bcross
+        complex(dp) :: phase, species_rho_phi, species_rho_B
+        complex(dp) :: species_j_phi, species_j_B
+
+        select case (trim(ion_collision_model))
+        case ('FokkerPlanck')
+            ! Preserve the original arithmetic path exactly by delegation.
+            rho_phi = hatG_rho_phi(plasma_in, kr, krp, j)
+            rho_B = hatG_rho_B(plasma_in, kr, krp, j)
+            j_phi = hatG_j_phi(plasma_in, kr, krp, j)
+            j_B = hatG_j_B(plasma_in, kr, krp, j)
+            return
+        case ('collisionless')
+            continue
+        case default
+            error stop 'Periodic ion_collision_model must be FokkerPlanck or collisionless'
+        end select
+
+        if (collisionless_kpar_epsilon <= 0.0_dp) then
+            error stop 'Collisionless periodic ions require collisionless_kpar_epsilon > 0'
+        end if
+
+        phase = exp(-com_unit * (kr - krp) * rg_grid%xb(j))
+        rho_phi = (0.0_dp, 0.0_dp)
+        rho_B = (0.0_dp, 0.0_dp)
+        j_phi = (0.0_dp, 0.0_dp)
+        j_B = (0.0_dp, 0.0_dp)
+
+        if (.not. turn_off_electrons) then
+            call flr_arg_pair_sp(plasma_in, 0, kr, krp, j, bplus, bcross)
+            rho_phi = core_rho_phi_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+            rho_B = core_rho_B_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+            j_phi = core_j_phi_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+            j_B = core_j_B_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+        end if
+
+        if (.not. turn_off_ions) then
+            do sp = 1, plasma_in%n_species - 1
+                call collisionless_ion_cores(plasma_in, sp, kr, krp, j, &
+                    collisionless_kpar_epsilon, species_rho_phi, species_rho_B, &
+                    species_j_phi, species_j_B)
+                rho_phi = rho_phi + species_rho_phi
+                rho_B = rho_B + species_rho_B
+                j_phi = j_phi + species_j_phi
+                j_B = j_B + species_j_B
+            end do
+        end if
+
+        rho_phi = phase * rho_phi
+        rho_B = phase * rho_B
+        j_phi = phase * j_phi
+        j_B = phase * j_B
+    end subroutine configured_hatG_all
+
+    complex(dp) function configured_hatG_rho_phi(plasma_in, kr, krp, j) result(value)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        complex(dp) :: unused_rho_B, unused_j_phi, unused_j_B
+
+        call configured_hatG_all(plasma_in, kr, krp, j, value, unused_rho_B, &
+            unused_j_phi, unused_j_B)
+    end function configured_hatG_rho_phi
+
+    complex(dp) function configured_hatG_rho_B(plasma_in, kr, krp, j) result(value)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        complex(dp) :: unused_rho_phi, unused_j_phi, unused_j_B
+
+        call configured_hatG_all(plasma_in, kr, krp, j, unused_rho_phi, value, &
+            unused_j_phi, unused_j_B)
+    end function configured_hatG_rho_B
+
+    complex(dp) function configured_hatG_j_phi(plasma_in, kr, krp, j) result(value)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        complex(dp) :: unused_rho_phi, unused_rho_B, unused_j_B
+
+        call configured_hatG_all(plasma_in, kr, krp, j, unused_rho_phi, &
+            unused_rho_B, value, unused_j_B)
+    end function configured_hatG_j_phi
+
+    complex(dp) function configured_hatG_j_B(plasma_in, kr, krp, j) result(value)
+        type(plasma_t), intent(in) :: plasma_in
+        real(dp), intent(in) :: kr, krp
+        integer, intent(in) :: j
+        complex(dp) :: unused_rho_phi, unused_rho_B, unused_j_phi
+
+        call configured_hatG_all(plasma_in, kr, krp, j, unused_rho_phi, &
+            unused_rho_B, unused_j_phi, value)
+    end function configured_hatG_j_B
+
+    subroutine collisionless_ion_cores(plasma_in, sp, kr, krp, j, epsilon, &
+            rho_phi, rho_B, j_phi, j_B)
+        use config_m, only: artificial_debye_case
+        use constants_m, only: com_unit, pi, sol
+        use flr2_fourier_kernel_m, only: flr_arg_pair_sp, scaled_bessel_pair
+        use Krook_kernel_plasma_prefacs_m, only: Krook_collisionless_kpar, &
+            Krook_collisionless_kpar_magnitude, Krook_collisionless_z0
+        use setup_m, only: omega
+
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr, krp, epsilon
+        complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
+
+        real(dp) :: grad_A1, grad_A2, bplus, bcross, ks, k_abs
+        real(dp) :: lambda_D, omega_c, sI0, sIm1, vT
+        real(dp) :: coeff0, coeff1, coeff2
+        complex(dp) :: k_pole, zeta0, response_Z
+        complex(dp) :: rho_phi_moment, j_phi_moment, magnetic_bracket
+        complex(dp) :: plasma_Z
+
+        call validate_inputs(plasma_in, sp, j, epsilon)
+        if (artificial_debye_case /= 0) then
+            error stop 'Collisionless periodic ions require artificial_debye_case=0'
+        end if
+
+        ks = plasma_in%ks(j)
+        grad_A1 = plasma_in%spec(sp)%A1(j)
+        grad_A2 = plasma_in%spec(sp)%A2(j)
+        vT = plasma_in%spec(sp)%vT(j)
+        omega_c = plasma_in%spec(sp)%omega_c(j)
+        lambda_D = plasma_in%spec(sp)%lambda_D(j)
+
+        call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+        call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
+
+        k_abs = Krook_collisionless_kpar_magnitude(plasma_in%kp(j), epsilon)
+        k_pole = Krook_collisionless_kpar(plasma_in%kp(j), epsilon)
+        zeta0 = Krook_collisionless_z0(plasma_in%om_E(j), omega, plasma_in%kp(j), vT, epsilon)
+        response_Z = plasma_Z(zeta0)
+
+        ! Thesis (13.53)--(13.55), m_phi=0.  Replacing k_parallel by k_abs
+        ! in a1 is part of the even collisionless regularization: together
+        ! with the rho-Phi prefactor it preserves the homogeneous static
+        ! Debye limit independently of the sign of k_parallel.
+        coeff0 = sI0 * (&
+            -plasma_in%om_E(j) / omega_c &
+            + ks * vT**2 / omega_c**2 * (grad_A1 + (1.0_dp + bplus) * grad_A2)) &
+            + ks * vT**2 / omega_c**2 * grad_A2 * bcross * sIm1
+        coeff1 = -k_abs / omega_c * sI0
+        coeff2 = ks * grad_A2 / (2.0_dp * omega_c**2) * sI0
+
+        ! Zeroth and first parallel-velocity moments, thesis (13.58),(13.59).
+        rho_phi_moment = response_Z * (&
+            coeff0 + sqrt(2.0_dp) * vT * zeta0 * coeff1 &
+            + 2.0_dp * vT**2 * zeta0**2 * coeff2) &
+            + sqrt(2.0_dp) * vT * (coeff1 + sqrt(2.0_dp) * vT * zeta0 * coeff2)
+        j_phi_moment = (zeta0 * response_Z + 1.0_dp) * coeff0 &
+            + sqrt(2.0_dp) * vT * zeta0 * coeff1 &
+            + 2.0_dp * vT**2 * zeta0**2 * coeff2 &
+            + 2.0_dp * vT**2 * coeff2
+
+        ! The original 2^(-7/2)/pi^2 and 1/(8*pi^2) prefactors are
+        ! written with the same explicit 1/(8*pi^2) normalization.
+        rho_phi = omega_c / (sqrt(2.0_dp) * lambda_D**2 * vT * k_abs) &
+            * rho_phi_moment / (8.0_dp * pi**2)
+        j_phi = omega_c / (lambda_D**2 * k_pole) &
+            * j_phi_moment / (8.0_dp * pi**2)
+
+        ! Mathematica-reduced common bracket in thesis (13.151),(13.153).
+        magnetic_bracket = 0.5_dp * grad_A2 * sI0 &
+            + (zeta0 * response_Z + 1.0_dp) * (&
+                (grad_A1 + grad_A2 * (1.0_dp + bplus + zeta0**2)) * sI0 &
+                + grad_A2 * bcross * sIm1)
+
+        rho_B = com_unit * vT**2 / (sol * lambda_D**2 * omega_c * k_pole) &
+            * magnetic_bracket / (8.0_dp * pi**2)
+        j_B = com_unit * sqrt(2.0_dp) * vT**3 * zeta0 &
+            / (sol * lambda_D**2 * omega_c * k_pole) &
+            * magnetic_bracket / (8.0_dp * pi**2)
+    end subroutine collisionless_ion_cores
+
+    subroutine validate_inputs(plasma_in, sp, j, epsilon)
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: epsilon
+
+        if (sp < 1 .or. sp >= plasma_in%n_species) then
+            error stop 'Collisionless periodic kernel requires an ion species index'
+        end if
+        if (j < 1 .or. j > plasma_in%grid_size) then
+            error stop 'Collisionless periodic kernel radial index is out of range'
+        end if
+        if (epsilon <= 0.0_dp) then
+            error stop 'Collisionless periodic kernel requires epsilon > 0'
+        end if
+        if (plasma_in%spec(sp)%vT(j) <= 0.0_dp) then
+            error stop 'Collisionless periodic kernel requires vT > 0'
+        end if
+        if (plasma_in%spec(sp)%lambda_D(j) <= 0.0_dp) then
+            error stop 'Collisionless periodic kernel requires lambda_D > 0'
+        end if
+        if (abs(plasma_in%spec(sp)%omega_c(j)) <= tiny(1.0_dp)) then
+            error stop 'Collisionless periodic kernel requires nonzero omega_c'
+        end if
+    end subroutine validate_inputs
+
+end module collisionless_fourier_kernel_m

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -66,7 +66,7 @@ contains
     !> 1/(8*pi^2) Fourier normalization, so no further scaling is applied here.
     subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         use grid_m, only: rg_grid
-        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, hatG_j_phi, hatG_j_B
+        use collisionless_fourier_kernel_m, only: configured_hatG_all
         use constants_m, only: pi
 
         type(plasma_t), intent(in) :: plasma
@@ -78,6 +78,7 @@ contains
         integer :: N, dim, m_row, m_col, im, imp, j
         real(dp) :: k_m, k_mp, weight
         complex(dp) :: acc_phi, acc_B, acc_jphi, acc_jB
+        complex(dp) :: point_phi, point_B, point_jphi, point_jB
 
         N = rg_grid%npts_b
         dim = 2 * M + 1
@@ -97,7 +98,8 @@ contains
         !$omp parallel do default(none) schedule(static) &
         !$omp shared(M, L, N, weight, plasma, Kphi, KB, Kjphi, KjB) &
         !$omp private(m_col, k_mp, imp, m_row, k_m, im, j, &
-        !$omp         acc_phi, acc_B, acc_jphi, acc_jB)
+        !$omp         acc_phi, acc_B, acc_jphi, acc_jB, &
+        !$omp         point_phi, point_B, point_jphi, point_jB)
         do m_col = -M, M
             k_mp = k_of_m(m_col, L)
             imp = m_col + M + 1
@@ -110,10 +112,12 @@ contains
                 acc_jphi = (0.0_dp, 0.0_dp)
                 acc_jB   = (0.0_dp, 0.0_dp)
                 do j = 1, N
-                    acc_phi  = acc_phi  + hatG_rho_phi(plasma, k_m, k_mp, j)
-                    acc_B    = acc_B    + hatG_rho_B(plasma, k_m, k_mp, j)
-                    acc_jphi = acc_jphi + hatG_j_phi(plasma, k_m, k_mp, j)
-                    acc_jB   = acc_jB   + hatG_j_B(plasma, k_m, k_mp, j)
+                    call configured_hatG_all(plasma, k_m, k_mp, j, &
+                        point_phi, point_B, point_jphi, point_jB)
+                    acc_phi  = acc_phi  + point_phi
+                    acc_B    = acc_B    + point_B
+                    acc_jphi = acc_jphi + point_jphi
+                    acc_jB   = acc_jB   + point_jB
                 end do
 
                 Kphi(im, imp)  = weight * acc_phi

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -70,6 +70,15 @@ target_link_libraries(test_collisionless_ion_kernel KIM_lib kilca_lib lapack cer
 add_test(NAME test_collisionless_ion_kernel
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_collisionless_ion_kernel.x)
 
+# m_phi=0 collisionless ion charge/current kernels in the periodic Fourier basis.
+add_executable(test_collisionless_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_collisionless_fourier_kernel.f90)
+set_target_properties(test_collisionless_fourier_kernel PROPERTIES
+                        OUTPUT_NAME test_collisionless_fourier_kernel.x
+                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_collisionless_fourier_kernel KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_collisionless_fourier_kernel
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_collisionless_fourier_kernel.x)
+
 add_executable(test_collisionless_ion_assembly ${CMAKE_SOURCE_DIR}/KIM/tests/test_collisionless_ion_assembly.f90)
 set_target_properties(test_collisionless_ion_assembly PROPERTIES
                         OUTPUT_NAME test_collisionless_ion_assembly.x

--- a/KIM/tests/test_collisionless_fourier_kernel.f90
+++ b/KIM/tests/test_collisionless_fourier_kernel.f90
@@ -1,0 +1,189 @@
+program test_collisionless_fourier_kernel
+    use KIM_kinds_m, only: dp
+    use collisionless_fourier_kernel_m, only: collisionless_ion_cores
+    use config_m, only: artificial_debye_case
+    use constants_m, only: pi
+    use flr2_fourier_kernel_m, only: set_global_kernel_approximations
+    use setup_m, only: omega
+    use species_m, only: plasma_t
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+
+    type(plasma_t) :: test_plasma
+    complex(dp) :: rho_phi, rho_B, j_phi, j_B
+    complex(dp) :: rho_phi_ref, rho_B_ref, j_phi_ref, j_B_ref
+    real(dp), parameter :: epsilon = 0.05_dp
+    real(dp), parameter :: kr = 0.73_dp, krp = -0.41_dp
+
+    call make_manufactured_plasma(test_plasma)
+    call set_global_kernel_approximations(.false.)
+    artificial_debye_case = 0
+    omega = 0.17_dp
+
+    call collisionless_ion_cores(test_plasma, 1, kr, krp, 1, epsilon, &
+        rho_phi, rho_B, j_phi, j_B)
+
+    rho_phi_ref = cmplx(-2.1836855175510750e-2_dp, -8.2515585946286270e-3_dp, dp)
+    rho_B_ref = cmplx(-3.0215925066508310e-14_dp, 4.7259864203647080e-14_dp, dp)
+    j_phi_ref = cmplx(3.3181741084489427e-3_dp, -2.0023934758877357e-2_dp, dp)
+    j_B_ref = cmplx(3.0810039432056770e-14_dp, -4.8189101490788025e-14_dp, dp)
+
+    call assert_close('rho-Phi Mathematica oracle', rho_phi, rho_phi_ref, 2.0e-13_dp)
+    ! fortnum's integer-order Bessel approximation is accurate to about 1e-8
+    ! for the I_{-1} value used by this manufactured case.
+    call assert_close('rho-B Mathematica oracle', rho_B, rho_B_ref, 5.0e-8_dp)
+    call assert_close('j-Phi Mathematica oracle', j_phi, j_phi_ref, 2.0e-13_dp)
+    call assert_close('j-B Mathematica oracle', j_B, j_B_ref, 5.0e-8_dp)
+
+    call test_magnetic_recurrence(test_plasma)
+    call test_homogeneous_static_limit(test_plasma)
+    call test_resonance_regularization(test_plasma)
+    call test_collision_frequency_independence(test_plasma)
+
+    print *, 'All collisionless Fourier-kernel tests PASSED'
+
+contains
+
+    subroutine make_manufactured_plasma(plasma)
+        type(plasma_t), intent(out) :: plasma
+
+        plasma%n_species = 2
+        plasma%grid_size = 1
+        allocate(plasma%spec(0:1))
+        allocate(plasma%ks(1), plasma%kp(1), plasma%om_E(1))
+        allocate(plasma%spec(1)%rho_L(1), plasma%spec(1)%vT(1))
+        allocate(plasma%spec(1)%omega_c(1), plasma%spec(1)%lambda_D(1))
+        allocate(plasma%spec(1)%A1(1), plasma%spec(1)%A2(1), plasma%spec(1)%nu(1))
+
+        plasma%ks(1) = 0.37_dp
+        plasma%kp(1) = -0.23_dp
+        plasma%om_E(1) = 0.41_dp
+        plasma%spec(1)%rho_L(1) = 0.62_dp
+        plasma%spec(1)%vT(1) = 1.3_dp
+        plasma%spec(1)%omega_c(1) = 2.1_dp
+        plasma%spec(1)%lambda_D(1) = 0.8_dp
+        plasma%spec(1)%A1(1) = 0.12_dp
+        plasma%spec(1)%A2(1) = -0.07_dp
+        plasma%spec(1)%nu(1) = 9.0e7_dp
+    end subroutine make_manufactured_plasma
+
+    subroutine test_magnetic_recurrence(plasma)
+        use Krook_kernel_plasma_prefacs_m, only: Krook_collisionless_z0
+        type(plasma_t), intent(in) :: plasma
+        complex(dp) :: rp, rb, jp, jb, z0
+
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
+        z0 = Krook_collisionless_z0(plasma%om_E(1), omega, plasma%kp(1), &
+            plasma%spec(1)%vT(1), epsilon)
+        call assert_close('j-B/rho-B recurrence', jb, &
+            sqrt(2.0_dp) * plasma%spec(1)%vT(1) * z0 * rb, 2.0e-13_dp)
+    end subroutine test_magnetic_recurrence
+
+    subroutine test_homogeneous_static_limit(plasma)
+        type(plasma_t), intent(inout) :: plasma
+        complex(dp) :: rp, rb, jp, jb, expected
+        real(dp) :: saved_omega, saved_om_E, saved_ks, saved_rho_L
+        real(dp) :: saved_A1, saved_A2
+
+        saved_omega = omega
+        saved_om_E = plasma%om_E(1)
+        saved_ks = plasma%ks(1)
+        saved_rho_L = plasma%spec(1)%rho_L(1)
+        saved_A1 = plasma%spec(1)%A1(1)
+        saved_A2 = plasma%spec(1)%A2(1)
+
+        omega = 0.0_dp
+        plasma%om_E(1) = 0.0_dp
+        plasma%ks(1) = 0.0_dp
+        plasma%spec(1)%rho_L(1) = 0.0_dp
+        plasma%spec(1)%A1(1) = 0.0_dp
+        plasma%spec(1)%A2(1) = 0.0_dp
+
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
+        expected = cmplx(-1.0_dp / (8.0_dp * pi**2 * plasma%spec(1)%lambda_D(1)**2), 0.0_dp, dp)
+        call assert_close('homogeneous static Debye limit', rp, expected, 2.0e-13_dp)
+        call assert_close('homogeneous rho-B vanishes', rb, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous j-Phi vanishes', jp, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous j-B vanishes', jb, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+
+        omega = saved_omega
+        plasma%om_E(1) = saved_om_E
+        plasma%ks(1) = saved_ks
+        plasma%spec(1)%rho_L(1) = saved_rho_L
+        plasma%spec(1)%A1(1) = saved_A1
+        plasma%spec(1)%A2(1) = saved_A2
+    end subroutine test_homogeneous_static_limit
+
+    subroutine test_resonance_regularization(plasma)
+        type(plasma_t), intent(inout) :: plasma
+        complex(dp) :: rp_wide, rb_wide, jp_wide, jb_wide
+        complex(dp) :: rp_narrow, rb_narrow, jp_narrow, jb_narrow
+        real(dp) :: saved_kp
+
+        saved_kp = plasma%kp(1)
+        plasma%kp(1) = 0.0_dp
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, 0.10_dp, &
+            rp_wide, rb_wide, jp_wide, jb_wide)
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, 0.025_dp, &
+            rp_narrow, rb_narrow, jp_narrow, jb_narrow)
+
+        call assert_finite('rho-Phi at resonance', rp_narrow)
+        call assert_finite('rho-B at resonance', rb_narrow)
+        call assert_finite('j-Phi at resonance', jp_narrow)
+        call assert_finite('j-B at resonance', jb_narrow)
+        if (abs(rb_wide - rb_narrow) <= tiny(1.0_dp) .or. &
+                abs(jp_wide - jp_narrow) <= tiny(1.0_dp)) then
+            print *, 'FAIL: collisionless kernels are insensitive to epsilon at resonance'
+            error stop
+        end if
+        plasma%kp(1) = saved_kp
+    end subroutine test_resonance_regularization
+
+    subroutine test_collision_frequency_independence(plasma)
+        type(plasma_t), intent(inout) :: plasma
+        complex(dp) :: rp_before, rb_before, jp_before, jb_before
+        complex(dp) :: rp_after, rb_after, jp_after, jb_after
+
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, &
+            rp_before, rb_before, jp_before, jb_before)
+        plasma%spec(1)%nu(1) = 1.0e-99_dp
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, &
+            rp_after, rb_after, jp_after, jb_after)
+        call assert_close('rho-Phi collision-frequency independence', rp_after, rp_before, 0.0_dp)
+        call assert_close('rho-B collision-frequency independence', rb_after, rb_before, 0.0_dp)
+        call assert_close('j-Phi collision-frequency independence', jp_after, jp_before, 0.0_dp)
+        call assert_close('j-B collision-frequency independence', jb_after, jb_before, 0.0_dp)
+    end subroutine test_collision_frequency_independence
+
+    subroutine assert_close(label, actual, expected, relative_tolerance)
+        character(*), intent(in) :: label
+        complex(dp), intent(in) :: actual, expected
+        real(dp), intent(in) :: relative_tolerance
+        real(dp) :: tolerance
+
+        if (abs(expected) > 0.0_dp) then
+            tolerance = relative_tolerance * abs(expected)
+        else
+            tolerance = relative_tolerance
+        end if
+        if (abs(actual - expected) > tolerance) then
+            print *, 'FAIL: ', label
+            print *, '  actual   = ', actual
+            print *, '  expected = ', expected
+            print *, '  error    = ', abs(actual - expected), ' tolerance = ', tolerance
+            error stop
+        end if
+    end subroutine assert_close
+
+    subroutine assert_finite(label, value)
+        character(*), intent(in) :: label
+        complex(dp), intent(in) :: value
+
+        if (.not. ieee_is_finite(real(value, dp)) .or. .not. ieee_is_finite(aimag(value))) then
+            print *, 'FAIL: ', label, ' is not finite: ', value
+            error stop
+        end if
+    end subroutine assert_finite
+
+end program test_collisionless_fourier_kernel

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -25,6 +25,7 @@ program test_kim_solver_periodic
     implicit none
 
     call test_run_type_end_to_end()
+    call test_collisionless_ions_end_to_end()
     call test_multi_ion_order_independence()
     call test_global_approximation_enabled()
 
@@ -32,6 +33,89 @@ program test_kim_solver_periodic
     stop 0
 
 contains
+
+    subroutine test_collisionless_ions_end_to_end()
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use config_m, only: profiles_in_memory, nml_config_path, &
+            ion_collision_model, collisionless_kpar_epsilon
+        use fields_m, only: EBdat, EBdat_t
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use species_m, only: set_profiles_from_arrays
+
+        integer, parameter :: npts = 201
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        complex(dp), allocatable :: phi_with_ions(:), jpar_with_ions(:)
+        complex(dp), allocatable :: phi_electrons(:), jpar_electrons(:)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: current_scale
+        integer :: i
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+            q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_collisionless_test.nml', &
+            collisionless_ions=.true.)
+        nml_config_path = './KIM_config_periodic_collisionless_test.nml'
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+            q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        if (trim(ion_collision_model) /= 'collisionless' .or. &
+                collisionless_kpar_epsilon <= 0.0_dp) then
+            print *, 'FAIL: collisionless periodic configuration was not retained'
+            error stop
+        end if
+        phi_with_ions = EBdat%Phi
+        jpar_with_ions = EBdat%jpar
+        do i = 1, size(phi_with_ions)
+            if (.not. ieee_is_finite(real(phi_with_ions(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(phi_with_ions(i))) .or. &
+                .not. ieee_is_finite(real(jpar_with_ions(i), dp)) .or. &
+                .not. ieee_is_finite(aimag(jpar_with_ions(i)))) then
+                print *, 'FAIL: non-finite collisionless periodic output at ', i
+                error stop
+            end if
+        end do
+        if (maxval(abs(phi_with_ions)) <= 0.0_dp .or. &
+                maxval(abs(jpar_with_ions)) <= 0.0_dp) then
+            print *, 'FAIL: collisionless periodic Phi or jpar is identically zero'
+            error stop
+        end if
+
+        ! Repeat with ions disabled.  A changed current proves that the new ion
+        ! current kernels reach reconstruction rather than only charge assembly.
+        deallocate(kim_instance)
+        call write_test_namelist('./KIM_config_periodic_collisionless_test.nml', &
+            collisionless_ions=.true., ions_disabled=.true.)
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+            q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+        phi_electrons = EBdat%Phi
+        jpar_electrons = EBdat%jpar
+
+        current_scale = max(1.0_dp, maxval(abs(jpar_with_ions)))
+        if (maxval(abs(jpar_with_ions - jpar_electrons)) <= 1.0e-10_dp * current_scale) then
+            print *, 'FAIL: disabling collisionless ions did not change jpar'
+            error stop
+        end if
+        if (maxval(abs(phi_with_ions - phi_electrons)) <= &
+                1.0e-10_dp * max(1.0_dp, maxval(abs(phi_with_ions)))) then
+            print *, 'FAIL: disabling collisionless ions did not change Phi'
+            error stop
+        end if
+
+        print *, 'PASS: collisionless periodic ions contribute finite Phi and jpar'
+    end subroutine test_collisionless_ions_end_to_end
 
     subroutine test_run_type_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
@@ -394,7 +478,8 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path, ion_masses, match_global_approximations)
+    subroutine write_test_namelist(path, ion_masses, match_global_approximations, &
+            collisionless_ions, ions_disabled)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
@@ -402,10 +487,15 @@ contains
         character(len=*), intent(in) :: path
         integer, intent(in), optional :: ion_masses(:)
         logical, intent(in), optional :: match_global_approximations
+        logical, intent(in), optional :: collisionless_ions, ions_disabled
         integer :: iunit, i, nions
-        logical :: custom_species
+        logical :: custom_species, use_collisionless, disable_ions
 
         custom_species = present(ion_masses)
+        use_collisionless = .false.
+        if (present(collisionless_ions)) use_collisionless = collisionless_ions
+        disable_ions = .false.
+        if (present(ions_disabled)) disable_ions = ions_disabled
         nions = 1
         if (custom_species) nions = size(ion_masses)
 
@@ -415,8 +505,14 @@ contains
         write(iunit, '(A)') ' artificial_debye_case = 0'
         write(iunit, '(A)') " type_of_run = 'electrostatic_periodic'"
         write(iunit, '(A)') " collision_model = 'FokkerPlanck'"
+        if (use_collisionless) then
+            write(iunit, '(A)') " ion_collision_model = 'collisionless'"
+            write(iunit, '(A)') ' collisionless_kpar_epsilon = 1.0e-5'
+        else
+            write(iunit, '(A)') " ion_collision_model = 'FokkerPlanck'"
+        end if
         write(iunit, '(A,L1)') ' read_species_from_namelist = ', custom_species
-        write(iunit, '(A)') ' turn_off_ions = .false.'
+        write(iunit, '(A,L1)') ' turn_off_ions = ', disable_ions
         write(iunit, '(A)') ' turn_off_electrons = .false.'
         write(iunit, '(A)') " plasma_type = 'D'"
         write(iunit, '(A)') ' rescale_density = .false.'

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -103,6 +103,8 @@ contains
 
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
 
+        call test_configured_dispatch(plasma)
+
         N = rg_grid%npts_b
         if (N /= n_rg) then
             print *, 'FAIL: rg_grid%npts_b /= n_rg; got ', N
@@ -169,6 +171,117 @@ contains
         end do
         print *, 'PASS: all matrix elements finite'
     end subroutine test_assemble
+
+    subroutine test_configured_dispatch(plasma)
+        use collisionless_fourier_kernel_m, only: collisionless_ion_cores, &
+            configured_hatG_rho_phi, configured_hatG_rho_B, &
+            configured_hatG_j_phi, configured_hatG_j_B
+        use config_m, only: ion_collision_model, collisionless_kpar_epsilon, &
+            turn_off_electrons, turn_off_ions
+        use constants_m, only: com_unit, pi
+        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, &
+            hatG_j_phi, hatG_j_B, flr_arg_pair_sp, core_rho_phi_sp, &
+            core_rho_B_sp, core_j_phi_sp, core_j_B_sp
+        use grid_m, only: rg_grid
+        use species_m, only: plasma_t
+
+        type(plasma_t), intent(inout) :: plasma
+        real(dp), parameter :: kr = 0.17_dp, krp = -0.09_dp
+        integer :: j, sp
+        real(dp) :: bplus, bcross, saved_nu
+        complex(dp) :: phase, electron_phi, electron_B, electron_jphi, electron_jB
+        complex(dp) :: ion_phi, ion_B, ion_jphi, ion_jB
+        complex(dp) :: core_phi, core_B, core_jphi, core_jB
+        complex(dp) :: actual_phi, actual_B, actual_jphi, actual_jB
+
+        j = max(1, rg_grid%npts_b / 2)
+        collisionless_kpar_epsilon = 1.0e-5_dp
+        turn_off_electrons = .false.
+        turn_off_ions = .false.
+
+        ! The configured wrapper must be an exact delegation in the default FP
+        ! mode so existing production results do not change.
+        ion_collision_model = 'FokkerPlanck'
+        call assert_dispatch_close('FP rho-Phi delegation', &
+            configured_hatG_rho_phi(plasma, kr, krp, j), hatG_rho_phi(plasma, kr, krp, j))
+        call assert_dispatch_close('FP rho-B delegation', &
+            configured_hatG_rho_B(plasma, kr, krp, j), hatG_rho_B(plasma, kr, krp, j))
+        call assert_dispatch_close('FP j-Phi delegation', &
+            configured_hatG_j_phi(plasma, kr, krp, j), hatG_j_phi(plasma, kr, krp, j))
+        call assert_dispatch_close('FP j-B delegation', &
+            configured_hatG_j_B(plasma, kr, krp, j), hatG_j_B(plasma, kr, krp, j))
+
+        phase = exp(-com_unit * (kr - krp) * rg_grid%xb(j))
+        call flr_arg_pair_sp(plasma, 0, kr, krp, j, bplus, bcross)
+        electron_phi = phase * core_rho_phi_sp(plasma, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+        electron_B = phase * core_rho_B_sp(plasma, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+        electron_jphi = phase * core_j_phi_sp(plasma, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+        electron_jB = phase * core_j_B_sp(plasma, 0, bplus, bcross, j) / (8.0_dp * pi**2)
+
+        ion_phi = (0.0_dp, 0.0_dp)
+        ion_B = (0.0_dp, 0.0_dp)
+        ion_jphi = (0.0_dp, 0.0_dp)
+        ion_jB = (0.0_dp, 0.0_dp)
+        do sp = 1, plasma%n_species - 1
+            call collisionless_ion_cores(plasma, sp, kr, krp, j, &
+                collisionless_kpar_epsilon, core_phi, core_B, core_jphi, core_jB)
+            ion_phi = ion_phi + phase * core_phi
+            ion_B = ion_B + phase * core_B
+            ion_jphi = ion_jphi + phase * core_jphi
+            ion_jB = ion_jB + phase * core_jB
+        end do
+
+        ion_collision_model = 'collisionless'
+        actual_phi = configured_hatG_rho_phi(plasma, kr, krp, j)
+        actual_B = configured_hatG_rho_B(plasma, kr, krp, j)
+        actual_jphi = configured_hatG_j_phi(plasma, kr, krp, j)
+        actual_jB = configured_hatG_j_B(plasma, kr, krp, j)
+        call assert_dispatch_close('hybrid rho-Phi composition', actual_phi, electron_phi + ion_phi)
+        call assert_dispatch_close('hybrid rho-B composition', actual_B, electron_B + ion_B)
+        call assert_dispatch_close('hybrid j-Phi composition', actual_jphi, electron_jphi + ion_jphi)
+        call assert_dispatch_close('hybrid j-B composition', actual_jB, electron_jB + ion_jB)
+        if (abs(ion_jphi) <= tiny(1.0_dp) .and. abs(ion_jB) <= tiny(1.0_dp)) then
+            print *, 'FAIL: configured collisionless ion current is zero'
+            error stop
+        end if
+
+        turn_off_electrons = .true.
+        call assert_dispatch_close('electron-off rho-Phi', &
+            configured_hatG_rho_phi(plasma, kr, krp, j), ion_phi)
+        call assert_dispatch_close('electron-off j-Phi', &
+            configured_hatG_j_phi(plasma, kr, krp, j), ion_jphi)
+        saved_nu = plasma%spec(1)%nu(j)
+        plasma%spec(1)%nu(j) = saved_nu * 17.0_dp
+        call assert_dispatch_close('collisionless ion nu independence', &
+            configured_hatG_rho_phi(plasma, kr, krp, j), ion_phi)
+        plasma%spec(1)%nu(j) = saved_nu
+
+        turn_off_electrons = .false.
+        turn_off_ions = .true.
+        call assert_dispatch_close('ion-off rho-Phi', &
+            configured_hatG_rho_phi(plasma, kr, krp, j), electron_phi)
+        call assert_dispatch_close('ion-off j-Phi', &
+            configured_hatG_j_phi(plasma, kr, krp, j), electron_jphi)
+
+        turn_off_ions = .false.
+        ion_collision_model = 'FokkerPlanck'
+        print *, 'PASS: configured FP/collisionless hybrid dispatch'
+    end subroutine test_configured_dispatch
+
+    subroutine assert_dispatch_close(label, actual, expected)
+        character(*), intent(in) :: label
+        complex(dp), intent(in) :: actual, expected
+        real(dp) :: tolerance
+
+        tolerance = 2.0e-12_dp * max(1.0_dp, abs(expected))
+        if (abs(actual - expected) > tolerance) then
+            print *, 'FAIL: ', label
+            print *, '  actual   = ', actual
+            print *, '  expected = ', expected
+            print *, '  error    = ', abs(actual - expected), ' tolerance = ', tolerance
+            error stop
+        end if
+    end subroutine assert_dispatch_close
 
     !> Recompute K^{rhoPhi}, K^{rhoB}, K^{jPhi} and K^{jB} at (m,m') by an INLINE
     !> brute-force periodic-trapezoidal sum using the SAME formula as the module,

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -238,7 +238,8 @@ contains
         actual_jB = configured_hatG_j_B(plasma, kr, krp, j)
         call assert_dispatch_close('hybrid rho-Phi composition', actual_phi, electron_phi + ion_phi)
         call assert_dispatch_close('hybrid rho-B composition', actual_B, electron_B + ion_B)
-        call assert_dispatch_close('hybrid j-Phi composition', actual_jphi, electron_jphi + ion_jphi)
+        call assert_dispatch_close('hybrid j-Phi composition', actual_jphi, &
+            electron_jphi + ion_jphi)
         call assert_dispatch_close('hybrid j-B composition', actual_jB, electron_jB + ion_jB)
         if (abs(ion_jphi) <= tiny(1.0_dp) .and. abs(ion_jB) <= tiny(1.0_dp)) then
             print *, 'FAIL: configured collisionless ion current is zero'

--- a/docs/derivations/collisionless_periodic_kernels.tex
+++ b/docs/derivations/collisionless_periodic_kernels.tex
@@ -1,0 +1,190 @@
+\documentclass[11pt]{article}
+
+\usepackage[T1]{fontenc}
+\usepackage{amsmath,amssymb}
+\usepackage[a4paper,margin=25mm]{geometry}
+\usepackage{booktabs}
+\usepackage[hidelinks]{hyperref}
+\usepackage{microtype}
+
+\newcommand{\ii}{\mathrm{i}}
+\newcommand{\kpar}{k_{\parallel}}
+\newcommand{\vth}{v_{T\sigma}}
+\newcommand{\oc}{\omega_{c\sigma}}
+\newcommand{\ld}{\lambda_{D\sigma}}
+\newcommand{\Zp}{\mathcal{Z}}
+\setlength{\emergencystretch}{3em}
+
+\title{Collisionless Ion Kernels for KIM Forced Periodicity}
+\author{}
+\date{22 July 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This note reduces the collisionless magnetized response kernels of Chapter~13
+of \texttt{PhD\_thesis.pdf} to the $m_\phi=0$ form implemented by KIM's
+forced-periodicity solver.  It records the Fourier convention, finite-Larmor-
+radius (FLR) arguments, causal regularization, four implementable charge and
+parallel-current kernels, and checks used by the test suite.  The symbolic
+reduction and numerical test oracle are reproducible with the accompanying
+\texttt{collisionless\_periodic\_kernels.wl} Wolfram Language source.
+\end{abstract}
+
+\section{Scope and conventions}
+
+The production periodic model is hybrid: electrons retain the existing
+Fokker--Planck response, while every enabled ion species uses the kernels below
+when \texttt{ion\_collision\_model=}\allowbreak\texttt{'collisionless'}.
+The derivation is
+specialized to $m_\phi=0$, consistent with the existing global collisionless
+charge implementation.  Species labels are suppressed where unambiguous.
+
+KIM reconstructs radial fields with $\exp(+\ii k_r r)$ and uses the local
+two-wavenumber phase
+\begin{equation}
+  P(k_r,k'_r,r_g)=\exp[-\ii(k_r-k'_r)r_g].
+\end{equation}
+Each local $G$ below includes the continuous Fourier normalization
+$1/(8\pi^2)$ but not $P$.  Thus, the functions supplied to matrix quadrature
+are $\widehat G=P G$.  This convention is intentionally the same as the
+existing Fokker--Planck Fourier kernels.
+
+The two-wavenumber FLR arguments are
+\begin{align}
+ b_+ &= \frac{\rho_L^2}{2}\left(2k_s^2+k_r^2+k_r'^2\right),\\
+ b_\times &= \rho_L^2\sqrt{k_s^2+k_r^2}\sqrt{k_s^2+k_r'^2},
+\end{align}
+with overflow-safe scaled Bessel products
+\begin{equation}
+ S_0=e^{-b_+}I_0(b_\times),\qquad
+ S_1=e^{-b_+}I_{-1}(b_\times).
+\end{equation}
+If the optional global-comparison approximation is enabled, the shared KIM
+FLR helper drops $k_s^2$ and takes electrons (but not ions) in the zero-FLR
+limit, exactly as for the Fokker--Planck kernels.
+
+\section{Causal prescription}
+
+The collisionless resonance is regularized by a positive user-supplied
+$\epsilon$ with dimensions of inverse length:
+\begin{equation}
+ k_{\mathrm{abs}}=\sqrt{\kpar^2+\epsilon^2},\qquad
+ k_{\mathrm{pole}}=\kpar+\ii\epsilon,
+\end{equation}
+and
+\begin{equation}
+ z_0=-\frac{\omega_E-\omega}
+ {\sqrt{2}\,\vth k_{\mathrm{abs}}},\qquad
+ Z_0=\Zp(z_0).
+\end{equation}
+Here $\Zp$ is the plasma dispersion function.  Keeping $z_0$ real prevents an
+unphysical exponentially growing evaluation in its lower half-plane.  Even
+charge-response denominators use $k_{\mathrm{abs}}$; signed inverse factors in
+$G^{\rho B}$, $G^{j\Phi}$, and $G^{jB}$ use $k_{\mathrm{pole}}$.
+
+\section{\texorpdfstring{$m_\phi=0$}{m-phi=0} reduction}
+
+Setting $m_\phi=0$ in thesis equations (13.53)--(13.55) gives
+\begin{align}
+ a_0={}&S_0\left[-\frac{\omega_E}{\oc}
+ +\frac{k_s\vth^2}{\oc^2}
+   \left(A_1+(1+b_+)A_2\right)\right]
+ +\frac{k_s\vth^2}{\oc^2}A_2b_\times S_1,\\
+ a_1={}&-\frac{k_{\mathrm{abs}}}{\oc}S_0,\\
+ a_2={}&\frac{k_s A_2}{2\oc^2}S_0.
+\end{align}
+The $k_{\mathrm{abs}}$ in $a_1$ is KIM's collisionless continuation of the
+signed thesis expression.  It is required for the even $\rho$--$\Phi$
+response to recover the same Debye limit on either side of the resonant
+surface.
+
+Equations (13.58) and (13.59) reduce to the moments
+\begin{align}
+ R_0={}&Z_0\left(a_0+\sqrt{2}\vth z_0a_1
+                  +2\vth^2z_0^2a_2\right)
+       +\sqrt{2}\vth\left(a_1+\sqrt{2}\vth z_0a_2\right),\\
+ R_1={}&(z_0Z_0+1)a_0+\sqrt{2}\vth z_0a_1
+       +2\vth^2z_0^2a_2+2\vth^2a_2.
+\end{align}
+The electrostatic kernels from equations (13.63) and (13.67) are therefore
+\begin{align}
+ G^{\rho\Phi}_\sigma(k_r,k'_r,r_g)
+ &=\frac{1}{8\pi^2}
+   \frac{\oc}{\sqrt{2}\,\ld^2\vth k_{\mathrm{abs}}}R_0,\label{eq:rhophi}\\
+ G^{j\Phi}_\sigma(k_r,k'_r,r_g)
+ &=\frac{1}{8\pi^2}
+   \frac{\oc}{\ld^2 k_{\mathrm{pole}}}R_1.\label{eq:jphi}
+\end{align}
+
+Mathematica reduces the bracket shared by thesis equations (13.151) and
+(13.153) to
+\begin{equation}
+ \mathcal{B}=\frac{A_2}{2}S_0
+ +(z_0Z_0+1)\left[
+   \left(A_1+A_2(1+b_++z_0^2)\right)S_0+A_2b_\times S_1
+ \right].
+\end{equation}
+The two magnetic-drive kernels are
+\begin{align}
+ G^{\rho B}_\sigma(k_r,k'_r,r_g)
+ &=\frac{1}{8\pi^2}
+   \frac{\ii\vth^2}{c\ld^2\oc k_{\mathrm{pole}}}\mathcal{B},\label{eq:rhoB}\\
+ G^{jB}_\sigma(k_r,k'_r,r_g)
+ &=\frac{1}{8\pi^2}
+   \frac{\ii\sqrt{2}\vth^3z_0}
+        {c\ld^2\oc k_{\mathrm{pole}}}\mathcal{B}.\label{eq:jB}
+\end{align}
+No collision frequency occurs in equations~\eqref{eq:rhophi}--\eqref{eq:jB}.
+In KIM's Gaussian-cgs convention, the local kernel dimensions implied by these
+expressions are summarized in Table~\ref{tab:dimensions}.
+
+\begin{table}[ht]
+ \centering
+ \caption{Dimensions of the local continuous-Fourier kernels.}
+ \label{tab:dimensions}
+ \begin{tabular}{@{}cc@{}}
+  \toprule
+  Kernel & Dimension \\
+  \midrule
+  $G^{\rho\Phi}$ & $\mathrm{cm}^{-2}$ \\
+  $G^{\rho B}$ & $1$ \\
+  $G^{j\Phi}$ & $\mathrm{cm}^{-1}\,\mathrm{s}^{-1}$ \\
+  $G^{jB}$ & $\mathrm{cm}\,\mathrm{s}^{-1}$ \\
+  \bottomrule
+ \end{tabular}
+\end{table}
+
+\section{Checks and implementation contract}
+
+The symbolic and Fortran tests enforce the following independent checks:
+\begin{enumerate}
+ \item The four kernels reproduce a nontrivial high-precision Mathematica
+       oracle including complex Landau response and off-diagonal FLR coupling.
+ \item Equations~\eqref{eq:rhoB} and \eqref{eq:jB} obey
+       \begin{equation}
+         G^{jB}=\sqrt{2}\vth z_0G^{\rho B}.
+       \end{equation}
+ \item In a homogeneous static zero-FLR plasma,
+       \begin{equation}
+         G^{\rho\Phi}=-\frac{1}{8\pi^2\ld^2},\qquad
+         G^{\rho B}=G^{j\Phi}=G^{jB}=0.
+       \end{equation}
+ \item All four kernels remain finite at $\kpar=0$ for $\epsilon>0$ and
+       respond to changing $\epsilon$.
+ \item Changing the ion Fokker--Planck collision frequency does not change any
+       collisionless ion kernel.
+ \item The default Fokker--Planck dispatch reproduces the original Fourier
+       functions exactly.  Collisionless dispatch equals FP electrons plus
+       collisionless ions and honors both species-disable flags.
+\end{enumerate}
+
+The current implementation requires positive $\epsilon$, $v_T$, and
+$\lambda_D$, nonzero $\omega_c$, and
+\texttt{artificial\_debye\_case=}\allowbreak\texttt{0}.  The diagnostic-only artificial Debye
+splits are not defined by the compact Chapter~13 reduction and are rejected
+instead of being assigned an invented decomposition.  Higher cyclotron
+harmonics $m_\phi\ne0$ remain outside the present model.
+
+\end{document}

--- a/docs/derivations/collisionless_periodic_kernels.wl
+++ b/docs/derivations/collisionless_periodic_kernels.wl
@@ -1,0 +1,82 @@
+(* ::Package:: *)
+
+(*
+  Reproducible m_phi = 0 reduction of the collisionless Fourier kernels.
+
+  Source: PhD_thesis.pdf, equations (13.53)--(13.59), (13.63),
+  (13.67), (13.151), and (13.153).
+
+  KIM convention:
+    kAbs  = Sqrt[kParallel^2 + epsilon^2]
+    kPole = kParallel + I epsilon
+    z0    = -(omegaE - omega)/(Sqrt[2] vT kAbs), kept real
+
+  The common continuous-Fourier normalization 1/(8 Pi^2) is included
+  in the four G expressions below; the radial Fourier phase is not.
+*)
+
+ClearAll["Global`*"];
+
+plasmaZ[z_] := I Sqrt[Pi] Exp[-z^2] Erfc[-I z];
+
+kAbs = Sqrt[kParallel^2 + epsilon^2];
+kPole = kParallel + I epsilon;
+z0 = -(omegaE - omega)/(Sqrt[2] vT kAbs);
+
+bPlus = rhoL^2 (2 ks^2 + kr^2 + krp^2)/2;
+bCross = rhoL^2 Sqrt[ks^2 + kr^2] Sqrt[ks^2 + krp^2];
+s0 = Exp[-bPlus] BesselI[0, bCross];
+s1 = Exp[-bPlus] BesselI[-1, bCross];
+
+(* Equations (13.53)--(13.55), m_phi = 0.  The kAbs replacement in a1
+   is the same even-denominator regularization used by KIM's existing
+   collisionless global charge kernel. *)
+a0 = s0 (-omegaE/omegaC + ks vT^2/omegaC^2 (A1 + (1 + bPlus) A2)) +
+  ks vT^2/omegaC^2 A2 bCross s1;
+a1 = -kAbs/omegaC s0;
+a2 = ks A2/(2 omegaC^2) s0;
+
+(* Equations (13.58) and (13.59), with their kernel prefactors rewritten
+   so that 1/(8 Pi^2) is visibly common to every Fourier-space kernel. *)
+rhoPhiMoment =
+  plasmaZ[z0] (a0 + Sqrt[2] vT z0 a1 + 2 vT^2 z0^2 a2) +
+  Sqrt[2] vT (a1 + Sqrt[2] vT z0 a2);
+jPhiMoment =
+  (z0 plasmaZ[z0] + 1) a0 + Sqrt[2] vT z0 a1 +
+  2 vT^2 z0^2 a2 + 2 vT^2 a2;
+
+rhoPhiCore = omegaC/(Sqrt[2] lambdaD^2 vT kAbs) rhoPhiMoment;
+jPhiCore = omegaC/(lambdaD^2 kPole) jPhiMoment;
+
+(* Equations (13.151) and (13.153), reduced to one common bracket. *)
+magneticBracket =
+  A2 s0/2 + (z0 plasmaZ[z0] + 1) ((A1 + A2 (1 + bPlus + z0^2)) s0 +
+    A2 bCross s1);
+rhoBCore = I vT^2/(c lambdaD^2 omegaC kPole) magneticBracket;
+jBCore = I Sqrt[2] vT^3 z0/(c lambdaD^2 omegaC kPole) magneticBracket;
+
+rhoPhiG = rhoPhiCore/(8 Pi^2);
+rhoBG = rhoBCore/(8 Pi^2);
+jPhiG = jPhiCore/(8 Pi^2);
+jBG = jBCore/(8 Pi^2);
+
+Print["magnetic recurrence check = ",
+  FullSimplify[jBCore - Sqrt[2] vT z0 rhoBCore]];
+Print["homogeneous static Debye check = ",
+  FullSimplify[rhoPhiG /. {A1 -> 0, A2 -> 0, omegaE -> 0, omega -> 0,
+      kr -> 0, krp -> 0, ks -> 0},
+    Assumptions -> {vT > 0, omegaC > 0, lambdaD > 0, epsilon > 0,
+      kParallel ∈ Reals}]];
+
+oracleRules = {
+  kr -> 0.73, krp -> -0.41, rhoL -> 0.62, ks -> 0.37,
+  kParallel -> -0.23, epsilon -> 0.05,
+  omegaE -> 0.41, omega -> 0.17,
+  vT -> 1.3, omegaC -> 2.1, lambdaD -> 0.8,
+  A1 -> 0.12, A2 -> -0.07, c -> 2.99792458*^10
+};
+
+Print["rho_phi = ", N[rhoPhiG /. oracleRules, 18]];
+Print["rho_B   = ", N[rhoBG /. oracleRules, 18]];
+Print["j_phi   = ", N[jPhiG /. oracleRules, 18]];
+Print["j_B     = ", N[jBG /. oracleRules, 18]];

--- a/docs/plans/2026-07-22-kim-periodic-collisionless-ions-design.md
+++ b/docs/plans/2026-07-22-kim-periodic-collisionless-ions-design.md
@@ -1,0 +1,98 @@
+# Collisionless Ions in the Forced-Periodicity Solver
+
+## Objective
+
+Extend `electrostatic_periodic` so `ion_collision_model='collisionless'`
+selects the same hybrid kinetic model as the global electrostatic solver:
+Fokker--Planck electrons and collisionless Krook/Hamiltonian ions. Unlike the
+current global implementation, the periodic implementation will include the
+collisionless-ion contribution to both charge and parallel current. The
+cyclotron-harmonic truncation remains `m_phi=0`, matching the global charge
+model.
+
+## Theory contract
+
+The mathematical source is `~/1_projects/PhD_thesis.pdf`, Chapter 13,
+especially equations (13.53)--(13.59), (13.63), (13.67), (13.151), and
+(13.153). The implementation uses the established KIM radial Fourier pair and
+the periodic phase convention already fixed for the FP kernels. The four
+continuous Fourier integrands are evaluated locally at each periodized
+gyrocentre-grid point and assembled with the existing endpoint-exclusive
+periodic trapezoidal rule.
+
+For each ion species, define
+
+- `b_plus` and `b_cross` with the existing two-wavenumber FLR convention;
+- `sI0 = exp(-b_plus) I_0(b_cross)` and
+  `sIm1 = exp(-b_plus) I_{-1}(b_cross)` using the existing overflow-safe
+  implementation;
+- `k_abs = sqrt(k_parallel**2 + epsilon**2)`;
+- `k_pole = k_parallel + i epsilon`;
+- `z0 = -(omega_E-omega)/(sqrt(2) v_T k_abs)`.
+
+The charge-potential response uses the even denominator `k_abs`, consistent
+with the existing global collisionless-ion prefactors. Signed inverse-
+`k_parallel` factors in the magnetic drive and both current moments use the
+causal pole `k_pole`. This keeps `z0` on the real axis, avoiding the unphysical
+lower-half-plane exponential growth of the plasma dispersion function, while
+retaining causal signed response factors.
+
+## Architecture
+
+Add `collisionless_fourier_kernel_m` beside the existing FP Fourier module.
+It owns pure/local per-species `m_phi=0` collisionless cores for
+`rho-Phi`, `rho-B`, `j-Phi`, and `j-B`, plus hybrid wrapper functions that:
+
+1. retain the current FP electron core;
+2. select FP or collisionless ion cores from `ion_collision_model`;
+3. respect `turn_off_electrons` and `turn_off_ions`;
+4. apply the existing radial Fourier phase and continuous-kernel
+   normalization exactly once.
+
+The new module reuses the public FLR argument and scaled-Bessel helpers from
+`flr2_fourier_kernel_m`. This is a one-way dependency; the existing FP module
+is not modified to depend on the collisionless implementation. The periodic
+assembler calls the configured hybrid wrappers. The default
+`ion_collision_model='FokkerPlanck'` path must reproduce the current matrices
+without numerical change.
+
+No collisionless susceptibility arrays are stored in `plasma_t`. The
+collisionless kernels consume local primitive/derived quantities (`vT`,
+`omega_c`, `lambda_D`, `A1`, `A2`, `ks`, `kp`, and `om_E`) and evaluate `z0`
+and `Z(z0)` directly. Consequently, `ion_fp_collision_scale` and the computed
+ion collision frequency cannot leak into collisionless ion kernels.
+
+## Current-density behavior
+
+For collisionless runs, reconstructed parallel current becomes
+
+`j_parallel = j_parallel,e(FP) + sum_i j_parallel,i(collisionless)`.
+
+Both ion-current kernels come from the first parallel-velocity moment of the
+same `m_phi=0` distribution used for the ion charge kernels. In particular,
+the Mathematica reduction must verify
+
+`G_jB = sqrt(2) vT z0 G_rhoB`
+
+for every ion species and Fourier pair. The implementation must not infer the
+potential-driven current from a charge-kernel ratio; it evaluates the thesis
+first-moment expression directly.
+
+## Verification
+
+The derivation will be retained as both a Wolfram Language source file and a
+standalone LaTeX document. Tests will cover:
+
+- Mathematica-generated complex oracle values for all four kernels;
+- homogeneous, static, zero-FLR Debye and zero-current anchors;
+- the exact `jB/rhoB` recurrence;
+- finite values at `k_parallel=0` for positive epsilon;
+- epsilon sensitivity;
+- FP-path preservation and explicit hybrid species decomposition;
+- independence from `ion_fp_collision_scale` in collisionless mode;
+- finite, nonzero ion current in a low-cost periodic assembly and solve;
+- an end-to-end `electrostatic_periodic` collisionless run.
+
+The clean baseline has one unrelated, documented failure in
+`test_rhs_balance` (`gamma_a_e` stale-`forces_nl` mismatch). That failure is
+not part of this feature and will be reported separately from new regressions.

--- a/docs/plans/2026-07-22-kim-periodic-collisionless-ions.md
+++ b/docs/plans/2026-07-22-kim-periodic-collisionless-ions.md
@@ -1,0 +1,168 @@
+# Collisionless Periodic Ion Kernels Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `m_phi=0` collisionless ion charge and parallel-current kernels to the forced-periodicity electrostatic solver while preserving FP electrons and the default FP-ion path.
+
+**Architecture:** A new `collisionless_fourier_kernel_m` implements the four local ion kernel cores from thesis Chapter 13 and exposes configured hybrid wrappers. `periodic_assembly_m` switches to those wrappers, which preserve existing FP electron and FP-ion behavior and substitute collisionless ions only when configured.
+
+**Tech Stack:** Fortran 2008, CMake/Ninja, CTest, LAPACK, libcerf plasma-dispersion function, Wolfram Language/Mathematica, LaTeX.
+
+---
+
+### Task 1: Freeze symbolic formulas and test oracles
+
+**Files:**
+- Create: `docs/derivations/collisionless_periodic_kernels.wl`
+- Create: `KIM/tests/test_collisionless_fourier_kernel.f90`
+- Modify: `KIM/tests/CMakeLists.txt`
+
+**Step 1: Add the Mathematica derivation source**
+
+Encode thesis (13.53)--(13.59), set `m_phi=0`, simplify the four moments, verify the magnetic-current recurrence, and print high-precision numerical values for a nontrivial manufactured parameter set.
+
+**Step 2: Run Mathematica**
+
+Run:
+
+```sh
+/Applications/Wolfram.app/Contents/MacOS/WolframKernel -noprompt \
+  -run 'Get["docs/derivations/collisionless_periodic_kernels.wl"];Quit[]'
+```
+
+Expected: all symbolic checks print `True` or `0`, followed by four finite complex oracle values.
+
+**Step 3: Write failing pure-kernel tests**
+
+Test the intended public API:
+
+```fortran
+call collisionless_ion_cores(plasma, 1, kr, krp, j, epsilon, &
+    rho_phi, rho_B, j_phi, j_B)
+```
+
+Assert the four Mathematica oracle values, homogeneous anchors, the `jB/rhoB` recurrence, finiteness at resonance, and epsilon sensitivity.
+
+**Step 4: Configure and run the test to verify RED**
+
+Run:
+
+```sh
+cmake -S . -B build
+cmake --build build --target test_collisionless_fourier_kernel.x
+ctest --test-dir build -R '^test_collisionless_fourier_kernel$' --output-on-failure
+```
+
+Expected: compilation fails because `collisionless_fourier_kernel_m` does not exist.
+
+### Task 2: Implement the four collisionless ion cores
+
+**Files:**
+- Create: `KIM/src/asymptotics/collisionless_fourier_kernel.f90`
+- Modify: `KIM/src/CMakeSources.in`
+
+**Step 1: Implement shared local response inputs**
+
+Use `flr_arg_pair_sp` and `scaled_bessel_pair`; evaluate `k_abs`, `k_pole`, real `z0`, and `plasma_Z(z0)` from the local periodic background. Reject nonpositive epsilon and invalid thermal/Debye/gyrofrequency inputs.
+
+**Step 2: Implement `rho-Phi` and `j-Phi`**
+
+Evaluate `a0`, `a1`, and `a2` from thesis (13.53)--(13.55) at `m_phi=0`, then the zeroth and first velocity moments from (13.58)--(13.59). Apply their respective thesis prefactors and the established `1/(8*pi^2)` continuous Fourier normalization exactly once.
+
+**Step 3: Implement `rho-B` and `j-B`**
+
+Use the Mathematica-reduced common magnetic bracket from thesis (13.151) and (13.153), the causal pole, and `1/c`. Evaluate both functions independently, retaining the recurrence as a test rather than as the implementation.
+
+**Step 4: Build and verify GREEN**
+
+Run the focused test. Expected: all oracle and identity cases pass.
+
+### Task 3: Add configured hybrid dispatch
+
+**Files:**
+- Modify: `KIM/src/asymptotics/collisionless_fourier_kernel.f90`
+- Modify: `KIM/src/electrostatic_poisson/periodic_assembly.f90`
+- Test: `KIM/tests/test_collisionless_fourier_kernel.f90`
+- Test: `KIM/tests/test_periodic_assembly.f90`
+
+**Step 1: Write failing dispatch tests**
+
+Assert:
+
+- FP configuration reproduces the existing `hatG_*` outputs;
+- collisionless configuration equals FP electron plus collisionless ion cores;
+- ion current is nonzero;
+- `turn_off_*` flags are honored;
+- changing FP ion collision frequency does not alter collisionless ion cores.
+
+**Step 2: Verify RED**
+
+Run the two focused tests. Expected: the collisionless dispatch assertions fail because periodic assembly still uses all-species FP kernels.
+
+**Step 3: Implement wrappers and assembly selection**
+
+Expose four `configured_hatG_*` wrappers and make `periodic_assembly_m` call them. Validate the collision-model string and preserve the default FP path.
+
+**Step 4: Verify GREEN and FP regression safety**
+
+Run `test_collisionless_fourier_kernel`, `test_periodic_assembly`, `test_flr2_fourier_kernel`, and `test_periodic_solve`.
+
+### Task 4: Exercise the periodic solve and output path
+
+**Files:**
+- Modify: `KIM/tests/test_kim_solver_periodic.f90`
+- Modify: `KIM/src/electrostatic_poisson/poisson_periodic.f90` if output metadata needs clarification
+
+**Step 1: Add a failing low-cost end-to-end case**
+
+Configure `ion_collision_model='collisionless'`, positive epsilon, small `M`, and a resolved `n_rg`. Assert finite/nonzero `Phi` and `jpar`, and verify that the current changes when ions are disabled.
+
+**Step 2: Verify RED, implement missing plumbing, and verify GREEN**
+
+The only expected plumbing is dispatch visibility and output description; no new namelist variables are required.
+
+### Task 5: Document the derivation
+
+**Files:**
+- Create: `docs/derivations/collisionless_periodic_kernels.tex`
+- Modify: `KIM/nmls/README.md`
+
+**Step 1: Write the standalone LaTeX derivation**
+
+Document source equations, `m_phi=0` reduction, FLR definitions, all four implementable kernels, Fourier conventions, causal prescription, dimensions, identities, and limitations.
+
+**Step 2: Build the document**
+
+Run:
+
+```sh
+cd docs/derivations
+pdflatex -interaction=nonstopmode -halt-on-error collisionless_periodic_kernels.tex
+```
+
+Expected: exit 0. Do not commit `.aux`, `.log`, or generated PDF unless explicitly requested.
+
+**Step 3: Update configuration documentation**
+
+State that `electrostatic_periodic` now supports FP electrons plus collisionless ions for charge and current, requires positive `collisionless_kpar_epsilon`, and retains `m_phi=0`.
+
+### Task 6: Full verification and representative run
+
+**Files:**
+- No production files unless verification exposes a defect.
+
+**Step 1: Run focused KIM tests**
+
+Run all periodic and collisionless KIM tests with `ctest -R`.
+
+**Step 2: Run the full build and CTest suite**
+
+Run `make all` and `make test`. Expected: no new failures; the documented baseline `test_rhs_balance` failure may remain.
+
+**Step 3: Run a low-cost collisionless periodic case**
+
+Use the actual AUG profile input already available to the project, with modest `M` and `n_rg`. Record wall time and verify finite `Phi_m.dat` and `jpar.dat`.
+
+**Step 4: Review the diff**
+
+Check formatting, generated-file exclusions, branch status, and preservation of the primary checkout.


### PR DESCRIPTION
## Summary

- add the `m_phi = 0` collisionless ion charge and parallel-current Fourier kernels
- keep Fokker–Planck electrons while selecting collisionless ions through `ion_collision_model`
- document the derivation in LaTeX and a reproducible Mathematica notebook/script
- add pure-kernel, hybrid-dispatch, resonance, collision-independence, and end-to-end coverage

## Motivation

The forced-periodicity solver previously assembled only Fokker–Planck ion kernels, even though the global electrostatic path supported collisionless ion charge. This made an honest periodic/global comparison impossible in collisionless-ion configurations and omitted the collisionless ion contribution to `jpar`.

The new implementation uses the Chapter 13 `m_phi = 0` response, the existing KIM causal prescription `k_abs = sqrt(k_parallel^2 + epsilon^2)` and `k_pole = k_parallel + i epsilon`, and the established periodic Fourier phase and normalization.

## User impact

`electrostatic_periodic` now supports:

- Fokker–Planck electrons
- collisionless ion charge response
- collisionless ion parallel-current response

Select it with:

```fortran
ion_collision_model = 'collisionless'
collisionless_kpar_epsilon = <positive 1/cm value>
artificial_debye_case = 0
```

The default Fokker–Planck behavior is unchanged.

## Validation

- `cmake --build build -j14`
- all 10 periodic/collisionless CTests pass
- Mathematica symbolic checks reproduce the magnetic-current recurrence and homogeneous static Debye limit
- standalone LaTeX derivation builds with `pdflatex`
- real AUG 33353, 2.9 s smoke run: `(m,n)=(7,2)`, `M=31`, `N_rg=256`, 14 OpenMP threads, 0.48 s wall time; finite, nonzero `Phi` and `jpar`

Full local CTest result: 37/38 pass. The only failure is the existing unrelated QL-Balance `test_rhs_balance` stale-`forces_nl` baseline failure (`gamma_a_e` expected 0, actual 0.277555756156289), documented in `AGENTS.md`.