### PR TITLE
feat(KIM): output periodic currents by species

### DIFF
--- a/KIM/README.md
+++ b/KIM/README.md
@@ -21,6 +21,13 @@ The following are automatically downloaded during build:
 ## Configuration
 The code is configured with the namelist file */nmls/KIM_config.nml*.
 
+For `type_of_run = 'electrostatic_periodic'`, the HDF5 `/fields` group contains
+the total parallel current `jpar`, the electron contribution `jpar_e`, the
+summed ion contribution `jpar_i`, and one dataset per configured ion species:
+`jpar_i1`, `jpar_i2`, and so on. Ion dataset indices follow the one-based ion
+order in `&KIM_species`; consequently, `jpar = jpar_e + jpar_i` and
+`jpar_i = sum(jpar_i1, jpar_i2, ...)`.
+
 ## Compilation
 To compile the code:
 ```

--- a/KIM/src/asymptotics/collisionless_fourier_kernel.f90
+++ b/KIM/src/asymptotics/collisionless_fourier_kernel.f90
@@ -16,78 +16,117 @@ module collisionless_fourier_kernel_m
 
 contains
 
-    subroutine configured_hatG_all(plasma_in, kr, krp, j, rho_phi, rho_B, j_phi, j_B)
+    subroutine configured_hatG_all(plasma_in, kr, krp, j, rho_phi, rho_B, j_phi, j_B, &
+            j_phi_species, j_B_species)
         ! Select the configured ion model without changing the electron model.
-        ! In the default FP mode this delegates directly to the established
-        ! functions.  In collisionless mode, electrons remain FP while every
-        ! enabled ion species uses collisionless_ion_cores.
-        use config_m, only: collisionless_kpar_epsilon, ion_collision_model, &
-            turn_off_electrons, turn_off_ions
-        use constants_m, only: com_unit, pi
-        use flr2_fourier_kernel_m, only: hatG_rho_phi, hatG_rho_B, &
-            hatG_j_phi, hatG_j_B, flr_arg_pair_sp, core_rho_phi_sp, &
-            core_rho_B_sp, core_j_phi_sp, core_j_B_sp
-        use grid_m, only: rg_grid
-
+        ! Accumulate the established per-species FP kernels in FokkerPlanck mode.
+        ! In collisionless mode, electrons remain FP while every enabled ion
+        ! species uses collisionless_ion_cores. Optionally return the individual
+        ! species' current kernels alongside their sums.
         type(plasma_t), intent(in) :: plasma_in
         real(dp), intent(in) :: kr, krp
         integer, intent(in) :: j
         complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
+        complex(dp), intent(out), optional :: j_phi_species(0:), j_B_species(0:)
 
         integer :: sp
-        real(dp) :: bplus, bcross
-        complex(dp) :: phase, species_rho_phi, species_rho_B
+        complex(dp) :: species_rho_phi, species_rho_B
         complex(dp) :: species_j_phi, species_j_B
 
-        select case (trim(ion_collision_model))
-        case ('FokkerPlanck')
-            ! Preserve the original arithmetic path exactly by delegation.
-            rho_phi = hatG_rho_phi(plasma_in, kr, krp, j)
-            rho_B = hatG_rho_B(plasma_in, kr, krp, j)
-            j_phi = hatG_j_phi(plasma_in, kr, krp, j)
-            j_B = hatG_j_B(plasma_in, kr, krp, j)
-            return
-        case ('collisionless')
-            continue
-        case default
-            error stop 'Periodic ion_collision_model must be FokkerPlanck or collisionless'
-        end select
-
-        if (collisionless_kpar_epsilon <= 0.0_dp) then
-            error stop 'Collisionless periodic ions require collisionless_kpar_epsilon > 0'
+        if (present(j_phi_species) .neqv. present(j_B_species)) then
+            error stop 'configured_hatG_all requires both species-current arrays'
+        end if
+        if (present(j_phi_species)) then
+            if (ubound(j_phi_species, 1) < plasma_in%n_species - 1 .or. &
+                    ubound(j_B_species, 1) < plasma_in%n_species - 1) then
+                error stop 'configured_hatG_all species-current arrays are too small'
+            end if
+            j_phi_species = (0.0_dp, 0.0_dp)
+            j_B_species = (0.0_dp, 0.0_dp)
         end if
 
-        phase = exp(-com_unit * (kr - krp) * rg_grid%xb(j))
         rho_phi = (0.0_dp, 0.0_dp)
         rho_B = (0.0_dp, 0.0_dp)
         j_phi = (0.0_dp, 0.0_dp)
         j_B = (0.0_dp, 0.0_dp)
 
-        if (.not. turn_off_electrons) then
-            call flr_arg_pair_sp(plasma_in, 0, kr, krp, j, bplus, bcross)
-            rho_phi = core_rho_phi_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
-            rho_B = core_rho_B_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
-            j_phi = core_j_phi_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
-            j_B = core_j_B_sp(plasma_in, 0, bplus, bcross, j) / (8.0_dp * pi**2)
-        end if
+        do sp = 0, plasma_in%n_species - 1
+            call configured_hatG_species(plasma_in, sp, kr, krp, j, &
+                species_rho_phi, species_rho_B, species_j_phi, species_j_B)
+            rho_phi = rho_phi + species_rho_phi
+            rho_B = rho_B + species_rho_B
+            j_phi = j_phi + species_j_phi
+            j_B = j_B + species_j_B
+            if (present(j_phi_species)) then
+                j_phi_species(sp) = species_j_phi
+                j_B_species(sp) = species_j_B
+            end if
+        end do
+    end subroutine configured_hatG_all
 
-        if (.not. turn_off_ions) then
-            do sp = 1, plasma_in%n_species - 1
+    subroutine configured_hatG_species(plasma_in, sp, kr, krp, j, &
+            rho_phi, rho_B, j_phi, j_B)
+        use config_m, only: collisionless_kpar_epsilon, ion_collision_model, &
+            turn_off_electrons, turn_off_ions
+        use constants_m, only: com_unit, pi
+        use flr2_fourier_kernel_m, only: flr_arg_pair_sp, core_rho_phi_sp, &
+            core_rho_B_sp, core_j_phi_sp, core_j_B_sp
+        use grid_m, only: rg_grid
+
+        type(plasma_t), intent(in) :: plasma_in
+        integer, intent(in) :: sp, j
+        real(dp), intent(in) :: kr, krp
+        complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
+
+        real(dp) :: bplus, bcross
+        complex(dp) :: phase
+
+        rho_phi = (0.0_dp, 0.0_dp)
+        rho_B = (0.0_dp, 0.0_dp)
+        j_phi = (0.0_dp, 0.0_dp)
+        j_B = (0.0_dp, 0.0_dp)
+        if ((sp == 0 .and. turn_off_electrons) .or. &
+                (sp >= 1 .and. turn_off_ions)) return
+
+        phase = exp(-com_unit * (kr - krp) * rg_grid%xb(j))
+        select case (trim(ion_collision_model))
+        case ('FokkerPlanck')
+            call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+            rho_phi = core_rho_phi_sp(plasma_in, sp, bplus, bcross, j) &
+                / (8.0_dp * pi**2)
+            rho_B = core_rho_B_sp(plasma_in, sp, bplus, bcross, j) &
+                / (8.0_dp * pi**2)
+            j_phi = core_j_phi_sp(plasma_in, sp, bplus, bcross, j) &
+                / (8.0_dp * pi**2)
+            j_B = core_j_B_sp(plasma_in, sp, bplus, bcross, j) &
+                / (8.0_dp * pi**2)
+        case ('collisionless')
+            if (collisionless_kpar_epsilon <= 0.0_dp) then
+                error stop 'Collisionless periodic ions require collisionless_kpar_epsilon > 0'
+            end if
+            if (sp == 0) then
+                call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
+                rho_phi = core_rho_phi_sp(plasma_in, sp, bplus, bcross, j) &
+                    / (8.0_dp * pi**2)
+                rho_B = core_rho_B_sp(plasma_in, sp, bplus, bcross, j) &
+                    / (8.0_dp * pi**2)
+                j_phi = core_j_phi_sp(plasma_in, sp, bplus, bcross, j) &
+                    / (8.0_dp * pi**2)
+                j_B = core_j_B_sp(plasma_in, sp, bplus, bcross, j) &
+                    / (8.0_dp * pi**2)
+            else
                 call collisionless_ion_cores(plasma_in, sp, kr, krp, j, &
-                    collisionless_kpar_epsilon, species_rho_phi, species_rho_B, &
-                    species_j_phi, species_j_B)
-                rho_phi = rho_phi + species_rho_phi
-                rho_B = rho_B + species_rho_B
-                j_phi = j_phi + species_j_phi
-                j_B = j_B + species_j_B
-            end do
-        end if
+                    collisionless_kpar_epsilon, rho_phi, rho_B, j_phi, j_B)
+            end if
+        case default
+            error stop 'Periodic ion_collision_model must be FokkerPlanck or collisionless'
+        end select
 
         rho_phi = phase * rho_phi
         rho_B = phase * rho_B
         j_phi = phase * j_phi
         j_B = phase * j_B
-    end subroutine configured_hatG_all
+    end subroutine configured_hatG_species
 
     complex(dp) function configured_hatG_rho_phi(plasma_in, kr, krp, j) result(value)
         type(plasma_t), intent(in) :: plasma_in

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -64,7 +64,8 @@ contains
     !> solve uses Kphi/KB, and j_par follows from thesis (11.8) as
     !> Kjphi . Phi_m + KjB . Br_m. The j-kernels already carry their
     !> 1/(8*pi^2) Fourier normalization, so no further scaling is applied here.
-    subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
+    subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
+            Kjphi_species, KjB_species)
         use grid_m, only: rg_grid
         use collisionless_fourier_kernel_m, only: configured_hatG_all
         use constants_m, only: pi
@@ -74,15 +75,30 @@ contains
         integer, intent(in) :: M
         complex(dp), allocatable, intent(out) :: Kphi(:,:), KB(:,:)
         complex(dp), allocatable, intent(out) :: Kjphi(:,:), KjB(:,:)
+        complex(dp), allocatable, intent(out), optional :: Kjphi_species(:,:,:)
+        complex(dp), allocatable, intent(out), optional :: KjB_species(:,:,:)
 
         integer :: N, dim, m_row, m_col, im, imp, j
         real(dp) :: k_m, k_mp, weight
         complex(dp) :: acc_phi, acc_B, acc_jphi, acc_jB
         complex(dp) :: point_phi, point_B, point_jphi, point_jB
+        complex(dp) :: acc_jphi_species(0:plasma%n_species - 1)
+        complex(dp) :: acc_jB_species(0:plasma%n_species - 1)
+        complex(dp) :: point_jphi_species(0:plasma%n_species - 1)
+        complex(dp) :: point_jB_species(0:plasma%n_species - 1)
+        logical :: want_species
 
         N = rg_grid%npts_b
         dim = 2 * M + 1
         allocate(Kphi(dim, dim), KB(dim, dim), Kjphi(dim, dim), KjB(dim, dim))
+        if (present(Kjphi_species) .neqv. present(KjB_species)) then
+            error stop 'assemble_periodic_matrices requires both species-current matrices'
+        end if
+        want_species = present(Kjphi_species)
+        if (want_species) then
+            allocate(Kjphi_species(dim, dim, 0:plasma%n_species - 1))
+            allocate(KjB_species(dim, dim, 0:plasma%n_species - 1))
+        end if
 
         ! Periodic trapezoidal weight. rg_grid%xb is EQUIDISTANT and ENDPOINT-
         ! EXCLUSIVE over one period (grid_generate_equidistant: h = L/N, xb(N) =
@@ -96,10 +112,13 @@ contains
         ! radial quadrature while retaining a fixed summation order in j for
         ! bitwise-reproducible entries at a given compiler/architecture.
         !$omp parallel do default(none) schedule(static) &
-        !$omp shared(M, L, N, weight, plasma, Kphi, KB, Kjphi, KjB) &
+        !$omp shared(M, L, N, weight, plasma, Kphi, KB, Kjphi, KjB, &
+        !$omp        want_species, Kjphi_species, KjB_species) &
         !$omp private(m_col, k_mp, imp, m_row, k_m, im, j, &
         !$omp         acc_phi, acc_B, acc_jphi, acc_jB, &
-        !$omp         point_phi, point_B, point_jphi, point_jB)
+        !$omp         acc_jphi_species, acc_jB_species, &
+        !$omp         point_phi, point_B, point_jphi, point_jB, &
+        !$omp         point_jphi_species, point_jB_species)
         do m_col = -M, M
             k_mp = k_of_m(m_col, L)
             imp = m_col + M + 1
@@ -111,9 +130,21 @@ contains
                 acc_B    = (0.0_dp, 0.0_dp)
                 acc_jphi = (0.0_dp, 0.0_dp)
                 acc_jB   = (0.0_dp, 0.0_dp)
+                if (want_species) then
+                    acc_jphi_species = (0.0_dp, 0.0_dp)
+                    acc_jB_species = (0.0_dp, 0.0_dp)
+                end if
                 do j = 1, N
-                    call configured_hatG_all(plasma, k_m, k_mp, j, &
-                        point_phi, point_B, point_jphi, point_jB)
+                    if (want_species) then
+                        call configured_hatG_all(plasma, k_m, k_mp, j, &
+                            point_phi, point_B, point_jphi, point_jB, &
+                            point_jphi_species, point_jB_species)
+                        acc_jphi_species = acc_jphi_species + point_jphi_species
+                        acc_jB_species = acc_jB_species + point_jB_species
+                    else
+                        call configured_hatG_all(plasma, k_m, k_mp, j, &
+                            point_phi, point_B, point_jphi, point_jB)
+                    end if
                     acc_phi  = acc_phi  + point_phi
                     acc_B    = acc_B    + point_B
                     acc_jphi = acc_jphi + point_jphi
@@ -124,6 +155,10 @@ contains
                 KB(im, imp)    = weight * acc_B
                 Kjphi(im, imp) = weight * acc_jphi
                 KjB(im, imp)   = weight * acc_jB
+                if (want_species) then
+                    Kjphi_species(im, imp, :) = weight * acc_jphi_species
+                    KjB_species(im, imp, :) = weight * acc_jB_species
+                end if
             end do
         end do
         !$omp end parallel do

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -37,13 +37,12 @@ module rt_electrostatic_periodic_m
     !> Does NOT error stop on a singular solve: it returns info /= 0 so the
     !> caller can decide (the run-type error stops; the tests inspect info).
     !>
-    !> The optional jpar returns the parallel current density perturbation on the
-    !> same r_out, per thesis (11.7): j_par = K^{jPhi} Phi + K^{jB} Br. It is
-    !> OPTIONAL because the Phase-3 convergence harnesses scan many (n_rg, M)
-    !> values for dPhi alone and have no use for it. Like dPhi, it is left
-    !> unallocated when the solve fails (info /= 0).
+    !> The optional jpar returns the total parallel current density perturbation
+    !> on the same r_out, per thesis (11.7): j_par = K^{jPhi} Phi + K^{jB} Br.
+    !> The optional jpar_species(:,sp) returns the contribution from each species,
+    !> with electron index sp=0. Both are left unallocated when the solve fails.
     subroutine compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                          r_out, dPhi, info, jpar)
+                                          r_out, dPhi, info, jpar, jpar_species)
         use KIM_kinds_m, only: dp
         use species_m, only: plasma
         use periodic_background_m, only: build_periodic_plasma
@@ -59,19 +58,36 @@ module rt_electrostatic_periodic_m
         complex(dp), allocatable, intent(out) :: dPhi(:)
         integer,     intent(out) :: info
         complex(dp), allocatable, intent(out), optional :: jpar(:)
+        complex(dp), allocatable, intent(out), optional :: jpar_species(:,:)
 
         complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:), Phi_m(:)
+        complex(dp), allocatable :: Kjphi_species(:,:,:), KjB_species(:,:,:)
         real(dp) :: L
+        integer :: sp
 
         L = 2.0_dp * (dx_asis + dx_tr)
 
         call set_global_kernel_approximations(periodic_match_global_kernel_approximations)
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
+        if (present(jpar_species)) then
+            call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
+                Kjphi_species, KjB_species)
+        else
+            call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
+        end if
         call solve_periodic(Kphi, KB, L, M, Br_const, Phi_m, info)
         if (info /= 0) return
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+
+        if (present(jpar_species)) then
+            allocate(jpar_species(size(r_out), 0:plasma%n_species - 1))
+            do sp = 0, plasma%n_species - 1
+                jpar_species(:, sp) = reconstruct_jpar(&
+                    Kjphi_species(:, :, sp), KjB_species(:, :, sp), &
+                    Phi_m, Br_const, L, M, r_out)
+            end do
+        end if
 
         if (present(jpar)) then
             jpar = reconstruct_jpar(Kjphi, KjB, Phi_m, Br_const, L, M, r_out)
@@ -205,17 +221,18 @@ module rt_electrostatic_periodic_m
         use grid_m, only: rg_grid
         use kim_resonances_m, only: r_res
         use fields_m, only: EBdat
-        use IO_collection_m, only: write_complex_profile_abs, write_periodic_scale_metadata
+        use IO_collection_m, only: itoa, write_complex_profile_abs, &
+            write_periodic_scale_metadata
 
         implicit none
 
         class(electrostatic_periodic_t), intent(inout) :: this
 
-        complex(dp), allocatable :: dPhi(:), jpar(:)
+        complex(dp), allocatable :: dPhi(:), jpar(:), jpar_species(:,:)
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
-        integer :: M, n_rg, info, i, reference_species
+        integer :: M, n_rg, info, i, reference_species, sp
 
         ! 1. Locate the resonant surface rm = r_res (q = |m/n|) on the global plasma.
         call prepare_resonances
@@ -277,7 +294,7 @@ module rt_electrostatic_periodic_m
         ! periodic core. It does NOT error stop on a singular solve; do it here.
         Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
         call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                        r_win, dPhi, info, jpar)
+                                        r_win, dPhi, info, jpar, jpar_species)
         if (info /= 0) then
             print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
             error stop "electrostatic_periodic: periodic solve failed"
@@ -293,9 +310,17 @@ module rt_electrostatic_periodic_m
         if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
         if (allocated(EBdat%Phi))    deallocate(EBdat%Phi)
         if (allocated(EBdat%jpar))   deallocate(EBdat%jpar)
+        if (allocated(EBdat%jpar_e)) deallocate(EBdat%jpar_e)
+        if (allocated(EBdat%jpar_i)) deallocate(EBdat%jpar_i)
         EBdat%r_grid = r_win
         EBdat%Phi    = dPhi
         EBdat%jpar   = jpar
+        EBdat%jpar_e = jpar_species(:, 0)
+        allocate(EBdat%jpar_i(size(jpar)))
+        EBdat%jpar_i = (0.0_dp, 0.0_dp)
+        if (plasma%n_species > 1) then
+            EBdat%jpar_i = sum(jpar_species(:, 1:plasma%n_species - 1), dim=2)
+        end if
 
         if (hdf5_output) then
             call write_complex_profile_abs(EBdat%r_grid, EBdat%Phi, rg_grid%npts_b, &
@@ -306,6 +331,20 @@ module rt_electrostatic_periodic_m
                 "/fields/jpar", &
                 'Parallel current density perturbation j_par, forced-periodicity solution', &
                 'statA/cm^2')
+            call write_complex_profile_abs(EBdat%r_grid, EBdat%jpar_e, rg_grid%npts_b, &
+                "/fields/jpar_e", &
+                'Electron parallel current density, forced-periodicity solution', &
+                'statA/cm^2')
+            call write_complex_profile_abs(EBdat%r_grid, EBdat%jpar_i, rg_grid%npts_b, &
+                "/fields/jpar_i", &
+                'Summed ion parallel current density, forced-periodicity solution', &
+                'statA/cm^2')
+            do sp = 1, plasma%n_species - 1
+                call write_complex_profile_abs(EBdat%r_grid, jpar_species(:, sp), &
+                    rg_grid%npts_b, "/fields/jpar_i"//trim(itoa(sp)), &
+                    'Ion-species parallel current density, forced-periodicity solution', &
+                    'statA/cm^2')
+            end do
         end if
 
     end subroutine run_electrostatic_periodic

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -28,11 +28,99 @@ program test_kim_solver_periodic
     call test_collisionless_ions_end_to_end()
     call test_multi_ion_order_independence()
     call test_global_approximation_enabled()
+    call test_species_resolved_currents(.false.)
+    call test_species_resolved_currents(.true.)
 
     print *, 'All tests PASSED'
     stop 0
 
 contains
+
+    subroutine test_species_resolved_currents(collisionless_ions)
+        use config_m, only: profiles_in_memory, nml_config_path
+        use fields_m, only: EBdat, EBdat_t
+        use IO_collection_m, only: deinitialize_hdf5_output, h5id
+        use KAMEL_hdf5_tools, only: h5_get, h5_obj_exists
+        use kim_base_m, only: kim_t
+        use kim_mod_m, only: from_kim_factory_get_kim
+        use species_m, only: set_profiles_from_arrays
+
+        logical, intent(in) :: collisionless_ions
+
+        integer, parameter :: npts = 201
+        integer, parameter :: ion_masses(2) = [2, 3]
+        real(dp) :: r_prof(npts), n_prof(npts), Te_prof(npts)
+        real(dp) :: Ti_prof(npts), q_prof(npts), Er_prof(npts)
+        complex(dp), allocatable :: jpar(:), jpar_e(:), jpar_i(:)
+        complex(dp), allocatable :: jpar_i1(:), jpar_i2(:)
+        class(kim_t), allocatable :: kim_instance
+        real(dp) :: scale
+        integer :: N
+        logical :: ex
+
+        call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
+                                q_prof, Er_prof)
+        call write_test_namelist('./KIM_config_periodic_species_jpar_test.nml', &
+            ion_masses=ion_masses, collisionless_ions=collisionless_ions, &
+            hdf5_enabled=.true.)
+        nml_config_path = './KIM_config_periodic_species_jpar_test.nml'
+
+        profiles_in_memory = .true.
+        call kim_init()
+        call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
+                                      q_prof, Er_prof, npts)
+        EBdat = EBdat_t()
+        call from_kim_factory_get_kim('electrostatic_periodic', kim_instance)
+        call kim_instance%init()
+        call kim_instance%run()
+
+        if (.not. allocated(EBdat%jpar_e)) then
+            print *, 'FAIL: periodic EBdat%jpar_e not allocated'
+            error stop
+        end if
+        if (.not. allocated(EBdat%jpar_i)) then
+            print *, 'FAIL: periodic EBdat%jpar_i not allocated'
+            error stop
+        end if
+
+        call h5_obj_exists(h5id, 'fields/jpar', ex)
+        if (.not. ex) error stop 'periodic total jpar dataset missing'
+        call h5_obj_exists(h5id, 'fields/jpar_e', ex)
+        if (.not. ex) error stop 'periodic electron jpar dataset missing'
+        call h5_obj_exists(h5id, 'fields/jpar_i', ex)
+        if (.not. ex) error stop 'periodic ion-sum jpar dataset missing'
+        call h5_obj_exists(h5id, 'fields/jpar_i1', ex)
+        if (.not. ex) error stop 'periodic first-ion jpar dataset missing'
+        call h5_obj_exists(h5id, 'fields/jpar_i2', ex)
+        if (.not. ex) error stop 'periodic second-ion jpar dataset missing'
+
+        N = size(EBdat%jpar)
+        allocate(jpar(N), jpar_e(N), jpar_i(N), jpar_i1(N), jpar_i2(N))
+        call h5_get(h5id, 'fields/jpar', jpar)
+        call h5_get(h5id, 'fields/jpar_e', jpar_e)
+        call h5_get(h5id, 'fields/jpar_i', jpar_i)
+        call h5_get(h5id, 'fields/jpar_i1', jpar_i1)
+        call h5_get(h5id, 'fields/jpar_i2', jpar_i2)
+
+        scale = max(1.0_dp, maxval(abs(jpar)))
+        if (maxval(abs(jpar_i - jpar_i1 - jpar_i2)) > 1.0e-12_dp * scale) then
+            error stop 'periodic ion species currents do not sum to jpar_i'
+        end if
+        if (maxval(abs(jpar - jpar_e - jpar_i)) > 1.0e-12_dp * scale) then
+            error stop 'periodic species currents do not sum to total jpar'
+        end if
+        if (maxval(abs(EBdat%jpar_e - jpar_e)) > 1.0e-12_dp * scale .or. &
+                maxval(abs(EBdat%jpar_i - jpar_i)) > 1.0e-12_dp * scale) then
+            error stop 'periodic EBdat species currents differ from HDF5 output'
+        end if
+
+        call deinitialize_hdf5_output()
+        if (collisionless_ions) then
+            print *, 'PASS: collisionless periodic species currents sum to total jpar'
+        else
+            print *, 'PASS: FokkerPlanck periodic species currents sum to total jpar'
+        end if
+    end subroutine test_species_resolved_currents
 
     subroutine test_collisionless_ions_end_to_end()
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
@@ -479,7 +567,7 @@ contains
     end subroutine make_test_profiles
 
     subroutine write_test_namelist(path, ion_masses, match_global_approximations, &
-            collisionless_ions, ions_disabled)
+            collisionless_ions, ions_disabled, hdf5_enabled)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
@@ -487,15 +575,17 @@ contains
         character(len=*), intent(in) :: path
         integer, intent(in), optional :: ion_masses(:)
         logical, intent(in), optional :: match_global_approximations
-        logical, intent(in), optional :: collisionless_ions, ions_disabled
+        logical, intent(in), optional :: collisionless_ions, ions_disabled, hdf5_enabled
         integer :: iunit, i, nions
-        logical :: custom_species, use_collisionless, disable_ions
+        logical :: custom_species, use_collisionless, disable_ions, write_hdf5
 
         custom_species = present(ion_masses)
         use_collisionless = .false.
         if (present(collisionless_ions)) use_collisionless = collisionless_ions
         disable_ions = .false.
         if (present(ions_disabled)) disable_ions = ions_disabled
+        write_hdf5 = .false.
+        if (present(hdf5_enabled)) write_hdf5 = hdf5_enabled
         nions = 1
         if (custom_species) nions = size(ion_masses)
 
@@ -539,11 +629,11 @@ contains
         write(iunit, '(A)') " profile_location = './'"
         write(iunit, '(A)') " output_path = './out_periodic_run_test/'"
         write(iunit, '(A)') ' hdf5_input = .false.'
-        write(iunit, '(A)') ' hdf5_output = .false.'
+        write(iunit, '(A,L1)') ' hdf5_output = ', write_hdf5
         write(iunit, '(A)') ' log_level = 3'
         write(iunit, '(A)') ' data_verbosity = 0'
         write(iunit, '(A)') ' calculate_asymptotics = .false.'
-        write(iunit, '(A)') " h5_out_file = ''"
+        write(iunit, '(A)') " h5_out_file = 'KIM_species_jpar.h5'"
         write(iunit, '(A)') ' write_diagnostics_dat = .false.'
         write(iunit, '(A)') '/'
         write(iunit, '(A)') '&KIM_SETUP'

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -57,6 +57,7 @@ contains
         class(kim_t), allocatable :: kim_instance
 
         complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:)
+        complex(dp), allocatable :: Kjphi_species(:,:,:), KjB_species(:,:,:)
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
         integer :: n_rg, N, dim, im, imp
 
@@ -111,7 +112,8 @@ contains
             error stop
         end if
 
-        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
+        call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
+            Kjphi_species, KjB_species)
 
         ! (shape) all four matrices are (2M+1) x (2M+1).
         dim = 2 * M + 1
@@ -127,6 +129,19 @@ contains
             error stop
         end if
         print *, 'PASS: shape (2M+1)x(2M+1) =', dim, 'x', dim
+
+        if (lbound(Kjphi_species, 3) /= 0 .or. &
+                ubound(Kjphi_species, 3) /= plasma%n_species - 1 .or. &
+                any(shape(Kjphi_species) /= shape(KjB_species))) then
+            error stop 'species-current matrix shape or bounds are wrong'
+        end if
+        if (maxval(abs(Kjphi - sum(Kjphi_species, dim=3))) > &
+                2.0e-12_dp * max(1.0_dp, maxval(abs(Kjphi))) .or. &
+                maxval(abs(KjB - sum(KjB_species, dim=3))) > &
+                2.0e-12_dp * max(1.0_dp, maxval(abs(KjB)))) then
+            error stop 'species-current matrices do not sum to aggregate matrices'
+        end if
+        print *, 'PASS: species-current matrices sum to aggregate matrices'
 
         ! (characterization) recompute two elements by an inline brute-force sum
         ! with the SAME quadrature formula and compare to the stored elements.


### PR DESCRIPTION
## Summary

- assemble species-resolved parallel-current kernels in the forced-periodicity solver for both Fokker–Planck and collisionless-ion modes
- write `fields/jpar_e`, `fields/jpar_i`, and per-ion `fields/jpar_i1`, `fields/jpar_i2`, … alongside the existing total `fields/jpar`
- retain the existing total-current and potential solutions while exposing each species contribution for diagnostics
- document the new HDF5 datasets and test that species currents sum to the total

## Motivation

The Er-scan analysis needs to distinguish electron and ion contributions to the parallel current without changing the physical solve or relying on separate species-removal runs. The periodic solver previously discarded that decomposition after summing its current kernels.

## Validation

- `cmake --build build --target KIM.x test_collisionless_fourier_kernel test_periodic_assembly test_kim_solver_periodic`
- `ctest --test-dir build -R 'test_collisionless_fourier_kernel|test_periodic_assembly|test_kim_solver_periodic' --output-on-failure` (3/3 passed)
- AUG `(m,n)=(7,2)`, `lambda=-1` comparison against the pre-change executable: relative L2 difference `2.8e-14` for `Phi` and `8.5e-15` for total `jpar`
