### PR TITLE
feat(KIM): integrate KiLCA-FLR2 as a run type

### DIFF
--- a/KIM/README.md
+++ b/KIM/README.md
@@ -28,6 +28,51 @@ summed ion contribution `jpar_i`, and one dataset per configured ion species:
 order in `&KIM_species`; consequently, `jpar = jpar_e + jpar_i` and
 `jpar_i = sum(jpar_i1, jpar_i2, ...)`.
 
+## FLR2 run type
+
+Set `type_of_run = 'flr2'` to solve the second-order finite-Larmor-radius
+response imported from KiLCA-FLR2 through the normal KIM lifecycle:
+
+```fortran
+&KIM_CONFIG
+  type_of_run = 'flr2'
+  collision_model = 'FokkerPlanck'
+  number_of_ion_species = 1
+/
+
+&KIM_SETUP
+  m_mode = -6
+  n_mode = 2
+  R0 = 165.0
+  type_br_field = 12
+  Br_boundary_re = 1.0
+  Br_boundary_im = 0.0
+/
+```
+
+This mode does not use KiLCA-FLR2's profile or equilibrium readers. KIM
+calculates the radial grid, cylindrical equilibrium, thermodynamic forces,
+collision frequencies, Larmor radii, and Fokker–Planck susceptibilities once;
+the FLR2 response consumes those prepared arrays directly. The result is
+written through the standard KIM field outputs:
+
+- `fields/Br`: radial magnetic-field perturbation in G
+- `fields/Phi`: electrostatic potential perturbation in statV
+- `fields/jpar`: parallel current density in statA/cm²
+
+`type_br_field = 12` applies the constant complex field configured by
+`Br_boundary_re` and `Br_boundary_im`. `type_br_field = 11` reads
+`./inp/Br_in.dat`. The current implementation requires Fokker–Planck
+collisions, `omega = 0`, and exactly one positively charged ion species.
+
+The optional `&KIM_FLR2` group enables or disables electron and ion FLR,
+potential, and current terms. All switches default to `.true.`; see the
+[namelist reference](nmls/README.md).
+
+The existing `type_of_run = 'flr2_benchmark'` is different: it exercises the
+FLR2 approximation of KIM's non-local integral kernel and global Poisson
+solver.
+
 ## Compilation
 To compile the code:
 ```

--- a/KIM/nmls/KIM_config.nml
+++ b/KIM/nmls/KIM_config.nml
@@ -3,7 +3,7 @@
 &kim_config
     number_of_ion_species = 1
     read_species_from_namelist = .false.    ! if false, initialize deuterium plasma
-    type_of_run = 'electrostatic'           ! 'electrostatic', 'electromagnetic', 'WKB_dispersion', or 'flr2_benchmark'
+    type_of_run = 'electrostatic'           ! Also: 'flr2', 'flr2_benchmark', 'electromagnetic', 'WKB_dispersion'
     collision_model = 'FokkerPlanck'        ! 'Krook' (unstable) or 'FokkerPlanck'
     artificial_debye_case = 0
     turn_off_ions = .false.
@@ -85,6 +85,16 @@
     gauss_int_nodes_Nx = 31                 ! Gauss integration node points, should be different from Nxp to avoid numerical problems
     gauss_int_nodes_Nxp = 30                !
     gauss_int_nodes_Ntheta = 17             ! For GaussLegendre integration of theta
+/
+
+&KIM_FLR2
+    flr2_electron_flr = .true.
+    flr2_ion_flr = .true.
+    flr2_electron_potential = .true.
+    flr2_ion_potential = .true.
+    flr2_electron_current = .true.
+    flr2_ion_current = .true.
+    flr2_include_potential_in_current = .true.
 /
 
 &kim_species ! not used rn

--- a/KIM/nmls/README.md
+++ b/KIM/nmls/README.md
@@ -4,7 +4,7 @@ KIM is configured via the namelist file KIM_config.nml containing multiple namel
 ## KIM_CONFIG
 - number_of_ion_species ... integer, number of ion species
 - read_species_from_namelist ... boolean, if false, initialize deuterium plasma
-- type_of_run ... string, specifies the type of run, options include: 'electrostatic', 'electrostatic_periodic', 'electromagnetic', 'WKB_dispersion', 'flr2_benchmark'
+- type_of_run ... string, specifies the type of run, options include: 'electrostatic', 'electrostatic_periodic', 'electromagnetic', 'WKB_dispersion', 'flr2', 'flr2_benchmark'. `flr2` runs the imported KiLCA-FLR2 local second-order response using KIM's prepared background; `flr2_benchmark` runs KIM's non-local FLR2 kernel benchmark.
 - collision_model ... string, collision model to use, options are: 'Krook', 'FokkerPlanck'
 - ion_collision_model ... string, ion model used with `collision_model='FokkerPlanck'`: `FokkerPlanck` (default) or `collisionless`. In `electrostatic_periodic`, collisionless mode keeps FP electrons and uses the $m_\phi=0$ collisionless ion kernels for both charge and parallel current.
 - collisionless_kpar_epsilon ... real, positive causal-pole width in 1/cm required by `ion_collision_model='collisionless'`. KIM uses $k_{\parallel}+i\epsilon$ for signed inverse factors and $\sqrt{k_{\parallel}^2+\epsilon^2}$ for even charge-response factors.
@@ -33,13 +33,13 @@ this ion model; the implemented derivation uses $m_\phi=0$.
 - n_mode ... integer, toroidal mode number of the resonant surface
 - omega ... double, perturbation frequency (rad/s)
 - spline_base ... integer, specifies which spline base to use in the FEM procedure, options: 1 - hat functions
-- type_br_field ... integer, specifies which type of Br field (array) is used
+- type_br_field ... integer, specifies which type of Br field (array) is used. The `flr2` run type supports 11 (read `./inp/Br_in.dat`) and 12 (constant complex field from `Br_boundary_re/im`).
 - collisions_off ... boolean, if true, sets collision frequencies to zero
 - set_profiles_constant ... integer, if 1, sets profiles constant to the core value
 - bc_type ... integer, boundary condition type. 0: None; 1: zero Neuman left, zero Dirichlet right; 2: Dirichlet left and right; 3: zero-misalignment
 - mphi_max ... integer, maximum number of cyclotron harmonics to include in kernel calculations
-- Br_boundary_re ... double, real part of Br at right boundary (default 1.0), used by 'electromagnetic' run type
-- Br_boundary_im ... double, imaginary part of Br at right boundary (default 0.0), used by 'electromagnetic' run type
+- Br_boundary_re ... double, real part of Br at right boundary (default 1.0), used by the `electromagnetic` run type and as the constant Br amplitude for `flr2`
+- Br_boundary_im ... double, imaginary part of Br at right boundary (default 0.0), used by the `electromagnetic` run type and as the constant Br amplitude for `flr2`
 
 ## KIM_GRID
 - r_plas ... double, minor radius of the plasma in cm
@@ -106,3 +106,24 @@ For `ion_collision_model='collisionless'`, these settings control the same
 periodic window and Fourier basis as in FP mode. The assembled response is FP
 electrons plus collisionless ion charge and current. Both `Phi` and `jpar` are
 written through the standard forced-periodicity output path.
+
+## KIM_FLR2
+
+This optional group controls only terms in the KiLCA-FLR2 response. KIM's
+existing profile, equilibrium, collision-frequency, density-rescaling, and
+energy-conservation settings remain authoritative.
+
+- flr2_electron_flr ... boolean, include the electron second-order FLR terms
+- flr2_ion_flr ... boolean, include the ion second-order FLR terms
+- flr2_electron_potential ... boolean, include electrons in the potential equation
+- flr2_ion_potential ... boolean, include ions in the potential equation
+- flr2_electron_current ... boolean, include electrons in the parallel current
+- flr2_ion_current ... boolean, include ions in the parallel current
+- flr2_include_potential_in_current ... boolean, include the solved potential contribution in the current; if false, `Phi` is set to zero and only the magnetic-drive current is returned
+
+All seven switches default to `.true.` when the group is omitted. The `flr2`
+run type requires `collision_model='FokkerPlanck'`, exactly one ion species,
+`omega=0`, nonzero radial electric field over the solve domain, and
+`type_br_field` 11 or 12. Existing `turn_off_electrons` and `turn_off_ions`
+settings also gate the corresponding FLR2 potential and current contributions.
+It writes `Br`, `Phi`, and `jpar` on KIM's guiding-centre boundary grid.

--- a/KIM/src/CMakeLists.txt
+++ b/KIM/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(KIM_lib STATIC "${KIM_setup}"
                         "${KIM_dispersion}"
                         "${KIM_WKB_dispersion}"
                         "${KIM_asymptotics}"
+                        "${KIM_flr2}"
                         "${KIM_diagnostics}"
                         "${KIM_electromagnetic}"
 )

--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -81,6 +81,11 @@ set(KIM_asymptotics asymptotics/FLR2_asymptotics.f90
                     asymptotics/collisionless_fourier_kernel.f90
 )
 
+set(KIM_flr2 flr2/flr2_tridiagonal.f90
+              flr2/flr2_response.f90
+              flr2/flr2_run_type.f90
+)
+
 set(KIM_diagnostics diagnostics/kim_diagnostics_mod.f90
                     diagnostics/kim_qldiff_mod.f90
 )

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -1208,6 +1208,8 @@ module species_m
         ! From plasma species (allocated in calculate_plasma_backs)
         do sp = 0, number_of_ion_species
             if (sp > ubound(plasma%spec, 1)) exit
+            if (allocated(plasma%spec(sp)%dndr)) deallocate(plasma%spec(sp)%dndr)
+            if (allocated(plasma%spec(sp)%dTdr)) deallocate(plasma%spec(sp)%dTdr)
             if (allocated(plasma%spec(sp)%vT)) deallocate(plasma%spec(sp)%vT)
             if (allocated(plasma%spec(sp)%nu)) deallocate(plasma%spec(sp)%nu)
             if (allocated(plasma%spec(sp)%omega_c)) deallocate(plasma%spec(sp)%omega_c)

--- a/KIM/src/flr2/flr2_response.f90
+++ b/KIM/src/flr2/flr2_response.f90
@@ -1,0 +1,230 @@
+module flr2_response_m
+    ! Second-order local response adapted from KiLCA-FLR2 response_current.f90.
+    ! Profile preparation is intentionally absent: KIM's plasma_t is the single
+    ! source of equilibrium, collision, force, FLR, and susceptibility data.
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use KIM_kinds_m, only: dp
+    use constants_m, only: com_unit, e_charge, pi
+    use species_m, only: plasma_t
+    use flr2_tridiagonal_m, only: solve_flr2_tridiagonal, FLR2_SOLVE_OK
+    implicit none
+    private
+
+    integer, parameter, public :: FLR2_RESPONSE_OK = 0
+    integer, parameter, public :: FLR2_RESPONSE_BAD_INPUT = 10
+
+    type, public :: flr2_options_t
+        logical :: electron_flr = .true.
+        logical :: ion_flr = .true.
+        logical :: electron_potential = .true.
+        logical :: ion_potential = .true.
+        logical :: electron_current = .true.
+        logical :: ion_current = .true.
+        logical :: include_potential_in_current = .true.
+    end type flr2_options_t
+
+    public :: solve_flr2_response
+
+contains
+
+    subroutine solve_flr2_response(background, mpol, ntor, major_radius, &
+                                   toroidal_field, bpsi_over_bphi, options, &
+                                   phi, parcur_over_b0, stat)
+        type(plasma_t), intent(in) :: background
+        integer, intent(in) :: mpol, ntor
+        real(dp), intent(in) :: major_radius
+        real(dp), intent(in) :: toroidal_field(:)
+        complex(dp), intent(in) :: bpsi_over_bphi(:)
+        type(flr2_options_t), intent(in) :: options
+        complex(dp), intent(out) :: phi(:), parcur_over_b0(:)
+        integer, intent(out) :: stat
+
+        integer :: i, include_phi, n, solver_stat, sp
+        real(dp) :: charge, current_switch, flr_switch, potential_switch
+        real(dp) :: dphi_dr, mode_factor, rho2_factor
+        complex(dp) :: factor_of_phi
+        complex(dp) :: f_species, g_species, h_species
+        complex(dp) :: f_current, f_potential
+        complex(dp) :: g_current, g_potential, h_potential
+        complex(dp), allocatable :: a2_in(:), a2_out(:), a0(:)
+        complex(dp), allocatable :: b2_in(:), b2_out(:), b0(:)
+        complex(dp), allocatable :: c2_in(:), c2_out(:), c0(:)
+        complex(dp), allocatable :: d2_in(:), d2_out(:), d0(:)
+
+        phi = (0.0_dp, 0.0_dp)
+        parcur_over_b0 = (0.0_dp, 0.0_dp)
+        stat = FLR2_RESPONSE_BAD_INPUT
+        n = background%grid_size
+
+        if (.not. valid_background(background, n)) return
+        if (.not. ieee_is_finite(major_radius) .or. major_radius <= 0.0_dp) return
+        if (size(toroidal_field) /= n .or. size(bpsi_over_bphi) /= n &
+            .or. size(phi) /= n .or. size(parcur_over_b0) /= n) return
+        if (.not. all(ieee_is_finite(toroidal_field))) return
+        if (.not. finite_complex_1d(bpsi_over_bphi)) return
+
+        allocate(a2_in(n), a2_out(n), a0(n))
+        allocate(b2_in(n), b2_out(n), b0(n))
+        allocate(c2_in(n), c2_out(n), c0(n))
+        allocate(d2_in(n), d2_out(n), d0(n))
+
+        do i = 1, n
+            mode_factor = real(mpol, dp) + background%q(i)*real(ntor, dp)
+            dphi_dr = -background%Er(i)
+            if (abs(dphi_dr) <= tiny(1.0_dp) &
+                .or. abs(background%q(i)) <= tiny(1.0_dp) &
+                .or. abs(background%om_E(i)) <= tiny(1.0_dp) &
+                .or. abs(toroidal_field(i)) <= tiny(1.0_dp)) return
+
+            factor_of_phi = com_unit*mode_factor/(background%q(i)*dphi_dr)
+            f_potential = (0.0_dp, 0.0_dp)
+            g_potential = (0.0_dp, 0.0_dp)
+            h_potential = (0.0_dp, 0.0_dp)
+            f_current = (0.0_dp, 0.0_dp)
+            g_current = (0.0_dp, 0.0_dp)
+
+            do sp = 0, background%n_species - 1
+                if (background%spec(sp)%nu(i) <= 0.0_dp) return
+
+                if (sp == 0) then
+                    flr_switch = logical_factor(options%electron_flr)
+                    potential_switch = logical_factor(options%electron_potential)
+                    current_switch = logical_factor(options%electron_current)
+                else
+                    flr_switch = logical_factor(options%ion_flr)
+                    potential_switch = logical_factor(options%ion_potential)
+                    current_switch = logical_factor(options%ion_current)
+                end if
+
+                charge = real(background%spec(sp)%Zspec, dp)*e_charge
+                rho2_factor = (background%spec(sp)%rho_L(i)/major_radius)**2*flr_switch
+
+                f_species = charge*background%spec(sp)%n(i)*background%spec(sp)%vT(i)**2 &
+                            /background%spec(sp)%nu(i) &
+                            *(background%spec(sp)%I11(i, 0) &
+                              *(background%spec(sp)%A1(i) + background%spec(sp)%A2(i)) &
+                              + 0.5_dp*background%spec(sp)%I13(i, 0)*background%spec(sp)%A2(i))
+                g_species = 0.5_dp*rho2_factor*charge*background%spec(sp)%n(i) &
+                            *background%spec(sp)%vT(i)**2/background%spec(sp)%nu(i) &
+                            *(background%spec(sp)%I11(i, 0) &
+                              *(background%spec(sp)%A1(i) + 2.0_dp*background%spec(sp)%A2(i)) &
+                              + 0.5_dp*background%spec(sp)%I13(i, 0)*background%spec(sp)%A2(i))
+                h_species = 0.5_dp*rho2_factor*charge*background%spec(sp)%n(i) &
+                            *major_radius**2/dphi_dr &
+                            *(background%spec(sp)%A1(i) + 2.5_dp*background%spec(sp)%A2(i))
+
+                f_potential = f_potential + potential_switch*f_species
+                g_potential = g_potential + potential_switch*g_species
+                h_potential = h_potential + potential_switch*h_species
+                f_current = f_current + current_switch*f_species
+                g_current = g_current + current_switch*g_species
+            end do
+
+            b0(i) = -4.0_dp*pi*mode_factor*f_potential &
+                    /(background%q(i)*background%om_E(i)*major_radius**2)
+            b2_in(i) = -4.0_dp*pi*mode_factor*g_potential &
+                       /(background%q(i)*background%om_E(i))
+            b2_out(i) = b2_in(i)
+
+            a0(i) = -b0(i)*factor_of_phi
+            a2_in(i) = -b2_in(i)*factor_of_phi + 4.0_dp*pi*h_potential
+            a2_out(i) = cmplx(1.0_dp, 0.0_dp, dp) + a2_in(i)
+
+            d0(i) = -f_current/(toroidal_field(i)*major_radius)
+            d2_in(i) = -g_current*major_radius/toroidal_field(i)
+            d2_out(i) = d2_in(i)
+            c0(i) = d0(i)*factor_of_phi
+            c2_in(i) = d2_in(i)*factor_of_phi
+            c2_out(i) = c2_in(i)
+        end do
+
+        include_phi = merge(1, 0, options%include_potential_in_current)
+        call solve_flr2_tridiagonal(include_phi, background%r_grid, bpsi_over_bphi, &
+                                    a2_in, a2_out, a0, b2_in, b2_out, b0, &
+                                    c2_in, c2_out, c0, d2_in, d2_out, d0, &
+                                    phi, parcur_over_b0, solver_stat)
+        if (solver_stat /= FLR2_SOLVE_OK) then
+            stat = solver_stat
+            return
+        end if
+        stat = FLR2_RESPONSE_OK
+    end subroutine solve_flr2_response
+
+    logical function valid_background(background, n)
+        type(plasma_t), intent(in) :: background
+        integer, intent(in) :: n
+        integer :: sp
+
+        valid_background = .false.
+        if (n < 3 .or. background%n_species < 1) return
+        if (.not. allocated(background%spec)) return
+        if (.not. allocated(background%r_grid) .or. size(background%r_grid) /= n) return
+        if (.not. allocated(background%q) .or. size(background%q) /= n) return
+        if (.not. allocated(background%B0) .or. size(background%B0) /= n) return
+        if (.not. allocated(background%Er) .or. size(background%Er) /= n) return
+        if (.not. allocated(background%om_E) .or. size(background%om_E) /= n) return
+        if (.not. all(ieee_is_finite(background%r_grid))) return
+        if (.not. all(ieee_is_finite(background%q))) return
+        if (.not. all(ieee_is_finite(background%B0)) &
+            .or. any(background%B0 <= 0.0_dp)) return
+        if (.not. all(ieee_is_finite(background%Er))) return
+        if (.not. all(ieee_is_finite(background%om_E))) return
+
+        do sp = 0, background%n_species - 1
+            if (.not. allocated(background%spec(sp)%n)) return
+            if (.not. allocated(background%spec(sp)%vT)) return
+            if (.not. allocated(background%spec(sp)%nu)) return
+            if (.not. allocated(background%spec(sp)%rho_L)) return
+            if (.not. allocated(background%spec(sp)%A1)) return
+            if (.not. allocated(background%spec(sp)%A2)) return
+            if (.not. allocated(background%spec(sp)%I11)) return
+            if (.not. allocated(background%spec(sp)%I13)) return
+            if (size(background%spec(sp)%n) /= n) return
+            if (size(background%spec(sp)%vT) /= n) return
+            if (size(background%spec(sp)%nu) /= n) return
+            if (size(background%spec(sp)%rho_L) /= n) return
+            if (size(background%spec(sp)%A1) /= n) return
+            if (size(background%spec(sp)%A2) /= n) return
+            if (size(background%spec(sp)%I11, 1) /= n) return
+            if (size(background%spec(sp)%I13, 1) /= n) return
+            if (lbound(background%spec(sp)%I11, 2) > 0 &
+                .or. ubound(background%spec(sp)%I11, 2) < 0) return
+            if (lbound(background%spec(sp)%I13, 2) > 0 &
+                .or. ubound(background%spec(sp)%I13, 2) < 0) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%n)) &
+                .or. any(background%spec(sp)%n <= 0.0_dp)) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%vT)) &
+                .or. any(background%spec(sp)%vT <= 0.0_dp)) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%nu)) &
+                .or. any(background%spec(sp)%nu <= 0.0_dp)) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%rho_L)) &
+                .or. any(background%spec(sp)%rho_L < 0.0_dp)) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%A1))) return
+            if (.not. all(ieee_is_finite(background%spec(sp)%A2))) return
+            if (.not. finite_complex_2d(background%spec(sp)%I11)) return
+            if (.not. finite_complex_2d(background%spec(sp)%I13)) return
+        end do
+        valid_background = .true.
+    end function valid_background
+
+    logical function finite_complex_1d(values)
+        complex(dp), intent(in) :: values(:)
+
+        finite_complex_1d = all(ieee_is_finite(real(values, dp))) &
+                            .and. all(ieee_is_finite(aimag(values)))
+    end function finite_complex_1d
+
+    logical function finite_complex_2d(values)
+        complex(dp), intent(in) :: values(:, :)
+
+        finite_complex_2d = all(ieee_is_finite(real(values, dp))) &
+                            .and. all(ieee_is_finite(aimag(values)))
+    end function finite_complex_2d
+
+    pure real(dp) function logical_factor(enabled)
+        logical, intent(in) :: enabled
+
+        logical_factor = merge(1.0_dp, 0.0_dp, enabled)
+    end function logical_factor
+
+end module flr2_response_m

--- a/KIM/src/flr2/flr2_run_type.f90
+++ b/KIM/src/flr2/flr2_run_type.f90
@@ -1,0 +1,127 @@
+module rt_flr2_m
+    use kim_base_m, only: kim_t
+    implicit none
+    private
+
+    type, extends(kim_t), public :: flr2_t
+    contains
+        procedure :: init => init_flr2
+        procedure :: run => run_flr2
+    end type flr2_t
+
+contains
+
+    subroutine init_flr2(this)
+        use equilibrium_m, only: calculate_equil, interpolate_equil
+        use grid_m, only: rg_grid
+        use IO_collection_m, only: create_output_directories
+        use logger_m, only: log_info
+        use species_m, only: plasma, set_plasma_quantities
+
+        class(flr2_t), intent(inout) :: this
+
+        this%run_type = 'flr2'
+        call create_output_directories
+        call generate_grids
+        call calculate_equil(.true.)
+        call set_plasma_quantities(plasma)
+        call interpolate_equil(rg_grid%xb)
+        call log_info('...flr2 model initialized with KIM background.')
+    end subroutine init_flr2
+
+    subroutine run_flr2(this)
+        use config_m, only: collision_model, flr2_electron_current, &
+                            flr2_electron_flr, flr2_electron_potential, &
+                            flr2_include_potential_in_current, flr2_ion_current, &
+                            flr2_ion_flr, flr2_ion_potential, turn_off_electrons, &
+                            turn_off_ions
+        use equilibrium_m, only: B0z
+        use fields_m, only: EBdat, get_Br_from_txt
+        use flr2_response_m, only: flr2_options_t, solve_flr2_response, &
+                                   FLR2_RESPONSE_OK
+        use IO_collection_m, only: write_complex_profile_abs
+        use KIM_kinds_m, only: dp
+        use logger_m, only: log_error, log_info
+        use setup_m, only: Br_boundary_im, Br_boundary_re, m_mode, n_mode, &
+                           omega, R0, type_br_field
+        use species_m, only: plasma
+
+        class(flr2_t), intent(inout) :: this
+
+        type(flr2_options_t) :: options
+        complex(dp), allocatable :: bpsi_over_bphi(:), parcur_over_b0(:)
+        complex(dp) :: br_constant
+        character(len=160) :: error_message
+        integer :: n, stat
+
+        if (trim(collision_model) /= 'FokkerPlanck') then
+            call log_error('FLR2 run type requires collision_model = FokkerPlanck.')
+        end if
+        if (abs(omega) > tiny(1.0_dp)) then
+            call log_error('FLR2 run type currently requires omega = 0.')
+        end if
+        if (plasma%n_species /= 2) then
+            call log_error('FLR2 run type currently requires exactly one ion species.')
+        end if
+        if (plasma%spec(1)%Zspec <= 0) then
+            call log_error('FLR2 run type requires a positively charged ion species.')
+        end if
+        if (turn_off_electrons .and. turn_off_ions) then
+            call log_error('FLR2 cannot disable both electrons and ions.')
+        end if
+
+        n = plasma%grid_size
+        if (allocated(EBdat%r_grid)) deallocate(EBdat%r_grid)
+        if (allocated(EBdat%Br)) deallocate(EBdat%Br)
+        if (allocated(EBdat%Phi)) deallocate(EBdat%Phi)
+        if (allocated(EBdat%jpar)) deallocate(EBdat%jpar)
+        allocate(EBdat%r_grid(n), EBdat%Br(n), EBdat%Phi(n), EBdat%jpar(n))
+        allocate(bpsi_over_bphi(n), parcur_over_b0(n))
+        EBdat%r_grid = plasma%r_grid
+
+        select case (type_br_field)
+            case (11)
+                call get_Br_from_txt(EBdat, './inp/Br_in.dat')
+            case (12)
+                br_constant = cmplx(Br_boundary_re, Br_boundary_im, dp)
+                EBdat%Br = br_constant
+            case default
+                write(error_message, '(A,I0,A)') &
+                    'FLR2 supports type_br_field = 11 (file) or 12 (constant), got ', &
+                    type_br_field, '.'
+                call log_error(trim(error_message))
+        end select
+
+        options%electron_flr = flr2_electron_flr
+        options%ion_flr = flr2_ion_flr
+        options%electron_potential = flr2_electron_potential .and. .not. turn_off_electrons
+        options%ion_potential = flr2_ion_potential .and. .not. turn_off_ions
+        options%electron_current = flr2_electron_current .and. .not. turn_off_electrons
+        options%ion_current = flr2_ion_current .and. .not. turn_off_ions
+        options%include_potential_in_current = flr2_include_potential_in_current
+        if (.not. options%electron_potential .and. .not. options%ion_potential) then
+            call log_error('FLR2 requires at least one species in the potential equation.')
+        end if
+
+        ! KiLCA-FLR2's radial-variable formulation uses B^r/B^phi, with
+        ! B_phi = B0z*R0 in KIM's cylindrical equilibrium. Keep B0z signed.
+        bpsi_over_bphi = EBdat%Br*R0/B0z
+        call solve_flr2_response(plasma, m_mode, n_mode, R0, B0z, &
+                                 bpsi_over_bphi, options, EBdat%Phi, &
+                                 parcur_over_b0, stat)
+        if (stat /= FLR2_RESPONSE_OK) then
+            write(error_message, '(A,I0)') 'FLR2 response solve failed with status ', stat
+            call log_error(trim(error_message))
+        end if
+        EBdat%jpar = parcur_over_b0*plasma%B0
+
+        call write_complex_profile_abs(EBdat%r_grid, EBdat%Br, n, &
+            '/fields/Br', 'Radial magnetic-field perturbation', 'G')
+        call write_complex_profile_abs(EBdat%r_grid, EBdat%Phi, n, &
+            '/fields/Phi', 'FLR2 electrostatic potential perturbation', 'statV')
+        call write_complex_profile_abs(EBdat%r_grid, EBdat%jpar, n, &
+            '/fields/jpar', 'FLR2 parallel current density perturbation', 'statA/cm^2')
+        call log_info('...'//trim(this%run_type)//' response solved.')
+    end subroutine run_flr2
+
+end module rt_flr2_m

--- a/KIM/src/flr2/flr2_tridiagonal.f90
+++ b/KIM/src/flr2/flr2_tridiagonal.f90
@@ -1,0 +1,146 @@
+module flr2_tridiagonal_m
+    ! Adapted from KiLCA-FLR2's progonka.f90. The module form adds explicit
+    ! interfaces, validation/status returns, and defined endpoint values for g.
+    use KIM_kinds_m, only: dp
+    implicit none
+    private
+
+    integer, parameter, public :: FLR2_SOLVE_OK = 0
+    integer, parameter, public :: FLR2_SOLVE_BAD_SIZE = 1
+    integer, parameter, public :: FLR2_SOLVE_BAD_GRID = 2
+    integer, parameter, public :: FLR2_SOLVE_SINGULAR = 3
+
+    public :: solve_flr2_tridiagonal
+
+contains
+
+    subroutine solve_flr2_tridiagonal(isw_f, x, q, &
+                                      a2_in, a2_out, a0, &
+                                      b2_in, b2_out, b0, &
+                                      c2_in, c2_out, c0, &
+                                      d2_in, d2_out, d0, &
+                                      f, g, stat)
+        integer, intent(in) :: isw_f
+        real(dp), intent(in) :: x(:)
+        complex(dp), intent(in) :: q(:)
+        complex(dp), intent(in) :: a2_in(:), a2_out(:), a0(:)
+        complex(dp), intent(in) :: b2_in(:), b2_out(:), b0(:)
+        complex(dp), intent(in) :: c2_in(:), c2_out(:), c0(:)
+        complex(dp), intent(in) :: d2_in(:), d2_out(:), d0(:)
+        complex(dp), intent(out) :: f(:), g(:)
+        integer, intent(out) :: stat
+
+        integer :: i, n
+        real(dp) :: dxm, dxp, dxt
+        real(dp), allocatable :: second_derivative_weights(:, :)
+        complex(dp) :: denominator
+        complex(dp), allocatable :: alpha(:), beta(:), equation(:, :), source(:)
+
+        stat = FLR2_SOLVE_OK
+        f = (0.0_dp, 0.0_dp)
+        g = (0.0_dp, 0.0_dp)
+        n = size(x)
+
+        if (n < 3 .or. .not. arrays_have_size(n)) then
+            stat = FLR2_SOLVE_BAD_SIZE
+            return
+        end if
+
+        do i = 2, n
+            if (x(i) <= x(i - 1)) then
+                stat = FLR2_SOLVE_BAD_GRID
+                return
+            end if
+        end do
+
+        if (is_near_zero(a0(1)) .or. is_near_zero(a0(n))) then
+            stat = FLR2_SOLVE_SINGULAR
+            return
+        end if
+
+        allocate(second_derivative_weights(-1:1, n))
+        allocate(equation(-1:1, n), alpha(n), beta(n), source(n))
+        second_derivative_weights = 0.0_dp
+        equation = (0.0_dp, 0.0_dp)
+        alpha = (0.0_dp, 0.0_dp)
+        beta = (0.0_dp, 0.0_dp)
+        source = (0.0_dp, 0.0_dp)
+
+        do i = 2, n - 1
+            dxp = x(i + 1) - x(i)
+            dxm = x(i) - x(i - 1)
+            dxt = dxp + dxm
+            second_derivative_weights(-1, i) = 2.0_dp/(dxm*dxt)
+            second_derivative_weights(0, i) = -2.0_dp/(dxm*dxp)
+            second_derivative_weights(1, i) = 2.0_dp/(dxp*dxt)
+
+            source(i) = b2_out(i)*sum(q(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                        + sum(b2_in(i - 1:i + 1)*q(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                        + b0(i)*q(i)
+
+            equation(:, i) = a2_out(i)*second_derivative_weights(:, i) &
+                             + a2_in(i - 1:i + 1)*second_derivative_weights(:, i)
+            equation(0, i) = equation(0, i) + a0(i)
+        end do
+
+        beta(2) = b0(1)*q(1)/a0(1)
+        do i = 2, n - 1
+            denominator = equation(0, i) + alpha(i)*equation(-1, i)
+            if (is_near_zero(denominator)) then
+                stat = FLR2_SOLVE_SINGULAR
+                return
+            end if
+            alpha(i + 1) = -equation(1, i)/denominator
+            beta(i + 1) = (source(i) - equation(-1, i)*beta(i))/denominator
+        end do
+
+        f(n) = b0(n)*q(n)/a0(n)
+        do i = n - 1, 1, -1
+            f(i) = alpha(i + 1)*f(i + 1) + beta(i + 1)
+        end do
+        f = f*real(isw_f, dp)
+
+        do i = 1, n
+            if (i == 1 .or. i == n) then
+                g(i) = c0(i)*f(i) + d0(i)*q(i)
+            else
+                g(i) = c2_out(i)*sum(f(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                       + sum(c2_in(i - 1:i + 1)*f(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                       + c0(i)*f(i) &
+                       + d2_out(i)*sum(q(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                       + sum(d2_in(i - 1:i + 1)*q(i - 1:i + 1)*second_derivative_weights(:, i)) &
+                       + d0(i)*q(i)
+            end if
+        end do
+
+    contains
+
+        logical function arrays_have_size(expected_size)
+            integer, intent(in) :: expected_size
+
+            arrays_have_size = size(q) == expected_size &
+                               .and. size(a2_in) == expected_size &
+                               .and. size(a2_out) == expected_size &
+                               .and. size(a0) == expected_size &
+                               .and. size(b2_in) == expected_size &
+                               .and. size(b2_out) == expected_size &
+                               .and. size(b0) == expected_size &
+                               .and. size(c2_in) == expected_size &
+                               .and. size(c2_out) == expected_size &
+                               .and. size(c0) == expected_size &
+                               .and. size(d2_in) == expected_size &
+                               .and. size(d2_out) == expected_size &
+                               .and. size(d0) == expected_size &
+                               .and. size(f) == expected_size &
+                               .and. size(g) == expected_size
+        end function arrays_have_size
+
+        logical function is_near_zero(value)
+            complex(dp), intent(in) :: value
+
+            is_near_zero = abs(value) <= tiny(1.0_dp)
+        end function is_near_zero
+
+    end subroutine solve_flr2_tridiagonal
+
+end module flr2_tridiagonal_m

--- a/KIM/src/general/KIM_mod.f90
+++ b/KIM/src/general/KIM_mod.f90
@@ -12,6 +12,7 @@ module kim_mod_m
         use rt_electrostatic_periodic_m, only: electrostatic_periodic_t
         use rt_electromagnetic_m, only: electromagnetic_t
         use rt_flr2_benchmark_m, only: flr2_benchmark_t
+        use rt_flr2_m, only: flr2_t
 
         implicit none
 
@@ -25,13 +26,15 @@ module kim_mod_m
                 allocate(kim_instance, source=electrostatic_periodic_t())
             case("flr2_benchmark")
                 allocate(kim_instance, source=flr2_benchmark_t())
+            case("flr2")
+                allocate(kim_instance, source=flr2_t())
             case("WKB_dispersion")
                 allocate(kim_instance, source=WKB_dispersion_t())
             case("electromagnetic")
                 allocate(kim_instance, source=electromagnetic_t())
             case default
                 print *, "Invalid kim type of run " // trim(type_of_run)
-                print *, "Options are: electrostatic, electrostatic_periodic, electromagnetic, flr2_benchmark, WKB_dispersion"
+                print *, "Options are: electrostatic, electrostatic_periodic, electromagnetic, flr2, flr2_benchmark, WKB_dispersion"
                 stop "Due to invalid type of run"
         end select
 

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -125,11 +125,20 @@ contains
         if (trim(type_of_run) == "WKB_dispersion") then
             call print_config_line('WKB Dispersion Mode', trim(WKB_dispersion_mode), width)
         end if
-        if (trim(type_of_run) == "electromagnetic") then
+        if (trim(type_of_run) == "electromagnetic" .or. trim(type_of_run) == "flr2") then
             write(value_str, '(ES12.3)') Br_boundary_re
             call print_config_line('Br Boundary (Re)', trim(adjustl(value_str)), width)
             write(value_str, '(ES12.3)') Br_boundary_im
             call print_config_line('Br Boundary (Im)', trim(adjustl(value_str)), width)
+        end if
+        if (trim(type_of_run) == "flr2") then
+            call print_bool_line('FLR2 Electron FLR', flr2_electron_flr, width)
+            call print_bool_line('FLR2 Ion FLR', flr2_ion_flr, width)
+            call print_bool_line('FLR2 Electron Potential', flr2_electron_potential, width)
+            call print_bool_line('FLR2 Ion Potential', flr2_ion_potential, width)
+            call print_bool_line('FLR2 Electron Current', flr2_electron_current, width)
+            call print_bool_line('FLR2 Ion Current', flr2_ion_current, width)
+            call print_bool_line('FLR2 Phi in Current', flr2_include_potential_in_current, width)
         end if
         call print_config_line('Plasma Type', trim(plasma_type), width)
         call print_config_line('Collision Model', trim(collision_model), width)

--- a/KIM/src/general/kim_solver_m.f90
+++ b/KIM/src/general/kim_solver_m.f90
@@ -142,6 +142,7 @@ contains
         class(kim_solver_t), intent(inout) :: self
         integer, intent(in) :: m, n
         integer, intent(out), optional :: stat
+        logical :: mode_changed
 
         if (.not. self%is_setup) then
             self%status = KIM_NOT_SETUP
@@ -149,12 +150,14 @@ contains
             return
         end if
 
+        mode_changed = m /= m_mode .or. n /= n_mode
         m_mode = m
         n_mode = n
 
-        ! The first solve reuses the equilibrium that init() built for the
-        ! configured mode; later solves recompute it for the new (m, n).
-        if (self%has_solved) call recompute_equilibrium_for_mode()
+        ! init() prepares the configured mode. Reuse it only when the first
+        ! requested mode matches; subsequent solves also rebuild because
+        ! callers may have replaced the in-memory profiles.
+        if (self%has_solved .or. mode_changed) call recompute_equilibrium_for_mode()
 
         call reset_fields()
         call self%run_type%run()
@@ -219,9 +222,10 @@ contains
     !> Recompute the background equilibrium for the current (m_mode, n_mode).
     subroutine recompute_equilibrium_for_mode()
         use equilibrium_m, only: calculate_equil, interpolate_equil
-        use species_m, only: plasma, set_plasma_quantities
+        use species_m, only: deallocate_plasma_derived, plasma, set_plasma_quantities
         use grid_m, only: rg_grid
 
+        call deallocate_plasma_derived()
         call calculate_equil(.false.)
         call set_plasma_quantities(plasma)
         call interpolate_equil(rg_grid%xb)

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -55,7 +55,12 @@ subroutine kim_read_config
                         periodic_kmax_scale, periodic_n_rg, &
                         periodic_match_global_kernel_approximations
 
-    integer :: periodic_iostat
+    namelist /KIM_FLR2/ flr2_electron_flr, flr2_ion_flr, &
+                        flr2_electron_potential, flr2_ion_potential, &
+                        flr2_electron_current, flr2_ion_current, &
+                        flr2_include_potential_in_current
+
+    integer :: flr2_iostat, periodic_iostat
 
     num_args = command_argument_count()
     if (num_args > 1) then
@@ -84,6 +89,18 @@ subroutine kim_read_config
     periodic_match_global_kernel_approximations = .false.
     rewind(unit = 77)
     read(unit = 77, nml = KIM_PERIODIC, iostat = periodic_iostat)
+
+    ! Optional standalone-FLR2 term switches. KIM's background and shared
+    ! susceptibility settings remain controlled by the existing groups.
+    flr2_electron_flr = .true.
+    flr2_ion_flr = .true.
+    flr2_electron_potential = .true.
+    flr2_ion_potential = .true.
+    flr2_electron_current = .true.
+    flr2_ion_current = .true.
+    flr2_include_potential_in_current = .true.
+    rewind(unit = 77)
+    read(unit = 77, nml = KIM_FLR2, iostat = flr2_iostat)
 
     close(unit = 77)
 

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -46,6 +46,16 @@ module config_m
     ! The forced-periodic solver uses its full Fourier kernel by default.
     logical :: periodic_match_global_kernel_approximations = .false.
 
+    ! KIM_FLR2 namelist variables. These switches only select terms in the
+    ! imported FLR2 response; all profiles and susceptibilities come from KIM.
+    logical :: flr2_electron_flr = .true.
+    logical :: flr2_ion_flr = .true.
+    logical :: flr2_electron_potential = .true.
+    logical :: flr2_ion_potential = .true.
+    logical :: flr2_electron_current = .true.
+    logical :: flr2_ion_current = .true.
+    logical :: flr2_include_potential_in_current = .true.
+
     ! KIM_IO namelist variables
     character(256) :: profile_location ! path to profile directory
     character(256) :: output_path         ! path to output directory

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -97,6 +97,50 @@ target_link_libraries(test_flr2_fourier_kernel KIM_lib kilca_lib lapack cerf for
 add_test(NAME test_flr2_fourier_kernel
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_fourier_kernel.x)
 
+add_executable(test_flr2_tridiagonal
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_tridiagonal.f90)
+set_target_properties(test_flr2_tridiagonal PROPERTIES
+                      OUTPUT_NAME test_flr2_tridiagonal.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_flr2_tridiagonal KIM_lib kilca_lib lapack cerf
+                      fortnum_amos_compat)
+add_test(NAME test_flr2_tridiagonal
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_tridiagonal.x)
+
+add_executable(test_flr2_response
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_response.f90)
+set_target_properties(test_flr2_response PROPERTIES
+                      OUTPUT_NAME test_flr2_response.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_flr2_response KIM_lib kilca_lib lapack cerf
+                      fortnum_amos_compat)
+add_test(NAME test_flr2_response
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_response.x)
+
+add_executable(test_flr2_factory
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_factory.f90)
+set_target_properties(test_flr2_factory PROPERTIES
+                      OUTPUT_NAME test_flr2_factory.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_flr2_factory KIM_lib kilca_lib lapack cerf
+                      fortnum_amos_compat)
+add_test(NAME test_flr2_factory
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_flr2_factory.x)
+
+add_executable(test_kim_solver_flr2
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_kim_solver_flr2.f90)
+set_target_properties(test_kim_solver_flr2 PROPERTIES
+                      OUTPUT_NAME test_kim_solver_flr2.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_kim_solver_flr2 KIM_lib kilca_lib lapack cerf
+                      fortnum_amos_compat)
+configure_file(${CMAKE_SOURCE_DIR}/KIM/tests/test_data/KIM_config_flr2_small.nml
+               ${CMAKE_BINARY_DIR}/tests/KIM_config_flr2_small.nml COPYONLY)
+add_test(NAME test_kim_solver_flr2
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_kim_solver_flr2.x)
+set_tests_properties(test_kim_solver_flr2 PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
+
 add_executable(test_ampere_matrices ${CMAKE_SOURCE_DIR}/KIM/tests/test_ampere_matrices.f90)
 set_target_properties(test_ampere_matrices PROPERTIES
                         OUTPUT_NAME test_ampere_matrices.x

--- a/KIM/tests/test_data/KIM_config_flr2_small.nml
+++ b/KIM/tests/test_data/KIM_config_flr2_small.nml
@@ -1,0 +1,108 @@
+&KIM_CONFIG
+    number_of_ion_species = 1
+    read_species_from_namelist = .false.
+    type_of_run = 'flr2'
+    collision_model = 'FokkerPlanck'
+    ion_collision_model = 'FokkerPlanck'
+    artificial_debye_case = 0
+    turn_off_ions = .false.
+    turn_off_electrons = .false.
+    plasma_type = 'D'
+    rescale_density = .false.
+    number_density_rescale = 1.0
+    ion_flr_scale_factor = 1.0
+    collision_frequency_scale = 1.0
+    boole_energy_conservation = .true.
+/
+
+&WKB_DISPERSION
+    WKB_dispersion_mode = 'KIM'
+    WKB_dispersion_solver = 'Muller'
+    WKB_solve_for_kr_squared = .false.
+    WKB_max_tracked_branches = 4
+    WKB_branch_search_halfwidth = 1.5
+    WKB_broad_search_halfwidth = 5.0
+    WKB_broad_search_interval = 0
+    WKB_root_tolerance = 1.0e-6
+    WKB_verbose = .false.
+/
+
+&KIM_IO
+    profile_location = './profiles/'
+    output_path = './out_flr2_small/'
+    hdf5_input = .false.
+    hdf5_output = .false.
+    log_level = 1
+    data_verbosity = 0
+    calculate_asymptotics = .false.
+    h5_out_file = ''
+/
+
+&KIM_SETUP
+    btor = -17977.413
+    R0 = 165.0
+    m_mode = -6
+    n_mode = 2
+    omega = 0.0
+    spline_base = 1
+    type_br_field = 12
+    collisions_off = .false.
+    set_profiles_constant = 0
+    bc_type = 3
+    mphi_max = 0
+    Br_boundary_re = 1.0
+    Br_boundary_im = 0.0
+/
+
+&KIM_GRID
+    r_min = 3.0
+    r_plas = 67.0
+    width_res = 0.5
+    ampl_res = 15.0
+    hrmax_scaling = 1.0
+    l_space_dim = 32
+    rg_space_dim = 32
+    grid_spacing_rg = 'equidistant'
+    grid_spacing_xl = 'equidistant'
+    theta_integration = 'GaussLegendre'
+    rkf45_atol = 1.0e-9
+    rkf45_rtol = 1.0e-6
+    kernel_taper_skip_threshold = 1.0e-6
+    Larmor_skip_factor = 5
+    gauss_int_nodes_Nx = 15
+    gauss_int_nodes_Nxp = 14
+    gauss_int_nodes_Ntheta = 10
+    quadpack_algorithm = 'QAG'
+    quadpack_key = 6
+    quadpack_limit = 500
+    quadpack_epsabs = 1.0e-10
+    quadpack_epsrel = 1.0e-10
+    quadpack_use_u_substitution = .true.
+/
+
+&KIM_PROFILES
+    coord_type = 'auto'
+    input_profile_dir = './'
+    equil_file = ''
+    geqdsk_file = ''
+    n_input_file = 'n_of_psiN.dat'
+    Te_input_file = 'Te_of_psiN.dat'
+    Ti_input_file = 'Ti_of_psiN.dat'
+    Vz_input_file = 'Vz_of_psiN.dat'
+    n_file = 'n.dat'
+    Te_file = 'Te.dat'
+    Ti_file = 'Ti.dat'
+    Vz_file = 'Vz.dat'
+    Er_file = 'Er.dat'
+    q_file = 'q.dat'
+/
+
+&KIM_FLR2
+    flr2_electron_flr = .true.
+    flr2_ion_flr = .false.
+    flr2_electron_potential = .true.
+    flr2_ion_potential = .true.
+    flr2_electron_current = .true.
+    flr2_ion_current = .true.
+    flr2_include_potential_in_current = .true.
+/

--- a/KIM/tests/test_flr2_factory.f90
+++ b/KIM/tests/test_flr2_factory.f90
@@ -1,0 +1,17 @@
+program test_flr2_factory
+    use kim_base_m, only: kim_t
+    use kim_mod_m, only: from_kim_factory_get_kim
+    use rt_flr2_m, only: flr2_t
+    implicit none
+
+    class(kim_t), allocatable :: run
+
+    call from_kim_factory_get_kim('flr2', run)
+    select type (run)
+        type is (flr2_t)
+            write(*,*) 'FLR2 factory test PASSED'
+        class default
+            write(*,*) 'FAIL: factory did not create flr2_t'
+            stop 1
+    end select
+end program test_flr2_factory

--- a/KIM/tests/test_flr2_response.f90
+++ b/KIM/tests/test_flr2_response.f90
@@ -1,0 +1,118 @@
+program test_flr2_response
+    use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+    use KIM_kinds_m, only: dp
+    use constants_m, only: e_charge
+    use species_m, only: plasma_t
+    use flr2_response_m, only: flr2_options_t, solve_flr2_response, &
+                              FLR2_RESPONSE_BAD_INPUT, FLR2_RESPONSE_OK
+    implicit none
+
+    integer, parameter :: n = 5
+    real(dp), parameter :: tol = 1.0e-11_dp
+    real(dp), parameter :: major_radius = 100.0_dp
+    type(plasma_t) :: background
+    type(flr2_options_t) :: options
+    complex(dp) :: bpsi_over_bphi(n), phi(n), current(n)
+    complex(dp) :: factor_of_phi, expected_phi, expected_current
+    real(dp) :: f_electron, d0_electron
+    integer :: stat
+
+    call make_constant_background(background)
+    bpsi_over_bphi = cmplx(1.0_dp, 0.0_dp, dp)
+    options%ion_potential = .false.
+    options%ion_current = .false.
+
+    call solve_flr2_response(background, 1, 1, major_radius, background%B0, &
+                             bpsi_over_bphi, options, phi, current, stat)
+    if (stat /= FLR2_RESPONSE_OK) then
+        write(*,*) 'FAIL: response status = ', stat
+        stop 1
+    end if
+
+    factor_of_phi = cmplx(0.0_dp, 1.0_dp, dp)*(1.0_dp + 2.0_dp) &
+                    /(2.0_dp*(-10.0_dp))
+    expected_phi = -bpsi_over_bphi(1)/factor_of_phi
+    if (maxval(abs(phi - expected_phi)) > tol) then
+        write(*,*) 'FAIL: aligned potential mismatch: ', phi
+        stop 1
+    end if
+    if (maxval(abs(current)) > tol) then
+        write(*,*) 'FAIL: aligned potential should cancel parallel current: ', current
+        stop 1
+    end if
+
+    options%include_potential_in_current = .false.
+    call solve_flr2_response(background, 1, 1, major_radius, background%B0, &
+                             bpsi_over_bphi, options, phi, current, stat)
+    if (stat /= FLR2_RESPONSE_OK) then
+        write(*,*) 'FAIL: magnetic-only response status = ', stat
+        stop 1
+    end if
+
+    f_electron = -e_charge
+    d0_electron = -f_electron/(background%B0(1)*major_radius)
+    expected_current = cmplx(d0_electron, 0.0_dp, dp)*bpsi_over_bphi(1)
+    if (maxval(abs(phi)) > tol) then
+        write(*,*) 'FAIL: disabled potential should be zero: ', phi
+        stop 1
+    end if
+    if (maxval(abs(current - expected_current)) > tol*max(1.0_dp, abs(expected_current))) then
+        write(*,*) 'FAIL: magnetic-only current mismatch: ', current
+        stop 1
+    end if
+
+    call solve_flr2_response(background, 1, 1, major_radius, -background%B0, &
+                             bpsi_over_bphi, options, phi, current, stat)
+    if (stat /= FLR2_RESPONSE_OK &
+        .or. maxval(abs(current + expected_current)) &
+             > tol*max(1.0_dp, abs(expected_current))) then
+        write(*,*) 'FAIL: signed toroidal field did not reverse current: ', current
+        stop 1
+    end if
+
+    background%spec(0)%n(3) = ieee_value(0.0_dp, ieee_quiet_nan)
+    call solve_flr2_response(background, 1, 1, major_radius, background%B0, &
+                             bpsi_over_bphi, options, phi, current, stat)
+    if (stat /= FLR2_RESPONSE_BAD_INPUT) then
+        write(*,*) 'FAIL: non-finite background was accepted, status = ', stat
+        stop 1
+    end if
+
+    write(*,*) 'FLR2 response test PASSED'
+
+contains
+
+    subroutine make_constant_background(plasma)
+        type(plasma_t), intent(out) :: plasma
+        integer :: sp
+
+        plasma%n_species = 2
+        plasma%grid_size = n
+        allocate(plasma%r_grid(n), plasma%q(n), plasma%B0(n), plasma%Er(n), plasma%om_E(n))
+        allocate(plasma%spec(0:1))
+
+        plasma%r_grid = [0.0_dp, 0.5_dp, 1.5_dp, 3.0_dp, 5.0_dp]
+        plasma%q = 2.0_dp
+        plasma%B0 = 1.0_dp
+        plasma%Er = 10.0_dp
+        plasma%om_E = 3.0_dp
+
+        do sp = 0, 1
+            allocate(plasma%spec(sp)%n(n), plasma%spec(sp)%vT(n))
+            allocate(plasma%spec(sp)%nu(n), plasma%spec(sp)%rho_L(n))
+            allocate(plasma%spec(sp)%A1(n), plasma%spec(sp)%A2(n))
+            allocate(plasma%spec(sp)%I11(n, 0:0), plasma%spec(sp)%I13(n, 0:0))
+            plasma%spec(sp)%n = 1.0_dp
+            plasma%spec(sp)%vT = 1.0_dp
+            plasma%spec(sp)%nu = 1.0_dp
+            plasma%spec(sp)%rho_L = 0.1_dp
+            plasma%spec(sp)%A1 = 1.0_dp
+            plasma%spec(sp)%A2 = 0.0_dp
+            plasma%spec(sp)%I11(:, 0) = cmplx(1.0_dp, 0.0_dp, dp)
+            plasma%spec(sp)%I13(:, 0) = cmplx(0.0_dp, 0.0_dp, dp)
+        end do
+        plasma%spec(0)%Zspec = -1
+        plasma%spec(1)%Zspec = 1
+    end subroutine make_constant_background
+
+end program test_flr2_response

--- a/KIM/tests/test_flr2_tridiagonal.f90
+++ b/KIM/tests/test_flr2_tridiagonal.f90
@@ -1,0 +1,54 @@
+program test_flr2_tridiagonal
+    use KIM_kinds_m, only: dp
+    use flr2_tridiagonal_m, only: solve_flr2_tridiagonal, FLR2_SOLVE_OK
+    implicit none
+
+    integer, parameter :: n = 5
+    real(dp), parameter :: tol = 1.0e-12_dp
+    real(dp) :: x(n)
+    complex(dp) :: q(n), a2_in(n), a2_out(n), a0(n)
+    complex(dp) :: b2_in(n), b2_out(n), b0(n)
+    complex(dp) :: c2_in(n), c2_out(n), c0(n)
+    complex(dp) :: d2_in(n), d2_out(n), d0(n)
+    complex(dp) :: f(n), g(n)
+    integer :: stat
+
+    x = [0.0_dp, 0.5_dp, 1.5_dp, 3.0_dp, 5.0_dp]
+    q = cmplx(x**2, 0.0_dp, dp)
+
+    a2_in = (3.0_dp, 0.0_dp)
+    a2_out = (2.0_dp, 0.0_dp)
+    a0 = (1.0_dp, 0.0_dp)
+    b2_in = (3.0_dp, 0.0_dp)
+    b2_out = (2.0_dp, 0.0_dp)
+    b0 = (1.0_dp, 0.0_dp)
+    c2_in = (3.0_dp, 0.0_dp)
+    c2_out = (2.0_dp, 0.0_dp)
+    c0 = (4.0_dp, 0.0_dp)
+    d2_in = (6.0_dp, 0.0_dp)
+    d2_out = (5.0_dp, 0.0_dp)
+    d0 = (7.0_dp, 0.0_dp)
+
+    call solve_flr2_tridiagonal(1, x, q, a2_in, a2_out, a0, &
+                                b2_in, b2_out, b0, c2_in, c2_out, c0, &
+                                d2_in, d2_out, d0, f, g, stat)
+
+    if (stat /= FLR2_SOLVE_OK) then
+        write(*,*) 'FAIL: solver status = ', stat
+        stop 1
+    end if
+    if (maxval(abs(f - q)) > tol) then
+        write(*,*) 'FAIL: manufactured quadratic solution mismatch: ', f
+        stop 1
+    end if
+    if (maxval(abs(g(2:n - 1) - (32.0_dp + 11.0_dp*q(2:n - 1)))) > tol) then
+        write(*,*) 'FAIL: second-derivative response mismatch: ', g
+        stop 1
+    end if
+    if (abs(g(1) - 11.0_dp*q(1)) > tol .or. abs(g(n) - 11.0_dp*q(n)) > tol) then
+        write(*,*) 'FAIL: algebraic boundary response mismatch: ', g
+        stop 1
+    end if
+
+    write(*,*) 'FLR2 tridiagonal test PASSED'
+end program test_flr2_tridiagonal

--- a/KIM/tests/test_kim_solver_flr2.f90
+++ b/KIM/tests/test_kim_solver_flr2.f90
@@ -1,0 +1,154 @@
+program test_kim_solver_flr2
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use KIM_kinds_m, only: dp
+    use config_m, only: flr2_ion_flr
+    use kim_solver_m, only: kim_profiles_t, kim_results_t, kim_solver_t, KIM_OK
+    implicit none
+
+    integer, parameter :: n_profile = 48
+    ! Deliberately differ from the configured m=-6 to verify that the first
+    ! in-process solve rebuilds its mode-dependent KIM background.
+    integer, parameter :: m_mode = -5, n_mode = 2
+    type(kim_solver_t) :: kim
+    type(kim_results_t) :: result
+    type(kim_profiles_t) :: profiles
+    integer :: i, stat
+    real(dp) :: fraction
+    complex(dp) :: expected_phi_boundary, factor_of_phi
+    logical :: passed
+
+    passed = .true.
+    allocate(profiles%r(n_profile), profiles%n(n_profile))
+    allocate(profiles%Te(n_profile), profiles%Ti(n_profile))
+    allocate(profiles%q(n_profile), profiles%Er(n_profile))
+    do i = 1, n_profile
+        profiles%r(i) = 3.0_dp + 64.0_dp*real(i - 1, dp)/real(n_profile - 1, dp)
+        fraction = (profiles%r(i) - 3.0_dp)/64.0_dp
+        profiles%n(i) = 5.0e13_dp*(1.0_dp - 0.8_dp*fraction)
+        profiles%Te(i) = 250.0_dp + 1250.0_dp*(1.0_dp - fraction)
+        profiles%Ti(i) = 0.8_dp*profiles%Te(i)
+        profiles%q(i) = 1.2_dp + 3.4_dp*fraction
+        profiles%Er(i) = 25.0_dp + 5.0_dp*fraction
+    end do
+
+    call kim%init('KIM_config_flr2_small.nml', run_type='flr2', &
+                  profiles=profiles, stat=stat)
+    call check('init returns KIM_OK', stat == KIM_OK, passed)
+    call check('optional KIM_FLR2 group was read', .not. flr2_ion_flr, passed)
+    if (stat /= KIM_OK) call done(passed)
+
+    call kim%solve(m_mode, n_mode, stat)
+    call check('solve returns KIM_OK', stat == KIM_OK, passed)
+    if (stat /= KIM_OK) call done(passed)
+    result = kim%results()
+
+    call check('field grid populated', allocated(result%r_field), passed)
+    if (allocated(result%r_field)) then
+        call check('field grid matches KIM plasma grid', &
+                   allocated(result%r_plasma) &
+                   .and. size(result%r_field) == size(result%r_plasma) &
+                   .and. maxval(abs(result%r_field - result%r_plasma)) < 1.0e-12_dp, &
+                   passed)
+        call check('field grid strictly increasing', &
+                   all(result%r_field(2:) > result%r_field(:size(result%r_field) - 1)), &
+                   passed)
+    end if
+
+    call check_complex_field('Br', result%Br, result%r_field, passed)
+    call check_complex_field('Phi', result%Phi, result%r_field, passed)
+    call check_complex_field('jpar', result%jpar, result%r_field, passed)
+    if (allocated(result%Br)) then
+        call check('constant Br drive preserved', &
+                   maxval(abs(result%Br - cmplx(1.0_dp, 0.0_dp, dp))) < 1.0e-12_dp, &
+                   passed)
+    end if
+    if (allocated(result%Phi)) then
+        call check('FLR2 potential is non-trivial', maxval(abs(result%Phi)) > 0.0_dp, passed)
+    end if
+    call check('signed B0z background populated', allocated(result%B0z), passed)
+    if (allocated(result%Phi) .and. allocated(result%B0z)) then
+        factor_of_phi = cmplx(0.0_dp, 1.0_dp, dp) &
+                        *real(m_mode + n_mode*profiles%q(1), dp) &
+                        /(profiles%q(1)*(-profiles%Er(1)))
+        expected_phi_boundary = -(cmplx(1.0_dp, 0.0_dp, dp)*165.0_dp/result%B0z(1)) &
+                                /factor_of_phi
+        call check('left boundary preserves signed B0z mapping', &
+                   abs(result%Phi(1) - expected_phi_boundary) &
+                   < 1.0e-10_dp*max(1.0_dp, abs(expected_phi_boundary)), passed)
+    end if
+    if (allocated(result%jpar)) then
+        call check('FLR2 current is non-trivial', maxval(abs(result%jpar)) > 0.0_dp, passed)
+    end if
+    call check('results retain requested mode', &
+               result%m == m_mode .and. result%n == n_mode, passed)
+    if (allocated(result%kp) .and. allocated(result%B0) &
+        .and. allocated(result%B0z) .and. allocated(result%B0th)) then
+        call check('first solve background uses requested mode', &
+                   abs(result%kp(1) &
+                       - (real(m_mode, dp)/result%r_plasma(1) &
+                          *result%B0th(1)/result%B0(1) &
+                          + real(n_mode, dp)/165.0_dp &
+                            *result%B0z(1)/result%B0(1))) < 1.0e-12_dp, passed)
+    end if
+
+    call kim%solve(m_mode - 1, n_mode, stat)
+    call check('second mode solve returns KIM_OK', stat == KIM_OK, passed)
+    if (stat == KIM_OK) then
+        result = kim%results()
+        call check('second solve background uses requested mode', &
+                   allocated(result%kp) .and. allocated(result%B0) &
+                   .and. allocated(result%B0z) .and. allocated(result%B0th) &
+                   .and. abs(result%kp(1) &
+                       - (real(m_mode - 1, dp)/result%r_plasma(1) &
+                          *result%B0th(1)/result%B0(1) &
+                          + real(n_mode, dp)/165.0_dp &
+                            *result%B0z(1)/result%B0(1))) < 1.0e-12_dp, passed)
+    end if
+
+    call kim%finalize()
+    call done(passed)
+
+contains
+
+    subroutine check(label, condition, all_passed)
+        character(*), intent(in) :: label
+        logical, intent(in) :: condition
+        logical, intent(inout) :: all_passed
+
+        if (condition) then
+            write(*,*) 'PASS: ', label
+        else
+            write(*,*) 'FAIL: ', label
+            all_passed = .false.
+        end if
+    end subroutine check
+
+    subroutine check_complex_field(label, values, grid, all_passed)
+        character(*), intent(in) :: label
+        complex(dp), allocatable, intent(in) :: values(:)
+        real(dp), allocatable, intent(in) :: grid(:)
+        logical, intent(inout) :: all_passed
+        logical :: valid
+
+        valid = allocated(values) .and. allocated(grid)
+        if (valid) valid = size(values) == size(grid)
+        if (valid) then
+            valid = all(ieee_is_finite(real(values))) &
+                    .and. all(ieee_is_finite(aimag(values)))
+        end if
+        call check(trim(label)//' populated, sized, and finite', valid, all_passed)
+    end subroutine check_complex_field
+
+    subroutine done(all_passed)
+        logical, intent(in) :: all_passed
+
+        if (all_passed) then
+            write(*,*) 'KIM FLR2 end-to-end test PASSED'
+            stop 0
+        else
+            write(*,*) 'KIM FLR2 end-to-end test FAILED'
+            stop 1
+        end if
+    end subroutine done
+
+end program test_kim_solver_flr2

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ Supporting directories include:
 - [`test/golden/`](test/golden/) — physics-output regression tests for all three solvers.
 
 KIM supports electrostatic, forced-periodic electrostatic, electromagnetic,
-WKB-dispersion, and FLR2 benchmark runs. Its forced-periodic solver can use
-Fokker–Planck ions or collisionless ion charge and parallel-current kernels;
-electrons remain Fokker–Planck in the collisionless-ion configuration. See the
-[KIM namelist reference](KIM/nmls/README.md) for the current options and their
+WKB-dispersion, standalone-FLR2, and FLR2 benchmark runs. The `flr2` run type
+integrates the second-order local response solver from KiLCA-FLR2 while reusing
+KIM's profile, equilibrium, collision-frequency, and susceptibility
+calculation. It is distinct from `flr2_benchmark`, which benchmarks KIM's
+non-local kernel. The forced-periodic solver can use Fokker–Planck ions or
+collisionless ion charge and parallel-current kernels; electrons remain
+Fokker–Planck in the collisionless-ion configuration. See the
+[KIM namelist reference](KIM/nmls/README.md) for current options and
 restrictions.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- add `type_of_run = 'flr2'` to KIM, porting the KiLCA-FLR2 second-order local response and tridiagonal solver
- reuse KIM's prepared profiles, equilibrium, collision frequencies, thermodynamic forces, Larmor radii, and Fokker–Planck susceptibilities
- map the radial magnetic drive with signed `B0z` and write standard KIM `Br`, `Phi`, and `jpar` outputs
- add optional `KIM_FLR2` term switches, configuration documentation, and focused numerical/factory/end-to-end tests
- make first and repeated in-process mode solves rebuild the correct KIM background and repair the shared derivative-array deallocation invariant

## Motivation and impact

This exposes KiLCA-FLR2 through the normal KIM lifecycle instead of introducing
another standalone executable or duplicating profile/equilibrium preparation.
Users can run the local FLR2 model with `type_of_run = 'flr2'`; the existing
`flr2_benchmark` remains the benchmark for KIM's non-local FLR2 kernel.

The response currently supports static (`omega = 0`) Fokker–Planck runs with
exactly one positively charged ion species and `type_br_field` 11 or 12.

## Validation

- `cmake --build build-flr2 --parallel 4`
- `ctest --test-dir build-flr2 --output-on-failure -R flr2` — 5/5 passed after rebasing onto current `main`
- checked/debug end-to-end regression, including first-mode mismatch and successive modes — passed
- full `ctest --test-dir build-flr2 --output-on-failure` — 41/42 passed before the rebase
  - only failure is the acknowledged pre-existing `test_rhs_balance` `gamma_a_e` baseline mismatch (`0.277555756156289` vs `0`)
- `git diff --check` — clean

All builds and tests were run inside the feature worktree; the main checkout's
`build/` executable was not touched.
