### PR TITLE
fix(KIM): stabilize collisionless ion limit

### DIFF
--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -107,6 +107,58 @@ module species_m
 
     end function scale_fp_collision_frequency
 
+    subroutine evaluate_susceptibility(x1, x2, symbI)
+        ! Markl et al., Nucl. Fusion 63 (2023) 126007, appendix A:
+        ! use the collisionless moments once the collisional W2_arr
+        ! representation enters its empirically identified cancellation
+        ! regime. Requiring both arguments to be large keeps the resonant
+        ! x1 -> 0 and Er -> 0 limits on the regular collisional evaluator.
+        use constants_m, only: pi
+        use use_libcerf_m, only: w_of_z_F
+
+        real(dp), intent(in) :: x1, x2
+        complex(dp), intent(out) :: symbI(0:nmmax, 0:nmmax)
+
+        real(dp), parameter :: smaller_argument_threshold = 1.0e3_dp
+        real(dp), parameter :: larger_argument_threshold = 1.0e4_dp
+        complex(dp), parameter :: imaginary_unit = (0.0_dp, 1.0_dp)
+        complex(dp) :: moment(0:2 * nmmax), plasma_z
+        real(dp) :: sigma, zeta
+        integer :: k, l, order
+
+        if (min(abs(x1), abs(x2)) < smaller_argument_threshold .or. &
+                max(abs(x1), abs(x2)) < larger_argument_threshold) then
+            call getIfunc(x1, x2, symbI)
+            return
+        end if
+
+        sigma = sign(1.0_dp, x1)
+        zeta = x2 / (sqrt(2.0_dp) * x1)
+        plasma_z = imaginary_unit * sqrt(pi) &
+            * w_of_z_F(cmplx(sigma * zeta, 0.0_dp, dp))
+
+        moment(0) = -imaginary_unit * plasma_z &
+            / (sqrt(2.0_dp) * abs(x1))
+        do order = 1, 2 * nmmax
+            moment(order) = sqrt(2.0_dp) * zeta * moment(order - 1)
+            if (mod(order, 2) == 1) then
+                select case (order)
+                case (1, 3)
+                    moment(order) = moment(order) - imaginary_unit / x1
+                case (5)
+                    moment(order) = moment(order) &
+                        - 3.0_dp * imaginary_unit / x1
+                end select
+            end if
+        end do
+
+        do k = 0, nmmax
+            do l = 0, nmmax
+                symbI(k, l) = moment(k + l)
+            end do
+        end do
+    end subroutine evaluate_susceptibility
+
     subroutine init_plasma(plasma_in)
 
         use config_m, only: read_species_from_namelist, plasma_type
@@ -415,7 +467,8 @@ module species_m
                                                     + mphi * plasma%spec(sp)%omega_c(j)  - omega) &
                                                     / plasma_in%spec(sp)%nu(j)
 
-                    call getIfunc(plasma_in%spec(sp)%x1(j), plasma_in%spec(sp)%x2(j, mphi), plasma_in%spec(sp)%symbI)
+                    call evaluate_susceptibility(plasma_in%spec(sp)%x1(j), &
+                        plasma_in%spec(sp)%x2(j, mphi), plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
                     plasma_in%spec(sp)%I20(j, mphi) = plasma_in%spec(sp)%symbI(2, 0)
                     plasma_in%spec(sp)%I02(j, mphi) = plasma_in%spec(sp)%symbI(0, 2)
@@ -446,7 +499,8 @@ module species_m
                                                         + mphi * plasma_in%spec(sp)%omega_c(j) - omega) &
                                                         / plasma_in%spec(sp)%nu_cc(j)
 
