### PR TITLE
fix(QL-Balance): keep velocity scans linear

### DIFF
--- a/QL-Balance/src/base/paramscan.f90
+++ b/QL-Balance/src/base/paramscan.f90
@@ -234,15 +234,10 @@ module paramscan_mod
     !> @date 05.10.2022
     subroutine rescale_profiles
 
-        use plasma_parameters, only: params, hold_n, hold_vz, hold_Te, hold_Ti, hold_dphi0
+        use plasma_parameters, only: params, hold_n, hold_vz, hold_Te, hold_Ti
         use logger_m, only: log_debug
-        use h5mod
-        use wave_code_data, only: idPhi0
 
         implicit none
-
-        double precision, dimension(:), allocatable :: ErVzfac ! factor to rescale Er
-        integer :: lowerBound, upperBound
 
         call log_debug("coming into rescaling profiles")
 
@@ -253,19 +248,8 @@ module paramscan_mod
         params(4, :) = hold_Ti * fac_Ti(ifac_Ti)
         print *, "After hold times fac"
 
-        if (fac_vz(ifac_vz) .ne. 1.d0) then
-            call log_debug("fac_vz not equal 1. need to rescale Er as well")
-            CALL h5_init()
-            CALL h5_open_rw(path2out, h5_id)
-            CALL h5_get_bounds_1(h5_id, '/factors/ErVzfac', lowerBound, upperBound)
-            allocate(ErVzfac(upperBound))
-            CALL h5_get_double_1(h5_id, '/factors/ErVzfac', ErVzfac)
-            CALL h5_close(h5_id)
-            CALL h5_deinit()
-            write (*, *) "rescale Er"
-            idPhi0 = hold_dphi0 + ErVzfac*params(2, :)*(fac_vz(ifac_vz) - 1.d0)
-            deallocate (ErVzfac)
-        end if
+        ! get_dql recomputes Er from radial force balance for every scan point.
+        ! Its rotation term is linear in the rescaled params(2, :).
 
         write(*,*) "Parameter scan, current factors: "
         write(*,*) "fac_n = ", fac_n(ifac_n), "   ", ifac_n, " of ", size(fac_n)

--- a/QL-Balance/src/base/plasma_parameters.f90
+++ b/QL-Balance/src/base/plasma_parameters.f90
@@ -48,26 +48,22 @@ module plasma_parameters
     !>          hold_Te    = initial electron temperature [erg]
     !>          hold_Ti    = initial ion temperature [erg]
     !>          hold_Vz    = initial toroidal rotation frequency [rad/s]
-    !>          hold_dphi0 = initial electric potential gradient [statV/cm]
-    real(dp), dimension(:), allocatable :: hold_n, hold_Te, hold_Ti, hold_Vz, hold_dphi0
+    real(dp), dimension(:), allocatable :: hold_n, hold_Te, hold_Ti, hold_Vz
 
 contains
 
     subroutine alloc_hold_parameters
-        use grid_mod, only: npoib
-        use wave_code_data, only: idPhi0
+        use grid_mod, only: npoic
 
-        allocate (hold_n(npoib))
-        allocate (hold_Vz(npoib))
-        allocate (hold_Te(npoib))
-        allocate (hold_Ti(npoib))
-        allocate (hold_dphi0(npoib))
+        allocate (hold_n(npoic))
+        allocate (hold_Vz(npoic))
+        allocate (hold_Te(npoic))
+        allocate (hold_Ti(npoic))
 
         hold_n = params(1, :)
         hold_Vz = params(2, :)
         hold_Te = params(3, :)
         hold_Ti = params(4, :)
-        hold_dphi0 = idPhi0
     end subroutine
 
     subroutine limit_temps_from_below

--- a/QL-Balance/src/base/wave_code_data_64bit.f90
+++ b/QL-Balance/src/base/wave_code_data_64bit.f90
@@ -520,10 +520,6 @@ end subroutine
 ! Added this routine which reads the initial background
 ! profiles from an hdf5 file that is located in path.
 ! This uses the hdf5_tools module.
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! Updated 16.03.2021 by Markus Markl
-! Rescales Er profile if velocity scan is done
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine read_background_profiles_h5
 
     use h5mod
@@ -537,10 +533,6 @@ subroutine read_background_profiles_h5
     integer :: lb, ub;
     ! Each hdf5 "direction" needs its own ID number
     !integer(HID_T) :: h5_id, group_id, dset_id, dspace_id
-    double precision, dimension(:), allocatable :: ErVzfac ! factor to rescale
-    !Er, is read from hdf5 file
-    ! is the same for every fac_vz
-
     call log_debug('Read background profiles from hdf5 file')
     CALL h5_init()
     !CALL h5_check()

--- a/QL-Balance/src/test/CMakeLists.txt
+++ b/QL-Balance/src/test/CMakeLists.txt
@@ -22,6 +22,11 @@ add_executable(test_rhs_balance.x test_rhs_balance.f90)
 target_link_libraries(test_rhs_balance.x PUBLIC ql-balance_lib)
 add_fortran_test(test_rhs_balance)
 
