### PR TITLE
test(golden): run harness unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
+      - name: Test golden-record harness
+        run: make pytest
+
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CONFIG ?= Release
 INSTALL_KIM_SYMLINK ?= OFF
+PYTHON ?= python3
 
 # Honor LIBNEO_REF/LIBNEO_PATH only when passed on the make command line; an
 # ambient value from the shell is ignored so it cannot change the libneo fetch.
@@ -37,6 +38,9 @@ PreProc:
 
 test: ninja
 	ctest --test-dir build --stop-on-failure --output-on-failure --no-label-summary
+
+pytest:
+	$(PYTHON) -m pytest test/golden/bin -q
 
 # Golden-record regression now lives in test/golden/ and runs in the dedicated
 # GitHub Actions job, NOT in `make test`/ctest. This target is for manual local


### PR DESCRIPTION
## Summary

- add the missing `make pytest` target promised by `.PHONY`
- run the golden-record comparator unit tests in the normal CI workflow
- allow developers to override the Python interpreter with `PYTHON=...`

## Why

The comparator tests protect the special `poy_test_err` handling and the restored full time-step coverage, but CI previously installed pytest without invoking either test module. This left the golden harness behavior unguarded.

This PR handles the independent test-wiring residue of #172. Deterministic BLAS selection and a same-build reproducibility check remain separate work.

## Validation

`make PYTHON=/Users/markusmarkl/code/.venv/bin/python3 pytest` — 12 passed

Refs #172
