### PR TITLE
fix(QL-Balance): propagate rescaled profiles to KIM

### DIFF
--- a/KIM/src/general/kim_solver_m.f90
+++ b/KIM/src/general/kim_solver_m.f90
@@ -59,6 +59,7 @@ module kim_solver_m
         class(kim_t), allocatable :: run_type
         logical :: is_setup = .false.
         logical :: has_solved = .false.
+        logical :: profiles_dirty = .false.
         integer :: status = KIM_OK
         type(kim_results_t) :: last
     contains
@@ -112,6 +113,7 @@ contains
         call self%run_type%init()
 
         self%is_setup = .true.
+        self%profiles_dirty = .false.
         if (present(stat)) stat = self%status
     end subroutine solver_init
 
@@ -128,6 +130,7 @@ contains
         end if
 
         call inject_profiles(profiles)
+        self%profiles_dirty = .true.
         self%status = KIM_OK
         if (present(stat)) stat = self%status
     end subroutine solver_set_profiles
@@ -154,10 +157,12 @@ contains
         m_mode = m
         n_mode = n
 
-        ! init() prepares the configured mode. Reuse it only when the first
-        ! requested mode matches; subsequent solves also rebuild because
-        ! callers may have replaced the in-memory profiles.
-        if (self%has_solved .or. mode_changed) call recompute_equilibrium_for_mode()
+        ! init() prepares the configured mode. Reuse it only while neither the
+        ! mode nor the in-memory profiles have changed.
+        if (self%has_solved .or. mode_changed .or. self%profiles_dirty) then
+            call recompute_equilibrium_for_mode()
+            self%profiles_dirty = .false.
+        end if
 
         call reset_fields()
         call self%run_type%run()
@@ -198,6 +203,7 @@ contains
         if (allocated(self%run_type)) deallocate(self%run_type)
         self%is_setup = .false.
         self%has_solved = .false.
+        self%profiles_dirty = .false.
         self%status = KIM_OK
     end subroutine solver_finalize
 

--- a/QL-Balance/src/base/kim_wave_code_adapter.f90
+++ b/QL-Balance/src/base/kim_wave_code_adapter.f90
@@ -487,17 +487,18 @@ contains
         !!
         !! Note: dPhi0 is only updated from Ercov during time evolution.
         !! For SingleStep runs, the input Er profile is preserved.
-        use wave_code_data, only: dim_r, &
+        use wave_code_data, only: dim_r, wcd_r => r, wcd_q => q, &
             wcd_n => n, wcd_Te => Te, wcd_Ti => Ti, &
             wcd_Vz => Vz, wcd_dPhi0 => dPhi0
         use plasma_parameters, only: params_b
         use baseparam_mod, only: ev, rtor
         use grid_mod, only: Ercov
-        use control_mod, only: type_of_run
+        use control_mod, only: type_of_run, kim_profiles_from_balance
 
         implicit none
 
-        integer :: k
+        type(kim_profiles_t) :: prof
+        integer :: k, ierr
 
         do k = 1, dim_r
             wcd_n(k)     = params_b(1, k)
@@ -512,6 +513,26 @@ contains
             do k = 1, dim_r
                 wcd_dPhi0(k) = -Ercov(k)
             end do
+        end if
+
+        ! Path A owns the current profiles in QL-Balance. Push every updated
+        ! scan/time-evolution state through KIM's public seam so the next solve
+        ! rebuilds its derived equilibrium from these values.
+        if (kim_profiles_from_balance) then
+            allocate(prof%r(dim_r), prof%n(dim_r), prof%Te(dim_r), &
+                     prof%Ti(dim_r), prof%q(dim_r), prof%Er(dim_r))
+            prof%r = wcd_r
+            prof%n = wcd_n
+            prof%Te = wcd_Te
+            prof%Ti = wcd_Ti
+            prof%q = wcd_q
+            prof%Er = -wcd_dPhi0
+
+            call kim_handle%set_profiles(prof, stat=ierr)
+            if (ierr /= KIM_OK) then
+                write(*,*) 'ERROR: KIM profile update failed with status ', ierr
+                stop 1
+            end if
         end if
 
     end subroutine kim_update_profiles

--- a/QL-Balance/src/test/CMakeLists.txt
+++ b/QL-Balance/src/test/CMakeLists.txt
@@ -26,3 +26,7 @@ add_fortran_test(test_rhs_balance)
 add_executable(test_kim_adapter.x test_kim_adapter.f90)
 target_link_libraries(test_kim_adapter.x PUBLIC ql-balance_lib)
 add_fortran_test(test_kim_adapter)
+configure_file(${CMAKE_SOURCE_DIR}/KIM/tests/test_data/KIM_config_em_small.nml
+               ${CMAKE_BINARY_DIR}/tests/KIM_config_em_small.nml COPYONLY)
+set_tests_properties(test_kim_adapter PROPERTIES
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/)

--- a/QL-Balance/src/test/test_kim_adapter.f90
+++ b/QL-Balance/src/test/test_kim_adapter.f90
@@ -6,17 +6,22 @@ program test_kim_adapter
     !   1. Module compilation and linkage (the adapter + KIM_lib resolve)
     !   2. interp_complex_profile helper correctness
     !   3. wave_code selector variable default
+    !   4. Rescaled QL-Balance profiles change the subsequent KIM solution
     !