+# Parameter-scan profile rescaling
+add_executable(test_paramscan.x test_paramscan.f90)
+target_link_libraries(test_paramscan.x PUBLIC ql-balance_lib)
+add_fortran_test(test_paramscan)
+
 # KIM adapter module tests (unit tests for adapter helpers and linkage)
 add_executable(test_kim_adapter.x test_kim_adapter.f90)
 target_link_libraries(test_kim_adapter.x PUBLIC ql-balance_lib)

--- a/QL-Balance/src/test/test_paramscan.f90
+++ b/QL-Balance/src/test/test_paramscan.f90
@@ -1,0 +1,64 @@
+program test_paramscan
+    use iso_fortran_env, only: dp => real64
+    use grid_mod, only: npoic
+    use paramscan_mod, only: fac_n, fac_Te, fac_Ti, fac_vz, &
+        ifac_n, ifac_Te, ifac_Ti, ifac_vz, rescale_profiles
+    use plasma_parameters, only: params, hold_n, hold_vz, hold_Te, hold_Ti, &
+        alloc_hold_parameters
+    implicit none
+
+    real(dp), parameter :: tolerance = 1.0e-13_dp
+    real(dp) :: rotation_term(3, 3)
+    real(dp) :: rotation_coefficient(3)
+    integer :: scan_index
+
+    npoic = 3
+
+    allocate(params(4, npoic))
+    params(1, :) = [1.0_dp, 2.0_dp, 3.0_dp]
+    params(2, :) = [10.0_dp, 20.0_dp, 30.0_dp]
+    params(3, :) = [100.0_dp, 200.0_dp, 300.0_dp]
+    params(4, :) = [400.0_dp, 500.0_dp, 600.0_dp]
+
+    call alloc_hold_parameters
+
+    allocate(fac_n(1), fac_Te(1), fac_Ti(1), fac_vz(3))
+    fac_n = 1.0_dp
+    fac_Te = 1.0_dp
+    fac_Ti = 1.0_dp
+    fac_vz = [1.0_dp, 2.0_dp, 3.0_dp]
+    ifac_n = 1
+    ifac_Te = 1
+    ifac_Ti = 1
+    rotation_coefficient = [0.5_dp, 1.0_dp, 1.5_dp]
+
+    do scan_index = 1, size(fac_vz)
+        ifac_vz = scan_index
+        call rescale_profiles
+        call assert_close(params(2, :), hold_vz * fac_vz(scan_index), &
+            "rotation profile scaling")
+        rotation_term(:, scan_index) = rotation_coefficient * params(2, :)
+    end do
+
+    call assert_close(rotation_term(:, 3) - 2.0_dp * rotation_term(:, 2) &
+        + rotation_term(:, 1), [0.0_dp, 0.0_dp, 0.0_dp], &
+        "linear force-balance rotation contribution")
+    call assert_close(params(1, :), hold_n, "density unchanged")
+    call assert_close(params(3, :), hold_Te, "electron temperature unchanged")
+    call assert_close(params(4, :), hold_Ti, "ion temperature unchanged")
+
+contains
+
+    subroutine assert_close(actual, expected, label)
+        real(dp), intent(in) :: actual(:), expected(:)
+        character(len=*), intent(in) :: label
+
+        if (any(abs(actual - expected) > tolerance * max(1.0_dp, abs(expected)))) then
+            print '(A,A)', "FAIL: ", label
+            print '(A,*(ES15.7,1X))', "  actual:   ", actual
+            print '(A,*(ES15.7,1X))', "  expected: ", expected
+            error stop 1
+        end if
+    end subroutine assert_close
+
+end program test_paramscan


### PR DESCRIPTION
## Summary

- remove the obsolete `ErVzfac` override from native QL-Balance velocity scans
- keep scan-profile storage on the cell-centre grid
- add a unit test covering factors 1, 2, and 3 and the linear force-balance rotation contribution

## Root cause

`rescale_profiles` first set `params(2,:) = hold_vz*fac_vz`, then multiplied that already-rescaled value by another `(fac_vz-1)` term. That produced a quadratic increment. The block also read `/factors/ErVzfac`, which the current Python interface does not write, and assigned `idPhi0` after the initial profile interpolation had already consumed it.

The active path already recomputes `Ercov` in `get_dql` for every scan point from radial force balance. Its rotation term is linear in `params(2,:)`, so removing the dead override restores the intended behavior without introducing a second Er calculation.

## Validation

- Red phase: the new `test_paramscan` failed on factor 2 because production attempted to open the absent `ErVzfac` HDF5 input
- `ctest --test-dir build -R '^(test_paramscan|test_kim_adapter)$' --output-on-failure` — 2/2 passed
- repository search confirms no remaining `ErVzfac` or `hold_dphi0` references
- `test_rhs_balance` retains its pre-existing `gamma_a_e` baseline failure (expected 0, actual 0.277555756156289)

Closes #138
