### PR TITLE
fix(KIM): correct perpendicular wavenumber geometry

### DIFF
--- a/KIM/src/CMakeSources.in
+++ b/KIM/src/CMakeSources.in
@@ -44,6 +44,7 @@ set(KIM_util util/findIndex.f90
 #)
 
 set(KIM_background_equilibrium background_equilibrium/species_mod.f90
+                            background_equilibrium/wavenumber_geometry.f90
                             background_equilibrium/calculate_equil.f90
                             background_equilibrium/profile_input_m.f90
                             background_equilibrium/periodization.f90

--- a/KIM/src/background_equilibrium/calculate_equil.f90
+++ b/KIM/src/background_equilibrium/calculate_equil.f90
@@ -47,10 +47,12 @@ module equilibrium_m
         ! matches the global solve.
 
             use species_m, only: plasma, calc_plasma_parameter_derivs
-            use constants_m, only: ev, pi, sol
+            use constants_m, only: ev, pi
             use setup_m, only: btor, R0, m_mode, n_mode
             use config_m, only: number_of_ion_species, output_path, hdf5_output
             use logger_m, only: log_info, log_warning
+            use wavenumber_geometry_m, only: parallel_wavenumber, perpendicular_wavenumber, &
+                                            exb_rotation_frequency
             use fortnum_ode_ddeabm, only: ddeabm_state_t, ddeabm_init, &
                 ddeabm_integrate_to
             use fortnum_status, only: fortnum_status_t, FORTNUM_OK
@@ -155,11 +157,13 @@ module equilibrium_m
                 hth(i) = B0th(i) / B0(i)
 
                 ! "senkrecht" wavenumber
-                plasma%ks(i) = (m_mode * hz(i) - n_mode * hth(i) / R0) / plasma%r_grid(i)
+                plasma%ks(i) = perpendicular_wavenumber(m_mode, n_mode, plasma%r_grid(i), &
+                                                        R0, hth(i), hz(i))
                 ! parallel wavenumber
-                plasma%kp(i) = (m_mode/(plasma%r_grid(i)) * hth(i) + n_mode / R0 * hz(i))
+                plasma%kp(i) = parallel_wavenumber(m_mode, n_mode, plasma%r_grid(i), &
+                                                   R0, hth(i), hz(i))
                 ! ExB rotation frequency
-                plasma%om_E(i) = - sol * plasma%ks(i) * plasma%Er(i) / plasma%B0(i)
+                plasma%om_E(i) = exb_rotation_frequency(plasma%ks(i), plasma%Er(i), plasma%B0(i))
 
             end do
 

--- a/KIM/src/background_equilibrium/wavenumber_geometry.f90
+++ b/KIM/src/background_equilibrium/wavenumber_geometry.f90
@@ -1,0 +1,37 @@
+module wavenumber_geometry_m
+
+    use KIM_kinds_m, only: dp
+    use constants_m, only: sol
+
+    implicit none
+    private
+
+    public :: parallel_wavenumber
+    public :: perpendicular_wavenumber
+    public :: exb_rotation_frequency
+
+contains
+
+    pure elemental real(dp) function parallel_wavenumber(m_mode, n_mode, r, R0, &
+                                                         hth, hz) result(kp)
+        integer, intent(in) :: m_mode, n_mode
+        real(dp), intent(in) :: r, R0, hth, hz
+
+        kp = hth * real(m_mode, dp) / r + hz * real(n_mode, dp) / R0
+    end function parallel_wavenumber
+
+    pure elemental real(dp) function perpendicular_wavenumber(m_mode, n_mode, r, &
+                                                              R0, hth, hz) result(ks)
+        integer, intent(in) :: m_mode, n_mode
+        real(dp), intent(in) :: r, R0, hth, hz
+
+        ks = hz * real(m_mode, dp) / r - hth * real(n_mode, dp) / R0
+    end function perpendicular_wavenumber
+
+    pure elemental real(dp) function exb_rotation_frequency(ks, Er, B0) result(omega_E)
+        real(dp), intent(in) :: ks, Er, B0
+
+        omega_E = -sol * Er * ks / B0
+    end function exb_rotation_frequency
+
+end module wavenumber_geometry_m

--- a/KIM/src/electromagnetic/electromagnetic_solver.f90
+++ b/KIM/src/electromagnetic/electromagnetic_solver.f90
@@ -57,6 +57,7 @@ module rt_electromagnetic_m
         use species_m, only: plasma
         use logger_m, only: log_info, log_debug, log_error
         use kim_diagnostics_m, only: compute_and_write_diagnostics
+        use wavenumber_geometry_m, only: perpendicular_wavenumber
 
         implicit none
 
@@ -84,7 +85,7 @@ module rt_electromagnetic_m
         integer :: sp
 
         integer :: N, i, j
-        real(dp) :: kz, hL, hR
+        real(dp) :: hL, hR
         character(8) :: date
         character(10) :: time
         character(5) :: zone
@@ -107,7 +108,6 @@ module rt_electromagnetic_m
         end select
 
         N = xl_grid%npts_b
-        kz = dble(n_mode) / R0
         Br_boundary = cmplx(Br_boundary_re, Br_boundary_im, dp)
 
         ! Initialize kernels
@@ -140,17 +140,13 @@ module rt_electromagnetic_m
             call calc_mass_matrix(M_mat)
         end if
 
-        ! Compute alpha(r) = i * (m/r * h_z - kz * h_theta) for A_par -> Br conversion
+        ! Compute ks and alpha = i*ks for A_par -> Br conversion.
         call interpolate_equil_to_xl(hz_xl, hth_xl)
-        allocate(alpha(N))
+        allocate(alpha(N), ks_xl(N))
         do i = 1, N
-            alpha(i) = com_unit * (dble(m_mode) / xl_grid%xb(i) * hz_xl(i) - kz * hth_xl(i))
-        end do
-
-        ! Compute ks(r) = (m * h_z - kz * h_theta) / r (perpendicular wavenumber)
-        allocate(ks_xl(N))
-        do i = 1, N
-            ks_xl(i) = (dble(m_mode) * hz_xl(i) - kz * hth_xl(i)) / xl_grid%xb(i)
+            ks_xl(i) = perpendicular_wavenumber(m_mode, n_mode, xl_grid%xb(i), &
+                                                R0, hth_xl(i), hz_xl(i))
+            alpha(i) = com_unit * ks_xl(i)
         end do
 
         ! Build laplace_perp: nabla^2_perp = d^2/dr^2 + (1/r)d/dr - ks^2

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -36,6 +36,15 @@ target_link_libraries(test_equil_ode_ddeabm KIM_lib)
 add_test(NAME test_equil_ode_ddeabm
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_equil_ode_ddeabm.x)
 
+add_executable(test_wavenumber_geometry
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_wavenumber_geometry.f90)
+set_target_properties(test_wavenumber_geometry PROPERTIES
+                      OUTPUT_NAME test_wavenumber_geometry.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_wavenumber_geometry KIM_lib)
+add_test(NAME test_wavenumber_geometry
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_wavenumber_geometry.x)
+
 add_executable(test_profile_input ${CMAKE_SOURCE_DIR}/KIM/tests/test_profile_input.f90)
 set_target_properties(test_profile_input PROPERTIES
                         OUTPUT_NAME test_profile_input.x

--- a/KIM/tests/test_wavenumber_geometry.f90
+++ b/KIM/tests/test_wavenumber_geometry.f90
@@ -1,0 +1,63 @@
+program test_wavenumber_geometry
+
+    use KIM_kinds_m, only: dp
+    use constants_m, only: sol
+    use wavenumber_geometry_m, only: parallel_wavenumber, perpendicular_wavenumber, &
+                                    exb_rotation_frequency
+
+    implicit none
+
+    integer, parameter :: m_mode = -7
+    integer, parameter :: n_mode = 3
+    real(dp), parameter :: r = 40.0_dp
+    real(dp), parameter :: R0 = 165.0_dp
+    real(dp), parameter :: hth = 0.6_dp
+    real(dp), parameter :: hz = -0.8_dp
+    real(dp), parameter :: scale = 2.5_dp
+    real(dp), parameter :: Er = -0.12_dp
+    real(dp), parameter :: B0 = 2.1e4_dp
+    real(dp), parameter :: tol = 100.0_dp * epsilon(1.0_dp)
+
+    real(dp) :: kp, ks, expected_kp, expected_ks
+    real(dp) :: scaled_ks, old_ks, omega_E
+
+    expected_kp = hth * m_mode / r + hz * n_mode / R0
+    expected_ks = hz * m_mode / r - hth * n_mode / R0
+
+    kp = parallel_wavenumber(m_mode, n_mode, r, R0, hth, hz)
+    ks = perpendicular_wavenumber(m_mode, n_mode, r, R0, hth, hz)
+
+    call assert_close('parallel wavenumber', kp, expected_kp, tol)
+    call assert_close('perpendicular wavenumber', ks, expected_ks, tol)
+    call assert_close('orthogonal rotation identity', kp**2 + ks**2, &
+                      (real(m_mode, dp) / r)**2 + (real(n_mode, dp) / R0)**2, tol)
+
+    scaled_ks = perpendicular_wavenumber(m_mode, n_mode, scale * r, scale * R0, hth, hz)
+    call assert_close('length scaling', scaled_ks, ks / scale, tol)
+
+    omega_E = exb_rotation_frequency(ks, Er, B0)
+    call assert_close('ExB rotation frequency', omega_E, -sol * Er * ks / B0, tol)
+
+    ! Both hth and n_mode are nonzero, so the historical extra division by r
+    ! on the toroidal term must be distinguishable from the correct expression.
+    old_ks = (real(m_mode, dp) * hz - real(n_mode, dp) * hth / R0) / r
+    if (abs(old_ks - expected_ks) <= 1.0e-6_dp) then
+        print *, 'negative control did not distinguish the old ks expression'
+        error stop 1
+    end if
+
+    print *, 'KIM wavenumber geometry OK'
+
+contains
+
+    subroutine assert_close(label, actual, expected, tolerance)
+        character(*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected, tolerance
+
+        if (abs(actual - expected) > tolerance * max(1.0_dp, abs(expected))) then
+            print *, trim(label), ': expected ', expected, ', got ', actual
+            error stop 2
+        end if
+    end subroutine assert_close
+
+end program test_wavenumber_geometry


### PR DESCRIPTION
## Summary

- centralize KIM's parallel and perpendicular wavenumber geometry in pure helper functions
- correct both the equilibrium and electromagnetic paths to use `ks = hz*m/r - hth*n/R0`
- derive the electromagnetic `alpha` from the same `ks` value to prevent the formulas drifting again
- add regression coverage for the geometry identities, length scaling, ExB frequency, and the historical extra-`/r` expression

## Root cause

The existing expressions applied a trailing division by `r` to the complete numerator. Since the toroidal contribution was already `n/R0`, this divided that term by radius a second time and made it dimensionally inconsistent.

Fixes #230.

## Verification

- rebased onto `main` at `505e906a`
- full isolated build completed successfully
- affected tests passed (`test_wavenumber_geometry`, `test_equil_ode_ddeabm`, `test_kim_solver_em`)
- full CTest suite: 43/44 passed; the only failure was the acknowledged pre-existing `test_rhs_balance` baseline failure (`gamma_a_e mismatch`)
- mutation check: reinstating the historical formula makes `test_wavenumber_geometry` fail on the perpendicular-wavenumber assertion
- independent code review found no blocking issues

## Expected Golden Record delta

The [`golden-record (main)` failure](https://github.com/itpplasma/KAMEL/actions/runs/30002150485) is the expected signal for this deliberate physics correction, not a build or rebase regression:

- KIM electromagnetic: 64/109 output files differ from the frozen baseline
- QL-Balance: 114/114 quantities pass
- KiLCA: 58/58 files pass
- the first changed background quantities are `backs/ks.dat` (`max_rel=5.516e-03`) and `backs/om_E.dat` (`max_rel=5.599e-03`)
- `kp` and unrelated equilibrium quantities remain unchanged; the other differences propagate from corrected `ks` through susceptibilities, kernels, and fields

No tolerance or exclusion changes are proposed. Per `test/golden/README.md`, after this intentional physics change is merged, re-bless the frozen baseline to the merge commit:

```bash
git tag -f -a golden-baseline <merge-sha> -m "Re-bless golden baseline (KIM perpendicular wavenumber fix #230)"
git push -f origin golden-baseline
```

Then rerun the Golden Record workflow to confirm the new baseline self-comparison is green.