-    ! Note: Full integration tests (calling kim_initialize) require
-    ! KIM config files and profile data, and are covered by Task 10
-    ! (end-to-end SingleStep validation).
-    !
-    use kim_wave_code_adapter_m, only: interp_complex_profile
-    use control_mod, only: wave_code
+    use kim_wave_code_adapter_m, only: interp_complex_profile, kim_initialize, &
+        kim_update_profiles, kim_run_for_all_modes, kim_Br_modes, kim_vac_Br
+    use control_mod, only: wave_code, kim_config_path, kim_profiles_from_balance, &
+        type_of_run
+    use wave_code_data, only: dim_mn, m_vals, n_vals, r, n, Te, Ti, q, &
+        Vth, Vz, dPhi0
+    use plasma_parameters, only: params_b
+    use grid_mod, only: Ercov
+    use baseparam_mod, only: ev
 
     implicit none
 
     integer :: num_passed, num_failed
+    external :: allocate_wave_code_data
 
     num_passed = 0
     num_failed = 0
@@ -29,6 +34,7 @@ program test_kim_adapter
     call test_wave_code_default()
     call test_interp_complex_constant()
     call test_interp_complex_linear()
+    call test_rescaled_profiles_change_kim_solution()
 
     print *, ""
     print *, "========================================"
@@ -160,6 +166,80 @@ contains
             call assert_equal_complex(z_new(i), expected, tol, &
                 "linear interp at new grid point")
         end do
+    end subroutine
+
+    ! ------------------------------------------------------------------
+    ! Regression for #136: a parameter-scan profile rescaling must cross
+    ! the adapter boundary and change KIM's next wave solution.
+    ! ------------------------------------------------------------------
+    subroutine test_rescaled_profiles_change_kim_solution()
+        integer, parameter :: npts = 40
+        integer, parameter :: m_mode = -6, n_mode = 2
+        real(8) :: r_grid(npts), frac, response_change, response_scale
+        real(8), allocatable :: base_n(:)
+        complex(8), allocatable :: br_rescaled(:)
+        integer :: i
+
+        print *, "--- test_rescaled_profiles_change_kim_solution ---"
+
+        dim_mn = 1
+        allocate(m_vals(dim_mn), n_vals(dim_mn))
+        m_vals = m_mode
+        n_vals = n_mode
+
+        do i = 1, npts
+            r_grid(i) = 3.0d0 + 64.0d0 * dble(i - 1) / dble(npts - 1)
+        end do
+        call allocate_wave_code_data(npts, r_grid)
+
+        do i = 1, npts
+            frac = (r(i) - 3.0d0) / 64.0d0
+            n(i) = 5.0d13 * (1.0d0 - 0.9d0 * frac)
+            Te(i) = 100.0d0 + 1900.0d0 * (1.0d0 - frac)
+            Ti(i) = 0.9d0 * Te(i)
+            q(i) = 1.0d0 + 3.0d0 * frac
+        end do
+        Vth = 0.0d0
+        Vz = 0.0d0
+        dPhi0 = 0.0d0
+
+        kim_config_path = "KIM_config_em_small.nml"
+        kim_profiles_from_balance = .true.
+        type_of_run = "ParameterScan"
+
+        call kim_initialize(npts, r_grid)
+        kim_vac_Br = (0.0d0, 0.0d0)
+
+        allocate(base_n(npts))
+        base_n = n
+        allocate(params_b(4, npts), Ercov(npts))
+        params_b(1, :) = 1.6d0 * base_n
+        params_b(2, :) = 0.0d0
+        params_b(3, :) = Te * ev
+        params_b(4, :) = Ti * ev
+        Ercov = 0.0d0
+
+        call kim_update_profiles()
+        call kim_run_for_all_modes()
+
+        allocate(br_rescaled(npts))
+        br_rescaled = kim_Br_modes(:, 1)
+
+        params_b(1, :) = base_n
+        call kim_update_profiles()
+        call kim_run_for_all_modes()
+
+        response_change = maxval(abs(kim_Br_modes(:, 1) - br_rescaled))
+        response_scale = max(maxval(abs(br_rescaled)), 1.0d-30)
+        if (response_change > 1.0d-6 * response_scale) then
+            print '(A,ES15.8)', "  PASS: rescaled density changed KIM Br by ", &
+                response_change
+            num_passed = num_passed + 1
+        else
+            print '(A,ES15.8)', "  FAIL: KIM Br remained frozen; max change = ", &
+                response_change
+            num_failed = num_failed + 1
+        end if
     end subroutine
 
 end program test_kim_adapter


### PR DESCRIPTION
## Summary

- reinject the current QL-Balance density, temperature, safety-factor, and electric-field profiles into KIM before each scan or time-evolution solve
- mark replaced KIM profiles as dirty so the derived equilibrium is rebuilt before the next solve, including the first scan point
- add an adapter regression test proving that rescaled density profiles change the KIM magnetic response

## Root cause

`kim_update_profiles` refreshed only QL-Balance's `wave_code_data` arrays. It never called `kim_handle%set_profiles`, so KIM continued solving with the profiles injected during initialization.

## Verification

- `cmake --build build --target test_kim_adapter.x test_kim_solver test_kim_solver_em -j 4`
- `ctest --test-dir build -R '^(test_kim_adapter|test_kim_solver|test_kim_solver_em)$' --output-on-failure`
- 3/3 focused tests passed

Closes #136