-                    call getIfunc(plasma_in%spec(sp)%x1_cc(j), plasma_in%spec(sp)%x2_cc(j, mphi), plasma_in%spec(sp)%symbI)
+                    call evaluate_susceptibility(plasma_in%spec(sp)%x1_cc(j), &
+                        plasma_in%spec(sp)%x2_cc(j, mphi), plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00_cc(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
                     plasma_in%spec(sp)%I20_cc(j, mphi) = plasma_in%spec(sp)%symbI(2, 0)
                     plasma_in%spec(sp)%I10_cc(j, mphi) = plasma_in%spec(sp)%symbI(1, 0)
@@ -936,7 +990,7 @@ module species_m
         if (.not. allocated(spec%symbI)) allocate(spec%symbI(0:nmmax, 0:nmmax))
         spec%symbI = 0.0d0
         do j = 1, plasma%grid_size
-            call getIfunc(spec%x1(j), spec%x2(j, mphi), spec%symbI)
+            call evaluate_susceptibility(spec%x1(j), spec%x2(j, mphi), spec%symbI)
             spec%I00(j, mphi) = spec%symbI(0, 0)
             spec%I20(j, mphi) = spec%symbI(2, 0)
             spec%I02(j, mphi) = spec%symbI(0, 2)

--- a/KIM/src/kernels/kernel.f90
+++ b/KIM/src/kernels/kernel.f90
@@ -412,7 +412,8 @@ module kernel_m
     end subroutine initialize_krook_mphi
 
     subroutine Krook_calc_kernel_rho_term_by_term(l, lp, k_rho_phi, k_rho_B, gauss_conf, &
-                                                   species_first, species_last, collisionless)
+                                                   species_first, species_last, collisionless, &
+                                                   k_rho_B_terms)
 
         use KIM_kinds_m, only: dp
         use integrals_gauss_m, only: gauss_integrate_F0, gauss_integrate_F1, gauss_integrate_F2, gauss_integrate_F3,&
@@ -432,6 +433,7 @@ module kernel_m
         type(gauss_config_t), intent(in) :: gauss_conf
         integer, intent(in), optional :: species_first, species_last
         logical, intent(in), optional :: collisionless
+        complex(dp), intent(out), optional :: k_rho_B_terms(3)
         real(dp) :: integral_val
         real(dp) :: current_distance
         integer :: current_idx_distance
@@ -446,6 +448,7 @@ module kernel_m
 
         k_rho_phi = 0.0d0
         k_rho_B = 0.0d0
+        if (present(k_rho_B_terms)) k_rho_B_terms = (0.0_dp, 0.0_dp)
 
         first_species = 0
         last_species = plasma%n_species - 1
@@ -462,7 +465,8 @@ module kernel_m
 
         do sigma = first_species, last_species
             if (turn_off_ions .and. sigma >= 1) cycle
-            do j = 2, size(plasma%r_grid)-1
+            ! Use the same complete radial-cell range as the FP assembly.
+            do j = 1, size(plasma%r_grid)-1
                 int_point%j = j
                 int_point%rhoT = 0.5d0 * (plasma%spec(sigma)%rho_L(j) + plasma%spec(sigma)%rho_L(j+1))
                 int_F0%int_point = int_point
@@ -512,6 +516,12 @@ module kernel_m
                     k_rho_B = k_rho_B + integral_val * Krook_G1_rho_B(j, plasma%spec(sigma), &
                         use_collisionless, collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, plasma%spec(sigma), &
                         use_collisionless, collisionless_kpar_epsilon)
+                    if (present(k_rho_B_terms)) then
+                        k_rho_B_terms(1) = k_rho_B_terms(1) + integral_val * &
+                            Krook_G1_rho_B(j, plasma%spec(sigma), use_collisionless, &
+                            collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, &
+                            plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    end if
 
                     call gauss_integrate_F2(int_F2, integral_val, gauss_conf)
                     k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * &
@@ -519,6 +529,12 @@ module kernel_m
                     k_rho_B = k_rho_B + integral_val * Krook_G2_rho_B(j, plasma%spec(sigma), &
                         use_collisionless, collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, plasma%spec(sigma), &
                         use_collisionless, collisionless_kpar_epsilon)
+                    if (present(k_rho_B_terms)) then
+                        k_rho_B_terms(2) = k_rho_B_terms(2) + integral_val * &
+                            Krook_G2_rho_B(j, plasma%spec(sigma), use_collisionless, &
+                            collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, &
+                            plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    end if
 
                     call gauss_integrate_F3(int_F3, integral_val, gauss_conf)
                     k_rho_phi = k_rho_phi + integral_val * Krook_kappa_rho_phi(j, plasma%spec(sigma)) * &
@@ -526,6 +542,12 @@ module kernel_m
                     k_rho_B = k_rho_B + integral_val * Krook_G3_rho_B(j, plasma%spec(sigma), &
                         use_collisionless, collisionless_kpar_epsilon) * &
                         Krook_kappa_rho_B(j, plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    if (present(k_rho_B_terms)) then
+                        k_rho_B_terms(3) = k_rho_B_terms(3) + integral_val * &
+                            Krook_G3_rho_B(j, plasma%spec(sigma), use_collisionless, &
+                            collisionless_kpar_epsilon) * Krook_kappa_rho_B(j, &
+                            plasma%spec(sigma), use_collisionless, collisionless_kpar_epsilon)
+                    end if
                 end if
 
             end do
@@ -533,6 +555,9 @@ module kernel_m
 
         k_rho_phi = k_rho_phi / (8.0d0 * pi**3.0d0)
         k_rho_B = k_rho_B / (8.0d0 * pi**3.0d0)
+        if (present(k_rho_B_terms)) then
+            k_rho_B_terms = k_rho_B_terms / (8.0_dp * pi**3)
+        end if
 
     end subroutine
 
@@ -895,7 +920,8 @@ module kernel_m
 
     end subroutine
 
-    subroutine FP_calc_kernel_element_ions(l, lp, k_rho_phi, k_rho_B, k_j_phi, k_j_B, gauss_conf, sigma)
+    subroutine FP_calc_kernel_element_ions(l, lp, k_rho_phi, k_rho_B, k_j_phi, k_j_B, &
+                                           gauss_conf, sigma, k_rho_B_terms)
 
         use KIM_kinds_m, only: dp
         use integrals_gauss_m, only: gauss_integrate_F0, gauss_integrate_F1, gauss_integrate_F2, gauss_integrate_F3,&
@@ -916,6 +942,7 @@ module kernel_m
 
         integer, intent(in) :: l, lp, sigma
         complex(dp) :: k_rho_phi, k_rho_B, k_j_phi, k_j_B
+        complex(dp), intent(out), optional :: k_rho_B_terms(3)
         integer :: j, mphi
         type(gauss_config_t), intent(in) :: gauss_conf
         real(dp) :: integral_val
@@ -931,6 +958,7 @@ module kernel_m
         k_rho_B = (0.0d0, 0.0d0)
         k_j_phi = (0.0d0, 0.0d0)
         k_j_B = (0.0d0, 0.0d0)
+        if (present(k_rho_B_terms)) k_rho_B_terms = (0.0_dp, 0.0_dp)
 
         call set_xl_at_edge(l, lp, int_point)
 
@@ -971,6 +999,10 @@ module kernel_m
                 ! end if
                 k_rho_phi = k_rho_phi + integral_val * pref_rho_phi_g1(sigma+1, j, mphi) * (-1.0d0)**mphi
                 k_rho_B = k_rho_B + integral_val * pref_rho_B_g1(sigma+1, j, mphi) * (-1.0d0)**mphi
+                if (present(k_rho_B_terms)) then
+                    k_rho_B_terms(1) = k_rho_B_terms(1) + integral_val * &
+                        pref_rho_B_g1(sigma+1, j, mphi) * (-1.0_dp)**mphi
+                end if
                 k_j_phi = k_j_phi + integral_val * pref_j_phi_g1(sigma+1, j, mphi) * (-1.0d0)**mphi
                 k_j_B = k_j_B + integral_val * pref_j_B_g1(sigma+1, j, mphi) * (-1.0d0)**mphi
             end do
@@ -987,6 +1019,10 @@ module kernel_m
                 call gauss_integrate_F2(int_F2, integral_val, gauss_conf)
                 k_rho_phi = k_rho_phi + integral_val * pref_rho_phi_g2(sigma+1, j, mphi) * (-1.0d0)**mphi
                 k_rho_B = k_rho_B + integral_val * pref_rho_B_g2(sigma+1, j, mphi) * (-1.0d0)**mphi
+                if (present(k_rho_B_terms)) then
+                    k_rho_B_terms(2) = k_rho_B_terms(2) + integral_val * &
+                        pref_rho_B_g2(sigma+1, j, mphi) * (-1.0_dp)**mphi
+                end if
                 k_j_phi = k_j_phi + integral_val * pref_j_phi_g2(sigma+1, j, mphi) * (-1.0d0)**mphi
                 k_j_B = k_j_B + integral_val * pref_j_B_g2(sigma+1, j, mphi) * (-1.0d0)**mphi
 
@@ -995,6 +1031,10 @@ module kernel_m
                 call gauss_integrate_F3(int_F3, integral_val, gauss_conf)
                 k_rho_phi = k_rho_phi + integral_val * pref_rho_phi_g3(sigma+1, j, mphi) * (-1.0d0)**mphi
                 k_rho_B = k_rho_B + integral_val * pref_rho_B_g3(sigma+1, j, mphi) * (-1.0d0)**mphi
+                if (present(k_rho_B_terms)) then
+                    k_rho_B_terms(3) = k_rho_B_terms(3) + integral_val * &
+                        pref_rho_B_g3(sigma+1, j, mphi) * (-1.0_dp)**mphi
+                end if
                 k_j_phi = k_j_phi + integral_val * pref_j_phi_g3(sigma+1,j, mphi) * (-1.0d0)**mphi
                 k_j_B = k_j_B + integral_val * pref_j_B_g3(sigma+1, j, mphi) * (-1.0d0)**mphi
             end do
@@ -1003,6 +1043,9 @@ module kernel_m
 
         k_rho_phi = k_rho_phi / (8.0d0 * pi**3.0d0)
         k_rho_B = k_rho_B / (8.0d0 * pi**3.0d0)
+        if (present(k_rho_B_terms)) then
+            k_rho_B_terms = k_rho_B_terms / (8.0_dp * pi**3)
+        end if
 
         k_j_phi = k_j_phi / (8.0d0 * pi**3.0d0)
         k_j_B = k_j_B / (8.0d0 * pi**3.0d0)

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -89,6 +89,16 @@ add_test(NAME test_collisionless_ion_assembly
 set_tests_properties(test_collisionless_ion_assembly PROPERTIES
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)
 
+add_executable(test_susceptibility_collisionless_limit
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_susceptibility_collisionless_limit.f90)
+set_target_properties(test_susceptibility_collisionless_limit PROPERTIES
+                      OUTPUT_NAME test_susceptibility_collisionless_limit.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_susceptibility_collisionless_limit
+                      KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_susceptibility_collisionless_limit
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_susceptibility_collisionless_limit.x)
+
 add_executable(test_flr2_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_fourier_kernel.f90)
 set_target_properties(test_flr2_fourier_kernel PROPERTIES
                         OUTPUT_NAME test_flr2_fourier_kernel.x

--- a/KIM/tests/test_collisionless_ion_assembly.f90
+++ b/KIM/tests/test_collisionless_ion_assembly.f90
@@ -6,7 +6,9 @@ program test_collisionless_ion_assembly
     use species_m, only: plasma, scale_fp_collision_frequency, set_profiles_from_arrays
     use grid_m, only: xl_grid, kernel_taper_skip_threshold
     use kernel_m, only: kernel_spl_t, FP_fill_kernels, assemble_configured_fp_charge, &
-        Krook_fill_kernel_phi_ions_collisionless, initialize_krook_mphi
+        Krook_fill_kernel_phi_ions_collisionless, initialize_krook_mphi, &
+        FP_calc_kernel_element_ions, Krook_calc_kernel_rho_term_by_term, &
+        larmor_taper_band_limit
     use integrands_gauss_m, only: integration_point_t
     use kim_base_m, only: kim_t
     use kim_mod_m, only: from_kim_factory_get_kim
@@ -22,7 +24,11 @@ program test_collisionless_ion_assembly
     class(kim_t), allocatable :: kim_instance
     complex(dp), allocatable :: ion_sum(:,:), electron_phi(:,:), electron_B(:,:)
     complex(dp), allocatable :: wide_band_ion(:,:), narrow_band_ion(:,:)
-    real(dp) :: scale, offdiag_max
+    complex(dp), allocatable :: weak_fp_ion_phi(:,:), weak_fp_ion_B(:,:)
+    complex(dp) :: rho_phi_projection, rho_B_projection
+    real(dp) :: scale, offdiag_max, rho_phi_error, rho_B_error
+    real(dp) :: rho_phi_shape_error, rho_B_shape_error
+    real(dp) :: requested_fp_scale, requested_kpar_epsilon
     integer :: i, j, wide_band_entries, narrow_band_entries
 
     krook_point%mphi = 17
@@ -42,7 +48,11 @@ program test_collisionless_ion_assembly
     end if
 
     call make_test_profiles(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof)
-    call write_test_namelist('./KIM_config_collisionless_assembly.nml')
+    requested_fp_scale = requested_ion_fp_scale()
+    requested_kpar_epsilon = requested_collisionless_kpar_epsilon()
+    call write_test_namelist(&
+        './KIM_config_collisionless_assembly.nml', requested_fp_scale, &
+        requested_kpar_epsilon)
     nml_config_path = './KIM_config_collisionless_assembly.nml'
     profiles_in_memory = .true.
     call kim_init()
@@ -50,17 +60,19 @@ program test_collisionless_ion_assembly
         print *, 'FAIL: ion_collision_model was not read from KIM_CONFIG'
         error stop
     end if
-    if (abs(collisionless_kpar_epsilon - 1.0e-5_dp) > 1.0e-15_dp) then
+    if (abs(collisionless_kpar_epsilon - requested_kpar_epsilon) > 1.0e-15_dp) then
         print *, 'FAIL: collisionless_kpar_epsilon was not read from KIM_CONFIG'
         error stop
     end if
-    if (abs(ion_fp_collision_scale - 0.25_dp) > 1.0e-15_dp) then
+    if (abs(ion_fp_collision_scale - requested_fp_scale) > 1.0e-15_dp) then
         print *, 'FAIL: ion_fp_collision_scale was not read from KIM_CONFIG'
         error stop
     end if
     call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, q_prof, Er_prof, npts)
     call from_kim_factory_get_kim('electrostatic', kim_instance)
     call kim_instance%init()
+    print *, 'ion max |x1| = ', maxval(abs(plasma%spec(1)%x1_cc))
+    print *, 'ion max |x2| = ', maxval(abs(plasma%spec(1)%x2_cc(:,0)))
 
     call Kphi%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
     call KB%init_kernel(xl_grid%npts_b, xl_grid%npts_b)
@@ -82,7 +94,37 @@ program test_collisionless_ion_assembly
     call FP_fill_kernels(Kphi, KB, Kjphi, KjB)
     electron_phi = Kphi%Kllp_e
     electron_B = KB%Kllp_e
+    weak_fp_ion_phi = Kphi%Kllp_i(:,:,1)
+    weak_fp_ion_B = KB%Kllp_i(:,:,1)
     call assemble_configured_fp_charge(Kphi, KB)
+
+    rho_phi_error = relative_frobenius_error(&
+        Kphi%Kllp_i(:,:,1), weak_fp_ion_phi)
+    rho_B_error = relative_frobenius_error(&
+        KB%Kllp_i(:,:,1), weak_fp_ion_B)
+    rho_phi_projection = least_squares_projection(&
+        Kphi%Kllp_i(:,:,1), weak_fp_ion_phi)
+    rho_B_projection = least_squares_projection(&
+        KB%Kllp_i(:,:,1), weak_fp_ion_B)
+    rho_phi_shape_error = relative_frobenius_error(&
+        Kphi%Kllp_i(:,:,1), rho_phi_projection * weak_fp_ion_phi)
+    rho_B_shape_error = relative_frobenius_error(&
+        KB%Kllp_i(:,:,1), rho_B_projection * weak_fp_ion_B)
+    print *, 'weak-FP -> collisionless rho-Phi relative error = ', rho_phi_error
+    print *, 'weak-FP -> collisionless rho-B relative error   = ', rho_B_error
+    print *, 'rho-Phi collisionless/FP norm ratio             = ', &
+        frobenius_norm(Kphi%Kllp_i(:,:,1)) / frobenius_norm(weak_fp_ion_phi)
+    print *, 'rho-B collisionless/FP norm ratio               = ', &
+        frobenius_norm(KB%Kllp_i(:,:,1)) / frobenius_norm(weak_fp_ion_B)
+    print *, 'rho-Phi best-fit complex factor                 = ', rho_phi_projection
+    print *, 'rho-B best-fit complex factor                   = ', rho_B_projection
+    print *, 'rho-Phi residual after best-fit factor          = ', rho_phi_shape_error
+    print *, 'rho-B residual after best-fit factor            = ', rho_B_shape_error
+    call compare_rho_B_terms(weak_fp_ion_B, KB%Kllp_i(:,:,1))
+    if (rho_phi_error > 0.01_dp .or. rho_B_error > 0.01_dp) then
+        print *, 'FAIL: collisionless ion charge kernels do not converge to weak FP'
+        error stop
+    end if
 
     if (maxval(abs(Kphi%Kllp_e - electron_phi)) > 0.0_dp .or. &
         maxval(abs(KB%Kllp_e - electron_B)) > 0.0_dp) then
@@ -168,8 +210,9 @@ contains
         end do
     end subroutine make_test_profiles
 
-    subroutine write_test_namelist(path)
+    subroutine write_test_namelist(path, fp_scale, kpar_epsilon)
         character(len=*), intent(in) :: path
+        real(dp), intent(in) :: fp_scale, kpar_epsilon
         integer :: unit
         open(newunit=unit, file=path, status='replace', action='write')
         write(unit, '(A)') '&KIM_CONFIG'
@@ -178,8 +221,8 @@ contains
         write(unit, '(A)') " type_of_run = 'electrostatic'"
         write(unit, '(A)') " collision_model = 'FokkerPlanck'"
         write(unit, '(A)') " ion_collision_model = 'collisionless'"
-        write(unit, '(A)') ' collisionless_kpar_epsilon = 1.0e-5'
-        write(unit, '(A)') ' ion_fp_collision_scale = 0.25'
+        write(unit, '(A,ES15.8)') ' collisionless_kpar_epsilon = ', kpar_epsilon
+        write(unit, '(A,ES15.8)') ' ion_fp_collision_scale = ', fp_scale
         write(unit, '(A)') ' read_species_from_namelist = .false.'
         write(unit, '(A)') ' turn_off_ions = .false.'
         write(unit, '(A)') ' turn_off_electrons = .false.'
@@ -246,5 +289,127 @@ contains
         write(unit, '(A)') '/'
         close(unit)
     end subroutine write_test_namelist
+
+    real(dp) function requested_ion_fp_scale() result(scale)
+        character(len=64) :: value
+        integer :: status
+
+        scale = 1.0e-5_dp
+        call get_environment_variable(&
+            'KIM_TEST_ION_FP_SCALE', value, status=status)
+        if (status == 0 .and. len_trim(value) > 0) read(value, *) scale
+    end function requested_ion_fp_scale
+
+    real(dp) function requested_collisionless_kpar_epsilon() result(epsilon)
+        character(len=64) :: value
+        integer :: status
+
+        epsilon = 1.0e-7_dp
+        call get_environment_variable(&
+            'KIM_TEST_KPAR_EPSILON', value, status=status)
+        if (status == 0 .and. len_trim(value) > 0) read(value, *) epsilon
+    end function requested_collisionless_kpar_epsilon
+
+    real(dp) function relative_frobenius_error(actual, expected) result(error)
+        complex(dp), intent(in) :: actual(:,:), expected(:,:)
+        real(dp) :: expected_norm
+
+        expected_norm = frobenius_norm(expected)
+        error = frobenius_norm(actual - expected) &
+            / max(expected_norm, tiny(1.0_dp))
+    end function relative_frobenius_error
+
+    real(dp) function frobenius_norm(matrix) result(norm)
+        complex(dp), intent(in) :: matrix(:,:)
+
+        norm = sqrt(sum(abs(matrix)**2))
+    end function frobenius_norm
+
+    complex(dp) function least_squares_projection(actual, expected) result(factor)
+        complex(dp), intent(in) :: actual(:,:), expected(:,:)
+        real(dp) :: expected_norm_squared
+
+        expected_norm_squared = sum(abs(expected)**2)
+        factor = sum(conjg(expected) * actual) &
+            / max(expected_norm_squared, tiny(1.0_dp))
+    end function least_squares_projection
+
+    subroutine compare_rho_B_terms(fp_total, collisionless_total)
+        use grid_m, only: gauss_int_nodes_Ntheta, gauss_int_nodes_Nx, &
+            gauss_int_nodes_Nxp
+        use integrals_gauss_m, only: gauss_config_t, init_gauss_int
+
+        complex(dp), intent(in) :: fp_total(:,:), collisionless_total(:,:)
+        type(gauss_config_t) :: gauss_conf
+        complex(dp), allocatable :: fp_terms(:,:,:), collisionless_terms(:,:,:)
+        complex(dp) :: fp_phi, fp_B, fp_j_phi, fp_j_B
+        complex(dp) :: collisionless_phi, collisionless_B
+        complex(dp) :: fp_element_terms(3), collisionless_element_terms(3)
+        complex(dp) :: projection
+        real(dp) :: dmax_global, error, shape_error
+        integer :: l, lp, lp_lo, term
+
+        allocate(fp_terms(size(fp_total,1), size(fp_total,2), 3))
+        allocate(collisionless_terms(size(fp_total,1), size(fp_total,2), 3))
+        fp_terms = (0.0_dp, 0.0_dp)
+        collisionless_terms = (0.0_dp, 0.0_dp)
+
+        gauss_conf%Nx = gauss_int_nodes_Nx
+        gauss_conf%Nxp = gauss_int_nodes_Nxp
+        gauss_conf%Ntheta = gauss_int_nodes_Ntheta
+        call init_gauss_int(gauss_conf)
+        dmax_global = larmor_taper_band_limit()
+
+        do l = 1, size(fp_total, 1)
+            lp_lo = l
+            do
+                if (lp_lo <= 1) exit
+                if (abs(xl_grid%xb(lp_lo-1) - xl_grid%xb(l)) > dmax_global) exit
+                lp_lo = lp_lo - 1
+            end do
+            lp_lo = min(lp_lo, l - 1)
+            if (lp_lo < 1) lp_lo = 1
+
+            do lp = lp_lo, l
+                call FP_calc_kernel_element_ions(l, lp, fp_phi, fp_B, fp_j_phi, &
+                    fp_j_B, gauss_conf, 1, k_rho_B_terms=fp_element_terms)
+                call Krook_calc_kernel_rho_term_by_term(l, lp, collisionless_phi, &
+                    collisionless_B, gauss_conf, species_first=1, species_last=1, &
+                    collisionless=.true., k_rho_B_terms=collisionless_element_terms)
+                fp_terms(l,lp,:) = fp_element_terms
+                fp_terms(lp,l,:) = fp_element_terms
+                collisionless_terms(l,lp,:) = collisionless_element_terms
+                collisionless_terms(lp,l,:) = collisionless_element_terms
+            end do
+        end do
+
+        print *, 'rho-B term reconstruction error (FP)          = ', &
+            relative_frobenius_error(sum(fp_terms, dim=3), fp_total)
+        print *, 'rho-B term reconstruction error (CL)          = ', &
+            relative_frobenius_error(sum(collisionless_terms, dim=3), &
+            collisionless_total)
+        do term = 1, 3
+            error = relative_frobenius_error(&
+                collisionless_terms(:,:,term), fp_terms(:,:,term))
+            projection = least_squares_projection(&
+                collisionless_terms(:,:,term), fp_terms(:,:,term))
+            shape_error = relative_frobenius_error(&
+                collisionless_terms(:,:,term), projection * fp_terms(:,:,term))
+            print *, 'rho-B F', term, 'G', term, ' relative error         = ', error
+            print *, 'rho-B F', term, 'G', term, ' CL/FP norm ratio       = ', &
+                frobenius_norm(collisionless_terms(:,:,term)) / &
+                max(frobenius_norm(fp_terms(:,:,term)), tiny(1.0_dp))
+            print *, 'rho-B F', term, 'G', term, ' FP fraction of total  = ', &
+                frobenius_norm(fp_terms(:,:,term)) / &
+                max(frobenius_norm(fp_total), tiny(1.0_dp))
+            print *, 'rho-B F', term, 'G', term, ' CL fraction of total  = ', &
+                frobenius_norm(collisionless_terms(:,:,term)) / &
+                max(frobenius_norm(collisionless_total), tiny(1.0_dp))
+            print *, 'rho-B F', term, 'G', term, ' best-fit factor        = ', &
+                projection
+            print *, 'rho-B F', term, 'G', term, ' shape residual         = ', &
+                shape_error
+        end do
+    end subroutine compare_rho_B_terms
 
 end program test_collisionless_ion_assembly

--- a/KIM/tests/test_susceptibility_collisionless_limit.f90
+++ b/KIM/tests/test_susceptibility_collisionless_limit.f90
@@ -1,0 +1,102 @@
+program test_susceptibility_collisionless_limit
+
+    use getIfunc_config_m, only: boole_energy_conservation
+    use KIM_kinds_m, only: dp
+    use species_m, only: evaluate_susceptibility
+    use use_libcerf_m, only: w_of_z_F
+
+    implicit none
+
+    real(dp), parameter :: pi = 4.0_dp * atan(1.0_dp)
+    real(dp), parameter :: z_values(3) = [0.7_dp, 5.0_dp, 10.0_dp]
+    real(dp), parameter :: scales(5) = &
+        [1.0_dp, 10.0_dp, 100.0_dp, 1000.0_dp, 10000.0_dp]
+    complex(dp) :: numerical(0:3, 0:3), exact(0:3, 0:3)
+    real(dp) :: x1, x2, z, large_argument_error
+    integer :: i, conservation, iz
+
+    do conservation = 1, 2
+        boole_energy_conservation = conservation == 1
+        large_argument_error = 0.0_dp
+        print '(A,L1)', 'energy conservation = ', boole_energy_conservation
+        do iz = 1, size(z_values)
+            z = z_values(iz)
+            print '(A,F5.1)', 'z = ', z
+            print '(A)', 'scale  err(I00)  err(I10)  err(I21)  err(I11)  err(I31)'
+            do i = 1, size(scales)
+                x1 = scales(i)
+                x2 = sqrt(2.0_dp) * z * x1
+                call evaluate_susceptibility(x1, x2, numerical)
+                call collisionless_limit(x1, x2, exact)
+                print '(F7.0,5(1X,ES10.3))', scales(i), &
+                    relative_error(numerical(0, 0), exact(0, 0)), &
+                    relative_error(numerical(1, 0), exact(1, 0)), &
+                    relative_error(numerical(2, 1), exact(2, 1)), &
+                    relative_error(numerical(1, 1), exact(1, 1)), &
+                    relative_error(numerical(3, 1), exact(3, 1))
+                if (scales(i) == 10000.0_dp) then
+                    large_argument_error = max(large_argument_error, &
+                        relative_error(numerical(0, 0), exact(0, 0)), &
+                        relative_error(numerical(1, 0), exact(1, 0)), &
+                        relative_error(numerical(2, 1), exact(2, 1)), &
+                        relative_error(numerical(1, 1), exact(1, 1)), &
+                        relative_error(numerical(3, 1), exact(3, 1)))
+                end if
+            end do
+        end do
+        if (large_argument_error > 1.0e-10_dp) then
+            print *, 'FAIL: large-argument susceptibility error = ', &
+                large_argument_error
+            error stop
+        end if
+    end do
+
+    x1 = -10000.0_dp
+    do iz = 1, size(z_values)
+        x2 = sqrt(2.0_dp) * z_values(iz) * abs(x1)
+        call evaluate_susceptibility(x1, x2, numerical)
+        call collisionless_limit(x1, x2, exact)
+        large_argument_error = max( &
+            relative_error(numerical(0, 0), exact(0, 0)), &
+            relative_error(numerical(1, 0), exact(1, 0)), &
+            relative_error(numerical(2, 1), exact(2, 1)), &
+            relative_error(numerical(1, 1), exact(1, 1)), &
+            relative_error(numerical(3, 1), exact(3, 1)))
+        if (large_argument_error > 1.0e-10_dp) then
+            print *, 'FAIL: negative-x1 susceptibility error = ', &
+                large_argument_error
+            error stop
+        end if
+    end do
+
+contains
+
+    subroutine collisionless_limit(x1, x2, values)
+        real(dp), intent(in) :: x1, x2
+        complex(dp), intent(out) :: values(0:3, 0:3)
+        real(dp) :: sigma, zeta
+        complex(dp) :: plasma_z, common
+
+        sigma = sign(1.0_dp, x1)
+        zeta = x2 / (sqrt(2.0_dp) * x1)
+        plasma_z = cmplx(0.0_dp, 1.0_dp, dp) * sqrt(pi) &
+            * w_of_z_F(cmplx(sigma * zeta, 0.0_dp, dp))
+        common = 1.0_dp + sigma * zeta * plasma_z
+
+        values = cmplx(0.0_dp, 0.0_dp, dp)
+        values(0, 0) = -cmplx(0.0_dp, 1.0_dp, dp) * plasma_z &
+            / (sqrt(2.0_dp) * abs(x1))
+        values(1, 0) = -cmplx(0.0_dp, 1.0_dp, dp) * common / x1
+        values(2, 1) = -cmplx(0.0_dp, 1.0_dp, dp) &
+            * (1.0_dp + 2.0_dp * zeta**2 * common) / x1
+        values(1, 1) = sqrt(2.0_dp) * zeta * values(1, 0)
+        values(3, 1) = sqrt(2.0_dp) * zeta * values(2, 1)
+    end subroutine collisionless_limit
+
+    real(dp) function relative_error(actual, expected) result(error)
+        complex(dp), intent(in) :: actual, expected
+
+        error = abs(actual - expected) / max(abs(expected), tiny(1.0_dp))
+    end function relative_error
+
+end program test_susceptibility_collisionless_limit


### PR DESCRIPTION
## Summary

- evaluate the Fokker–Planck susceptibility with the Markl et al. collisionless moment recurrence when both normalized arguments enter the large-argument cancellation regime
- include the first radial cell in the collisionless Krook kernel assembly so its integration range matches the FP assembly
- expose separately integrated `F1*G1`, `F2*G2`, and `F3*G3` rho-B terms for convergence diagnostics
- add susceptibility-limit and weak-FP/collisionless assembly regression coverage

## Why

The direct `getIfunc` evaluation loses accuracy through cancellation/underflow at very low ion collision frequency. Separately, the collisionless assembly started at radial cell 2 while the FP assembly started at cell 1. These effects obscured convergence between the two formulations.

The term-by-term comparison shows that all three rho-B terms converge together; there is no isolated susceptibility-term or sign error. With ion FP scale `1e-5` and collisionless k-parallel broadening `1e-7 1/cm`, the total rho-B relative error is about 0.119%, while rho-Phi agrees to about 2.5e-7 relative error.

This change does not alter the production default or user-selected `collisionless_kpar_epsilon`.

## Validation

```text
cmake --build build --target test_collisionless_ion_assembly \
  test_susceptibility_collisionless_limit \
  test_collisionless_fourier_kernel test_periodic_background_build -j2

ctest --test-dir build \
  -R 'test_(collisionless_ion_assembly|susceptibility_collisionless_limit|collisionless_fourier_kernel|periodic_background_build)' \
  --output-on-failure
```

Result: 4/4 tests passed after rebasing onto current `main`.