### PR TITLE
feat(KIM): add species-specific conservation and charge diagnostics

### DIFF
--- a/KIM/nmls/README.md
+++ b/KIM/nmls/README.md
@@ -10,12 +10,22 @@ KIM is configured via the namelist file KIM_config.nml containing multiple namel
 - collisionless_kpar_epsilon ... real, positive causal-pole width in 1/cm required by `ion_collision_model='collisionless'`. KIM uses $k_{\parallel}+i\epsilon$ for signed inverse factors and $\sqrt{k_{\parallel}^2+\epsilon^2}$ for even charge-response factors.
 - ion_fp_collision_scale ... real, positive multiplier applied only to ion FP collision frequencies. It has no effect on collisionless ion kernels.
 - collision_frequency_scale ... real, positive multiplier applied to the calculated electron and ion collision frequencies before the Krook argument z0 and the Fokker-Planck susceptibility inputs are assembled; default 1.0 leaves the collision formulas unchanged
+- electron_ifunc_conservation_model ... integer, electron FPGEN conservation model: `0` particle number, `1` number and energy, `2` number and parallel momentum, `3` number, energy, and parallel momentum. Default `-1` inherits `boole_energy_conservation`. Use `1` for resistive calculations; electron momentum conservation removes the resistive response.
+- ion_ifunc_conservation_model ... integer, ion FPGEN conservation model with the same numbering. Use `1` for the tokamak-like flow-braking model and `3` for the momentum-conserving cylindrical model.
+- boole_energy_conservation ... deprecated boolean fallback used only for a species whose integer model is `-1`; `.true.` resolves to model `1`, `.false.` to model `0`
 - artificial_debye_case ... integer, if 0: full calculation of kernel, if 1: Debye case, if 2: exclude Debye case
 
 Collisionless forced periodicity currently requires `artificial_debye_case=0`,
 `theta_integration='GaussLegendre'`, and a positive
 `collisionless_kpar_epsilon`. Higher cyclotron harmonics are not included in
 this ion model; the implemented derivation uses $m_\phi=0$.
+
+For the cylindrical comparison requested in the Er scan, use:
+
+```fortran
+electron_ifunc_conservation_model = 1  ! N+E: retain electron resistivity
+ion_ifunc_conservation_model = 3       ! N+E+P: conserve ion parallel momentum
+```
 
 ## KIM_IO
 - profile_location ... string, path to the profiles

--- a/KIM/src/asymptotics/collisionless_fourier_kernel.f90
+++ b/KIM/src/asymptotics/collisionless_fourier_kernel.f90
@@ -17,7 +17,7 @@ module collisionless_fourier_kernel_m
 contains
 
     subroutine configured_hatG_all(plasma_in, kr, krp, j, rho_phi, rho_B, j_phi, j_B, &
-            j_phi_species, j_B_species)
+            j_phi_species, j_B_species, rho_phi_species, rho_B_species)
         ! Select the configured ion model without changing the electron model.
         ! Accumulate the established per-species FP kernels in FokkerPlanck mode.
         ! In collisionless mode, electrons remain FP while every enabled ion
@@ -28,6 +28,7 @@ contains
         integer, intent(in) :: j
         complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
         complex(dp), intent(out), optional :: j_phi_species(0:), j_B_species(0:)
+        complex(dp), intent(out), optional :: rho_phi_species(0:), rho_B_species(0:)
 
         integer :: sp
         complex(dp) :: species_rho_phi, species_rho_B
@@ -43,6 +44,17 @@ contains
             end if
             j_phi_species = (0.0_dp, 0.0_dp)
             j_B_species = (0.0_dp, 0.0_dp)
+        end if
+        if (present(rho_phi_species) .neqv. present(rho_B_species)) then
+            error stop 'configured_hatG_all requires both species-charge arrays'
+        end if
+        if (present(rho_phi_species)) then
+            if (ubound(rho_phi_species, 1) < plasma_in%n_species - 1 .or. &
+                    ubound(rho_B_species, 1) < plasma_in%n_species - 1) then
+                error stop 'configured_hatG_all species-charge arrays are too small'
+            end if
+            rho_phi_species = (0.0_dp, 0.0_dp)
+            rho_B_species = (0.0_dp, 0.0_dp)
         end if
 
         rho_phi = (0.0_dp, 0.0_dp)
@@ -60,6 +72,10 @@ contains
             if (present(j_phi_species)) then
                 j_phi_species(sp) = species_j_phi
                 j_B_species(sp) = species_j_B
+            end if
+            if (present(rho_phi_species)) then
+                rho_phi_species(sp) = species_rho_phi
+                rho_B_species(sp) = species_rho_B
             end if
         end do
     end subroutine configured_hatG_all

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -107,7 +107,7 @@ module species_m
 
     end function scale_fp_collision_frequency
 
-    subroutine evaluate_susceptibility(x1, x2, symbI)
+    subroutine evaluate_susceptibility(x1, x2, conservation_model, symbI)
         ! Markl et al., Nucl. Fusion 63 (2023) 126007, appendix A:
         ! use the collisionless moments once the collisional W2_arr
         ! representation enters its empirically identified cancellation
@@ -117,6 +117,7 @@ module species_m
         use use_libcerf_m, only: w_of_z_F
 
         real(dp), intent(in) :: x1, x2
+        integer, intent(in) :: conservation_model
         complex(dp), intent(out) :: symbI(0:nmmax, 0:nmmax)
 
         real(dp), parameter :: smaller_argument_threshold = 1.0e3_dp
@@ -128,7 +129,7 @@ module species_m
 
         if (min(abs(x1), abs(x2)) < smaller_argument_threshold .or. &
                 max(abs(x1), abs(x2)) < larger_argument_threshold) then
-            call getIfunc(x1, x2, symbI)
+            call getIfunc_model(x1, x2, conservation_model, symbI)
             return
         end if
 
@@ -403,12 +404,12 @@ module species_m
         use setup_m, only: omega, mphi_max
         use grid_m, only: rg_grid
         use KIM_kinds_m, only: dp
-        use config_m, only: ion_flr_scale_factor
+        use config_m, only: ion_flr_scale_factor, ifunc_model_for_species
 
         implicit none
 
         type(plasma_t), intent(inout) :: plasma_in
-        integer :: sp, j, mphi
+        integer :: sp, j, mphi, ifunc_model
 
         ! Allocate arrays
         do sp = 0, plasma_in%n_species-1
@@ -452,6 +453,7 @@ module species_m
         ! Calculate on boundary points (npts_b)
         do sp = 0, plasma_in%n_species-1
             plasma_in%spec(sp)%symbI = 0.0d0
+            ifunc_model = ifunc_model_for_species(sp)
 
             do j = 1, rg_grid%npts_b
 
@@ -468,7 +470,8 @@ module species_m
                                                     / plasma_in%spec(sp)%nu(j)
 
                     call evaluate_susceptibility(plasma_in%spec(sp)%x1(j), &
-                        plasma_in%spec(sp)%x2(j, mphi), plasma_in%spec(sp)%symbI)
+                        plasma_in%spec(sp)%x2(j, mphi), ifunc_model, &
+                        plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
                     plasma_in%spec(sp)%I20(j, mphi) = plasma_in%spec(sp)%symbI(2, 0)
                     plasma_in%spec(sp)%I02(j, mphi) = plasma_in%spec(sp)%symbI(0, 2)
@@ -484,6 +487,7 @@ module species_m
         ! Calculate on cell centers (npts_c)
         do sp = 0, plasma_in%n_species-1
             plasma_in%spec(sp)%symbI = 0.0d0
+            ifunc_model = ifunc_model_for_species(sp)
 
             do j = 1, rg_grid%npts_c
                 plasma_in%spec(sp)%A1_cc(j) = plasma_in%spec(sp)%dndr_cc(j) / plasma_in%spec(sp)%n_cc(j) &
@@ -500,7 +504,8 @@ module species_m
                                                         / plasma_in%spec(sp)%nu_cc(j)
 
                     call evaluate_susceptibility(plasma_in%spec(sp)%x1_cc(j), &
-                        plasma_in%spec(sp)%x2_cc(j, mphi), plasma_in%spec(sp)%symbI)
+                        plasma_in%spec(sp)%x2_cc(j, mphi), ifunc_model, &
+                        plasma_in%spec(sp)%symbI)
                     plasma_in%spec(sp)%I00_cc(j, mphi) = plasma_in%spec(sp)%symbI(0, 0)
                     plasma_in%spec(sp)%I20_cc(j, mphi) = plasma_in%spec(sp)%symbI(2, 0)
                     plasma_in%spec(sp)%I10_cc(j, mphi) = plasma_in%spec(sp)%symbI(1, 0)
@@ -980,17 +985,22 @@ module species_m
 
         use kim_resonances_m, only: r_res
         use grid_m, only: width_res
+        use config_m, only: resolved_electron_ifunc_conservation_model, &
+                            resolved_ion_ifunc_conservation_model
 
         implicit none
 
         type(species_t), intent(inout) :: spec
         integer, intent(in) :: mphi
-        integer :: j
+        integer :: j, ifunc_model
 
         if (.not. allocated(spec%symbI)) allocate(spec%symbI(0:nmmax, 0:nmmax))
         spec%symbI = 0.0d0
+        ifunc_model = resolved_ion_ifunc_conservation_model
+        if (spec%Zspec < 0) ifunc_model = resolved_electron_ifunc_conservation_model
         do j = 1, plasma%grid_size
-            call evaluate_susceptibility(spec%x1(j), spec%x2(j, mphi), spec%symbI)
+            call evaluate_susceptibility(spec%x1(j), spec%x2(j, mphi), &
+                ifunc_model, spec%symbI)
             spec%I00(j, mphi) = spec%symbI(0, 0)
             spec%I20(j, mphi) = spec%symbI(2, 0)
             spec%I02(j, mphi) = spec%symbI(0, 2)

--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -404,12 +404,15 @@ module species_m
         use setup_m, only: omega, mphi_max
         use grid_m, only: rg_grid
         use KIM_kinds_m, only: dp
-        use config_m, only: ion_flr_scale_factor, ifunc_model_for_species
+        use config_m, only: ion_flr_scale_factor, ifunc_model_for_species, &
+                            ion_temperature_gradient_model, &
+                            temperature_gradient_force_terms
 
         implicit none
 
         type(plasma_t), intent(inout) :: plasma_in
         integer :: sp, j, mphi, ifunc_model
+        real(dp) :: normalized_temperature_gradient, a1_temperature, a2_force
 
         ! Allocate arrays
         do sp = 0, plasma_in%n_species-1
@@ -457,10 +460,15 @@ module species_m
 
             do j = 1, rg_grid%npts_b
 
+                normalized_temperature_gradient = plasma_in%spec(sp)%dTdr(j) &
+                    / plasma_in%spec(sp)%T(j)
+                call temperature_gradient_force_terms(sp, &
+                    ion_temperature_gradient_model, &
+                    normalized_temperature_gradient, a1_temperature, a2_force)
                 plasma_in%spec(sp)%A1(j) = plasma_in%spec(sp)%dndr(j) / plasma_in%spec(sp)%n(j) &
                     - plasma_in%spec(sp)%Zspec * e_charge / (plasma_in%spec(sp)%T(j) * ev) * plasma_in%Er(j) &
-                    - 3.0d0 / (2.0d0 * plasma_in%spec(sp)%T(j)) * plasma_in%spec(sp)%dTdr(j)
-                plasma_in%spec(sp)%A2(j) = plasma_in%spec(sp)%dTdr(j) / plasma_in%spec(sp)%T(j)
+                    + a1_temperature
+                plasma_in%spec(sp)%A2(j) = a2_force
 
 
                 plasma_in%spec(sp)%x1(j) = plasma_in%kp(j) * plasma_in%spec(sp)%vT(j) / plasma_in%spec(sp)%nu(j)
@@ -490,10 +498,15 @@ module species_m
             ifunc_model = ifunc_model_for_species(sp)
 
             do j = 1, rg_grid%npts_c
+                normalized_temperature_gradient = plasma_in%spec(sp)%dTdr_cc(j) &
+                    / plasma_in%spec(sp)%T_cc(j)
+                call temperature_gradient_force_terms(sp, &
+                    ion_temperature_gradient_model, &
+                    normalized_temperature_gradient, a1_temperature, a2_force)
                 plasma_in%spec(sp)%A1_cc(j) = plasma_in%spec(sp)%dndr_cc(j) / plasma_in%spec(sp)%n_cc(j) &
                     - plasma_in%spec(sp)%Zspec * e_charge / (plasma_in%spec(sp)%T_cc(j) * ev) * plasma_in%Er_cc(j) &
-                    - 3.0d0 / (2.0d0 * plasma_in%spec(sp)%T_cc(j)) * plasma_in%spec(sp)%dTdr_cc(j)
-                plasma_in%spec(sp)%A2_cc(j) = plasma_in%spec(sp)%dTdr_cc(j) / plasma_in%spec(sp)%T_cc(j)
+                    + a1_temperature
+                plasma_in%spec(sp)%A2_cc(j) = a2_force
 
                 plasma_in%spec(sp)%x1_cc(j) = 0.5d0 * (plasma_in%kp(j) + plasma_in%kp(j+1)) &
                     * plasma_in%spec(sp)%vT_cc(j) / plasma_in%spec(sp)%nu_cc(j)

--- a/KIM/src/diagnostics/kim_qldiff_mod.f90
+++ b/KIM/src/diagnostics/kim_qldiff_mod.f90
@@ -29,6 +29,7 @@ contains
         !   Es   - complex perpendicular electric field amplitude [statV/cm]
         !   Br   - complex radial magnetic perturbation amplitude [G]
         use constants_m, only: sol
+        use config_m, only: resolved_electron_ifunc_conservation_model
 
         real(dp), intent(in) :: vTe, nue, om_E, B0, kpar
         complex(dp), intent(in) :: Es, Br
@@ -38,10 +39,11 @@ contains
         complex(dp) :: symbI(0:3, 0:3)
 
         interface
-            subroutine getIfunc(x1, x2, symbI)
+            subroutine getIfunc_model(x1, x2, conservation_model, symbI)
                 double precision, intent(in) :: x1, x2
+                integer, intent(in) :: conservation_model
                 double complex, dimension(0:3, 0:3), intent(out) :: symbI
-            end subroutine
+            end subroutine getIfunc_model
         end interface
 
         ! Normalized distance to resonance and inverse normalized
@@ -49,7 +51,8 @@ contains
         x1 = kpar * vTe / nue
         x2 = -om_E / nue
 
-        call getIfunc(x1, x2, symbI)
+        call getIfunc_model(x1, x2, &
+            resolved_electron_ifunc_conservation_model, symbI)
 
         comfac = 0.5_dp / (nue * B0**2)
         epm2 = sol**2 * abs(Es)**2

--- a/KIM/src/electrostatic_poisson/periodic_assembly.f90
+++ b/KIM/src/electrostatic_poisson/periodic_assembly.f90
@@ -65,7 +65,7 @@ contains
     !> Kjphi . Phi_m + KjB . Br_m. The j-kernels already carry their
     !> 1/(8*pi^2) Fourier normalization, so no further scaling is applied here.
     subroutine assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
-            Kjphi_species, KjB_species)
+            Kjphi_species, KjB_species, Kphi_species, KB_species)
         use grid_m, only: rg_grid
         use collisionless_fourier_kernel_m, only: configured_hatG_all
         use constants_m, only: pi
@@ -77,6 +77,8 @@ contains
         complex(dp), allocatable, intent(out) :: Kjphi(:,:), KjB(:,:)
         complex(dp), allocatable, intent(out), optional :: Kjphi_species(:,:,:)
         complex(dp), allocatable, intent(out), optional :: KjB_species(:,:,:)
+        complex(dp), allocatable, intent(out), optional :: Kphi_species(:,:,:)
+        complex(dp), allocatable, intent(out), optional :: KB_species(:,:,:)
 
         integer :: N, dim, m_row, m_col, im, imp, j
         real(dp) :: k_m, k_mp, weight
@@ -86,7 +88,11 @@ contains
         complex(dp) :: acc_jB_species(0:plasma%n_species - 1)
         complex(dp) :: point_jphi_species(0:plasma%n_species - 1)
         complex(dp) :: point_jB_species(0:plasma%n_species - 1)
-        logical :: want_species
+        complex(dp) :: acc_phi_species(0:plasma%n_species - 1)
+        complex(dp) :: acc_B_species(0:plasma%n_species - 1)
+        complex(dp) :: point_phi_species(0:plasma%n_species - 1)
+        complex(dp) :: point_B_species(0:plasma%n_species - 1)
+        logical :: want_current_species, want_charge_species, want_any_species
 
         N = rg_grid%npts_b
         dim = 2 * M + 1
@@ -94,10 +100,19 @@ contains
         if (present(Kjphi_species) .neqv. present(KjB_species)) then
             error stop 'assemble_periodic_matrices requires both species-current matrices'
         end if
-        want_species = present(Kjphi_species)
-        if (want_species) then
+        if (present(Kphi_species) .neqv. present(KB_species)) then
+            error stop 'assemble_periodic_matrices requires both species-charge matrices'
+        end if
+        want_current_species = present(Kjphi_species)
+        want_charge_species = present(Kphi_species)
+        want_any_species = want_current_species .or. want_charge_species
+        if (want_current_species) then
             allocate(Kjphi_species(dim, dim, 0:plasma%n_species - 1))
             allocate(KjB_species(dim, dim, 0:plasma%n_species - 1))
+        end if
+        if (want_charge_species) then
+            allocate(Kphi_species(dim, dim, 0:plasma%n_species - 1))
+            allocate(KB_species(dim, dim, 0:plasma%n_species - 1))
         end if
 
         ! Periodic trapezoidal weight. rg_grid%xb is EQUIDISTANT and ENDPOINT-
@@ -113,12 +128,13 @@ contains
         ! bitwise-reproducible entries at a given compiler/architecture.
         !$omp parallel do default(none) schedule(static) &
         !$omp shared(M, L, N, weight, plasma, Kphi, KB, Kjphi, KjB, &
-        !$omp        want_species, Kjphi_species, KjB_species) &
+        !$omp        want_current_species, want_charge_species, want_any_species, &
+        !$omp        Kjphi_species, KjB_species, Kphi_species, KB_species) &
         !$omp private(m_col, k_mp, imp, m_row, k_m, im, j, &
         !$omp         acc_phi, acc_B, acc_jphi, acc_jB, &
-        !$omp         acc_jphi_species, acc_jB_species, &
+        !$omp         acc_jphi_species, acc_jB_species, acc_phi_species, acc_B_species, &
         !$omp         point_phi, point_B, point_jphi, point_jB, &
-        !$omp         point_jphi_species, point_jB_species)
+        !$omp         point_jphi_species, point_jB_species, point_phi_species, point_B_species)
         do m_col = -M, M
             k_mp = k_of_m(m_col, L)
             imp = m_col + M + 1
@@ -130,15 +146,20 @@ contains
                 acc_B    = (0.0_dp, 0.0_dp)
                 acc_jphi = (0.0_dp, 0.0_dp)
                 acc_jB   = (0.0_dp, 0.0_dp)
-                if (want_species) then
+                if (want_any_species) then
+                    acc_phi_species = (0.0_dp, 0.0_dp)
+                    acc_B_species = (0.0_dp, 0.0_dp)
                     acc_jphi_species = (0.0_dp, 0.0_dp)
                     acc_jB_species = (0.0_dp, 0.0_dp)
                 end if
                 do j = 1, N
-                    if (want_species) then
+                    if (want_any_species) then
                         call configured_hatG_all(plasma, k_m, k_mp, j, &
                             point_phi, point_B, point_jphi, point_jB, &
-                            point_jphi_species, point_jB_species)
+                            point_jphi_species, point_jB_species, &
+                            point_phi_species, point_B_species)
+                        acc_phi_species = acc_phi_species + point_phi_species
+                        acc_B_species = acc_B_species + point_B_species
                         acc_jphi_species = acc_jphi_species + point_jphi_species
                         acc_jB_species = acc_jB_species + point_jB_species
                     else
@@ -155,9 +176,13 @@ contains
                 KB(im, imp)    = weight * acc_B
                 Kjphi(im, imp) = weight * acc_jphi
                 KjB(im, imp)   = weight * acc_jB
-                if (want_species) then
+                if (want_current_species) then
                     Kjphi_species(im, imp, :) = weight * acc_jphi_species
                     KjB_species(im, imp, :) = weight * acc_jB_species
+                end if
+                if (want_charge_species) then
+                    Kphi_species(im, imp, :) = weight * acc_phi_species
+                    KB_species(im, imp, :) = weight * acc_B_species
                 end if
             end do
         end do

--- a/KIM/src/electrostatic_poisson/poisson_periodic.f90
+++ b/KIM/src/electrostatic_poisson/poisson_periodic.f90
@@ -42,7 +42,7 @@ module rt_electrostatic_periodic_m
     !> The optional jpar_species(:,sp) returns the contribution from each species,
     !> with electron index sp=0. Both are left unallocated when the solve fails.
     subroutine compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                          r_out, dPhi, info, jpar, jpar_species)
+                                          r_out, dPhi, info, jpar, jpar_species, rho_B, rho_B_species)
         use KIM_kinds_m, only: dp
         use species_m, only: plasma
         use periodic_background_m, only: build_periodic_plasma
@@ -59,9 +59,12 @@ module rt_electrostatic_periodic_m
         integer,     intent(out) :: info
         complex(dp), allocatable, intent(out), optional :: jpar(:)
         complex(dp), allocatable, intent(out), optional :: jpar_species(:,:)
+        complex(dp), allocatable, intent(out), optional :: rho_B(:)
+        complex(dp), allocatable, intent(out), optional :: rho_B_species(:,:)
 
         complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:), Phi_m(:)
         complex(dp), allocatable :: Kjphi_species(:,:,:), KjB_species(:,:,:)
+        complex(dp), allocatable :: Kphi_species(:,:,:), KB_species(:,:,:)
         real(dp) :: L
         integer :: sp
 
@@ -69,9 +72,15 @@ module rt_electrostatic_periodic_m
 
         call set_global_kernel_approximations(periodic_match_global_kernel_approximations)
         call build_periodic_plasma(rm, dx_asis, dx_tr, n_rg)
-        if (present(jpar_species)) then
+        if (present(jpar_species) .and. present(rho_B_species)) then
+            call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
+                Kjphi_species, KjB_species, Kphi_species, KB_species)
+        else if (present(jpar_species)) then
             call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
                 Kjphi_species, KjB_species)
+        else if (present(rho_B_species)) then
+            call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
+                Kphi_species=Kphi_species, KB_species=KB_species)
         else
             call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB)
         end if
@@ -79,6 +88,17 @@ module rt_electrostatic_periodic_m
         if (info /= 0) return
 
         dPhi = reconstruct_delta_phi(Phi_m, L, M, r_out)
+        if (present(rho_B)) then
+            rho_B = reconstruct_delta_phi(Br_const * KB(:, M + 1), L, M, r_out)
+        end if
+
+        if (present(rho_B_species)) then
+            allocate(rho_B_species(size(r_out), 0:plasma%n_species - 1))
+            do sp = 0, plasma%n_species - 1
+                rho_B_species(:, sp) = reconstruct_delta_phi(&
+                    Br_const * KB_species(:, M + 1, sp), L, M, r_out)
+            end do
+        end if
 
         if (present(jpar_species)) then
             allocate(jpar_species(size(r_out), 0:plasma%n_species - 1))
@@ -229,6 +249,7 @@ module rt_electrostatic_periodic_m
         class(electrostatic_periodic_t), intent(inout) :: this
 
         complex(dp), allocatable :: dPhi(:), jpar(:), jpar_species(:,:)
+        complex(dp), allocatable :: rho_B(:), rho_B_species(:,:), rho_B_i(:)
         complex(dp) :: Br_const
         real(dp), allocatable :: r_win(:)
         real(dp) :: rm, rhoL_rm, dx_asis, dx_tr, L, k_max
@@ -294,7 +315,8 @@ module rt_electrostatic_periodic_m
         ! periodic core. It does NOT error stop on a singular solve; do it here.
         Br_const = cmplx(Br_boundary_re, Br_boundary_im, dp)
         call compute_periodic_delta_phi(rm, dx_asis, dx_tr, M, n_rg, Br_const, &
-                                        r_win, dPhi, info, jpar, jpar_species)
+                                        r_win, dPhi, info, jpar, jpar_species, &
+                                        rho_B, rho_B_species)
         if (info /= 0) then
             print *, "Error (electrostatic_periodic): solve_periodic failed, info = ", info
             error stop "electrostatic_periodic: periodic solve failed"
@@ -321,6 +343,11 @@ module rt_electrostatic_periodic_m
         if (plasma%n_species > 1) then
             EBdat%jpar_i = sum(jpar_species(:, 1:plasma%n_species - 1), dim=2)
         end if
+        allocate(rho_B_i(size(rho_B)))
+        rho_B_i = (0.0_dp, 0.0_dp)
+        if (plasma%n_species > 1) then
+            rho_B_i = sum(rho_B_species(:, 1:plasma%n_species - 1), dim=2)
+        end if
 
         if (hdf5_output) then
             call write_complex_profile_abs(EBdat%r_grid, EBdat%Phi, rg_grid%npts_b, &
@@ -339,11 +366,27 @@ module rt_electrostatic_periodic_m
                 "/fields/jpar_i", &
                 'Summed ion parallel current density, forced-periodicity solution', &
                 'statA/cm^2')
+            call write_complex_profile_abs(EBdat%r_grid, rho_B, rg_grid%npts_b, &
+                "/fields/rho_B", &
+                'Charge density driven directly by imposed radial magnetic field', &
+                'statC/cm^3')
+            call write_complex_profile_abs(EBdat%r_grid, rho_B_species(:, 0), rg_grid%npts_b, &
+                "/fields/rho_B_e", &
+                'Electron charge density driven directly by imposed radial magnetic field', &
+                'statC/cm^3')
+            call write_complex_profile_abs(EBdat%r_grid, rho_B_i, rg_grid%npts_b, &
+                "/fields/rho_B_i", &
+                'Summed ion charge density driven directly by imposed radial magnetic field', &
+                'statC/cm^3')
             do sp = 1, plasma%n_species - 1
                 call write_complex_profile_abs(EBdat%r_grid, jpar_species(:, sp), &
                     rg_grid%npts_b, "/fields/jpar_i"//trim(itoa(sp)), &
                     'Ion-species parallel current density, forced-periodicity solution', &
                     'statA/cm^2')
+                call write_complex_profile_abs(EBdat%r_grid, rho_B_species(:, sp), &
+                    rg_grid%npts_b, "/fields/rho_B_i"//trim(itoa(sp)), &
+                    'Ion-species charge density driven directly by imposed radial magnetic field', &
+                    'statC/cm^3')
             end do
         end if
 

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -143,6 +143,10 @@ contains
         call print_config_line('Plasma Type', trim(plasma_type), width)
         call print_config_line('Collision Model', trim(collision_model), width)
         call print_config_line('Ion Collision Model', trim(ion_collision_model), width)
+        call print_config_line('Electron I-function Model', &
+            trim(ifunc_model_name(resolved_electron_ifunc_conservation_model)), width)
+        call print_config_line('Ion I-function Model', &
+            trim(ifunc_model_name(resolved_ion_ifunc_conservation_model)), width)
         write(value_str, '(ES12.4)') ion_fp_collision_scale
         call print_config_line('Ion FP nu scale', trim(adjustl(value_str)), width)
         if (trim(ion_collision_model) == 'collisionless') then

--- a/KIM/src/general/config_display.f90
+++ b/KIM/src/general/config_display.f90
@@ -147,6 +147,8 @@ contains
             trim(ifunc_model_name(resolved_electron_ifunc_conservation_model)), width)
         call print_config_line('Ion I-function Model', &
             trim(ifunc_model_name(resolved_ion_ifunc_conservation_model)), width)
+        call print_config_line('Ion Temperature-gradient Model', &
+            trim(ion_temperature_gradient_model), width)
         write(value_str, '(ES12.4)') ion_fp_collision_scale
         call print_config_line('Ion FP nu scale', trim(adjustl(value_str)), width)
         if (trim(ion_collision_model) == 'collisionless') then

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -20,7 +20,8 @@ subroutine kim_read_config
                         ion_collision_model, collisionless_kpar_epsilon, ion_fp_collision_scale, &
                         turn_off_ions, turn_off_electrons, plasma_type, rescale_density, &
                         number_density_rescale, ion_flr_scale_factor, &
-                        collision_frequency_scale, boole_energy_conservation
+                        collision_frequency_scale, boole_energy_conservation, &
+                        electron_ifunc_conservation_model, ion_ifunc_conservation_model
 
     namelist /WKB_DISPERSION/ WKB_dispersion_mode, WKB_dispersion_solver, &
                         WKB_solve_for_kr_squared, &
@@ -76,6 +77,10 @@ subroutine kim_read_config
         write(*,*) 'Namelist path provided: ', nml_config_path
     end if
 
+    electron_ifunc_conservation_model = IFUNC_MODEL_INHERIT
+    ion_ifunc_conservation_model = IFUNC_MODEL_INHERIT
+    boole_energy_conservation = .true.
+
     open(unit = 77, file = trim(nml_config_path))
     read(unit = 77, nml = KIM_CONFIG)
     read(unit = 77, nml = WKB_DISPERSION)
@@ -104,8 +109,22 @@ subroutine kim_read_config
 
     close(unit = 77)
 
-    ! Propagate KIM_CONFIG flag to the QL-Balance getIfunc_config module
-    ! so the shared I-function code picks up the energy-conservation switch.
+    if (.not. ifunc_model_is_valid(electron_ifunc_conservation_model)) then
+        write(*,*) 'Invalid electron_ifunc_conservation_model: ', &
+            electron_ifunc_conservation_model
+        error stop 'I-function conservation models must be -1, 0, 1, 2, or 3'
+    end if
+    if (.not. ifunc_model_is_valid(ion_ifunc_conservation_model)) then
+        write(*,*) 'Invalid ion_ifunc_conservation_model: ', ion_ifunc_conservation_model
+        error stop 'I-function conservation models must be -1, 0, 1, 2, or 3'
+    end if
+
+    resolved_electron_ifunc_conservation_model = resolve_ifunc_model( &
+        electron_ifunc_conservation_model, boole_energy_conservation)
+    resolved_ion_ifunc_conservation_model = resolve_ifunc_model( &
+        ion_ifunc_conservation_model, boole_energy_conservation)
+
+    ! Preserve the legacy wrapper for standalone QL-Balance callers.
     getIfunc_boole_energy_conservation = boole_energy_conservation
 
     call set_log_level(log_level)

--- a/KIM/src/general/read_config.f90
+++ b/KIM/src/general/read_config.f90
@@ -21,7 +21,8 @@ subroutine kim_read_config
                         turn_off_ions, turn_off_electrons, plasma_type, rescale_density, &
                         number_density_rescale, ion_flr_scale_factor, &
                         collision_frequency_scale, boole_energy_conservation, &
-                        electron_ifunc_conservation_model, ion_ifunc_conservation_model
+                        electron_ifunc_conservation_model, ion_ifunc_conservation_model, &
+                        ion_temperature_gradient_model
 
     namelist /WKB_DISPERSION/ WKB_dispersion_mode, WKB_dispersion_solver, &
                         WKB_solve_for_kr_squared, &
@@ -79,6 +80,7 @@ subroutine kim_read_config
 
     electron_ifunc_conservation_model = IFUNC_MODEL_INHERIT
     ion_ifunc_conservation_model = IFUNC_MODEL_INHERIT
+    ion_temperature_gradient_model = 'full'
     boole_energy_conservation = .true.
 
     open(unit = 77, file = trim(nml_config_path))
@@ -117,6 +119,12 @@ subroutine kim_read_config
     if (.not. ifunc_model_is_valid(ion_ifunc_conservation_model)) then
         write(*,*) 'Invalid ion_ifunc_conservation_model: ', ion_ifunc_conservation_model
         error stop 'I-function conservation models must be -1, 0, 1, 2, or 3'
+    end if
+    if (.not. ion_temperature_gradient_model_is_valid( &
+            ion_temperature_gradient_model)) then
+        write(*,*) 'Invalid ion_temperature_gradient_model: ', &
+            trim(ion_temperature_gradient_model)
+        error stop 'ion_temperature_gradient_model must be full, zero_A2, or zero_Tprime'
     end if
 
     resolved_electron_ifunc_conservation_model = resolve_ifunc_model( &

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -28,6 +28,10 @@ module config_m
     integer :: ion_ifunc_conservation_model = IFUNC_MODEL_INHERIT
     integer :: resolved_electron_ifunc_conservation_model = IFUNC_MODEL_ENERGY
     integer :: resolved_ion_ifunc_conservation_model = IFUNC_MODEL_ENERGY
+    ! Diagnostic control for the ion thermodynamic-force terms. This changes
+    ! only A1i/A2i; the physical Ti profile and all quantities derived from it
+    ! remain unchanged.
+    character(24) :: ion_temperature_gradient_model = 'full'
     ! Deprecated compatibility setting. It is consulted only when a species'
     ! integer conservation model is left at IFUNC_MODEL_INHERIT.
     logical :: boole_energy_conservation = .true.
@@ -118,6 +122,44 @@ contains
             .and. model <= IFUNC_MODEL_ENERGY_MOMENTUM
 
     end function ifunc_model_is_valid
+
+    pure logical function ion_temperature_gradient_model_is_valid(model)
+
+        character(*), intent(in) :: model
+
+        select case (trim(model))
+        case ('full', 'zero_A2', 'zero_Tprime')
+            ion_temperature_gradient_model_is_valid = .true.
+        case default
+            ion_temperature_gradient_model_is_valid = .false.
+        end select
+
+    end function ion_temperature_gradient_model_is_valid
+
+    pure subroutine temperature_gradient_force_terms(species_index, model, &
+            normalized_gradient, a1_temperature, a2)
+
+        integer, intent(in) :: species_index
+        character(*), intent(in) :: model
+        real(dp), intent(in) :: normalized_gradient
+        real(dp), intent(out) :: a1_temperature, a2
+
+        a1_temperature = -1.5_dp * normalized_gradient
+        a2 = normalized_gradient
+
+        if (species_index > 0) then
+            select case (trim(model))
+            case ('zero_A2')
+                a2 = 0.0_dp
+            case ('zero_Tprime')
+                a1_temperature = 0.0_dp
+                a2 = 0.0_dp
+            case default
+                continue
+            end select
+        end if
+
+    end subroutine temperature_gradient_force_terms
 
     pure integer function resolve_ifunc_model(model, legacy_energy_conservation)
 

--- a/KIM/src/setup/config_mod.f90
+++ b/KIM/src/setup/config_mod.f90
@@ -16,10 +16,20 @@ module config_m
     logical :: turn_off_ions ! if true, only the first species (electrons) is considered in calculations
     logical :: turn_off_electrons
     character(100) :: plasma_type ! type of plasma ('H' for hydrogen, 'D' for deuterium)
-    ! Energy-conservation correction in the I-functions (getIfunc). When .true.
-    ! (default), the symmetric (Imn(m,0)-Imn(m,2))*(Imn(n,0)-Imn(n,2))/denom term
-    ! is added so the collision operator conserves energy. When .false., the bare
-    ! Imn is used — apples-to-apples with the GORILLA OU operator on v_par.
+    integer, parameter :: IFUNC_MODEL_INHERIT = -1
+    integer, parameter :: IFUNC_MODEL_NUMBER = 0
+    integer, parameter :: IFUNC_MODEL_ENERGY = 1
+    integer, parameter :: IFUNC_MODEL_MOMENTUM = 2
+    integer, parameter :: IFUNC_MODEL_ENERGY_MOMENTUM = 3
+    ! KiLCA-compatible per-species conservation models: 0=N, 1=N+E,
+    ! 2=N+P_parallel, 3=N+E+P_parallel. The -1 default inherits the legacy
+    ! boole_energy_conservation setting.
+    integer :: electron_ifunc_conservation_model = IFUNC_MODEL_INHERIT
+    integer :: ion_ifunc_conservation_model = IFUNC_MODEL_INHERIT
+    integer :: resolved_electron_ifunc_conservation_model = IFUNC_MODEL_ENERGY
+    integer :: resolved_ion_ifunc_conservation_model = IFUNC_MODEL_ENERGY
+    ! Deprecated compatibility setting. It is consulted only when a species'
+    ! integer conservation model is left at IFUNC_MODEL_INHERIT.
     logical :: boole_energy_conservation = .true.
 
     ! WKB_DISPERSION namelist variables
@@ -98,4 +108,63 @@ module config_m
     character(256) :: Er_file = 'Er.dat'
     character(256) :: q_file = 'q.dat'
 
-end module
+contains
+
+    pure logical function ifunc_model_is_valid(model)
+
+        integer, intent(in) :: model
+
+        ifunc_model_is_valid = model >= IFUNC_MODEL_INHERIT &
+            .and. model <= IFUNC_MODEL_ENERGY_MOMENTUM
+
+    end function ifunc_model_is_valid
+
+    pure integer function resolve_ifunc_model(model, legacy_energy_conservation)
+
+        integer, intent(in) :: model
+        logical, intent(in) :: legacy_energy_conservation
+
+        if (model == IFUNC_MODEL_INHERIT) then
+            resolve_ifunc_model = merge(IFUNC_MODEL_ENERGY, IFUNC_MODEL_NUMBER, &
+                legacy_energy_conservation)
+        else
+            resolve_ifunc_model = model
+        end if
+
+    end function resolve_ifunc_model
+
+    pure function ifunc_model_name(model) result(name)
+
+        integer, intent(in) :: model
+        character(len=16) :: name
+
+        select case (model)
+        case (IFUNC_MODEL_NUMBER)
+            name = '0 (N)'
+        case (IFUNC_MODEL_ENERGY)
+            name = '1 (N+E)'
+        case (IFUNC_MODEL_MOMENTUM)
+            name = '2 (N+P)'
+        case (IFUNC_MODEL_ENERGY_MOMENTUM)
+            name = '3 (N+E+P)'
+        case (IFUNC_MODEL_INHERIT)
+            name = '-1 (inherit)'
+        case default
+            name = 'invalid'
+        end select
+
+    end function ifunc_model_name
+
+    integer function ifunc_model_for_species(species_index)
+
+        integer, intent(in) :: species_index
+
+        if (species_index == 0) then
+            ifunc_model_for_species = resolved_electron_ifunc_conservation_model
+        else
+            ifunc_model_for_species = resolved_ion_ifunc_conservation_model
+        end if
+
+    end function ifunc_model_for_species
+
+end module config_m

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -143,6 +143,12 @@ module IO_collection_m
             'Positive imaginary part of the causal collisionless k_parallel pole.', '1/cm')
         call h5_add(h5grpid, 'ion_fp_collision_scale', ion_fp_collision_scale, &
             'Multiplier applied only to computed Fokker-Planck ion collision frequencies.', '1')
+        call h5_add(h5grpid, 'electron_ifunc_conservation_model', &
+            resolved_electron_ifunc_conservation_model, &
+            'Resolved electron I-function model: 0=N, 1=N+E, 2=N+P, 3=N+E+P.', '1')
+        call h5_add(h5grpid, 'ion_ifunc_conservation_model', &
+            resolved_ion_ifunc_conservation_model, &
+            'Resolved ion I-function model: 0=N, 1=N+E, 2=N+P, 3=N+E+P.', '1')
         call h5_add(h5grpid, 'read_species_from_namelist', read_species_from_namelist, &
             'Logical switch to read species from namelist or use default deuterium plasma.', 'true/false')
         call h5_add(h5grpid, 'turn_off_ions', turn_off_ions, &

--- a/KIM/src/util/IO_collection.f90
+++ b/KIM/src/util/IO_collection.f90
@@ -149,6 +149,9 @@ module IO_collection_m
         call h5_add(h5grpid, 'ion_ifunc_conservation_model', &
             resolved_ion_ifunc_conservation_model, &
             'Resolved ion I-function model: 0=N, 1=N+E, 2=N+P, 3=N+E+P.', '1')
+        call h5_add(h5grpid, 'ion_temperature_gradient_model', &
+            trim(ion_temperature_gradient_model), &
+            'Ion force diagnostic: full, zero_A2, or zero_Tprime.', 'str')
         call h5_add(h5grpid, 'read_species_from_namelist', read_species_from_namelist, &
             'Logical switch to read species from namelist or use default deuterium plasma.', 'true/false')
         call h5_add(h5grpid, 'turn_off_ions', turn_off_ions, &

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -108,6 +108,26 @@ target_link_libraries(test_susceptibility_collisionless_limit
 add_test(NAME test_susceptibility_collisionless_limit
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_susceptibility_collisionless_limit.x)
 
+add_executable(test_ifunc_conservation_models
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_ifunc_conservation_models.f90)
+set_target_properties(test_ifunc_conservation_models PROPERTIES
+                      OUTPUT_NAME test_ifunc_conservation_models.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_ifunc_conservation_models
+                      KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_ifunc_conservation_models
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_ifunc_conservation_models.x)
+
+add_executable(test_ifunc_model_config
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_ifunc_model_config.f90)
+set_target_properties(test_ifunc_model_config PROPERTIES
+                      OUTPUT_NAME test_ifunc_model_config.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_ifunc_model_config
+                      KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_ifunc_model_config
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_ifunc_model_config.x)
+
 add_executable(test_flr2_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_fourier_kernel.f90)
 set_target_properties(test_flr2_fourier_kernel PROPERTIES
                         OUTPUT_NAME test_flr2_fourier_kernel.x

--- a/KIM/tests/CMakeLists.txt
+++ b/KIM/tests/CMakeLists.txt
@@ -128,6 +128,16 @@ target_link_libraries(test_ifunc_model_config
 add_test(NAME test_ifunc_model_config
          COMMAND ${CMAKE_BINARY_DIR}/tests/test_ifunc_model_config.x)
 
+add_executable(test_ion_temperature_gradient_model
+               ${CMAKE_SOURCE_DIR}/KIM/tests/test_ion_temperature_gradient_model.f90)
+set_target_properties(test_ion_temperature_gradient_model PROPERTIES
+                      OUTPUT_NAME test_ion_temperature_gradient_model.x
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/")
+target_link_libraries(test_ion_temperature_gradient_model
+                      KIM_lib kilca_lib lapack cerf fortnum_amos_compat)
+add_test(NAME test_ion_temperature_gradient_model
+         COMMAND ${CMAKE_BINARY_DIR}/tests/test_ion_temperature_gradient_model.x)
+
 add_executable(test_flr2_fourier_kernel ${CMAKE_SOURCE_DIR}/KIM/tests/test_flr2_fourier_kernel.f90)
 set_target_properties(test_flr2_fourier_kernel PROPERTIES
                         OUTPUT_NAME test_flr2_fourier_kernel.x

--- a/KIM/tests/test_ifunc_conservation_models.f90
+++ b/KIM/tests/test_ifunc_conservation_models.f90
@@ -1,0 +1,125 @@
+program test_ifunc_conservation_models
+
+    use getIfunc_config_m, only: boole_energy_conservation
+    use KIM_kinds_m, only: dp
+
+    implicit none
+
+    interface
+        subroutine getIfunc(x1, x2, symbI)
+            import dp
+            real(dp), intent(in) :: x1, x2
+            complex(dp), intent(out) :: symbI(0:3, 0:3)
+        end subroutine getIfunc
+
+        subroutine getIfunc_model(x1, x2, conservation_model, symbI)
+            import dp
+            real(dp), intent(in) :: x1, x2
+            integer, intent(in) :: conservation_model
+            complex(dp), intent(out) :: symbI(0:3, 0:3)
+        end subroutine getIfunc_model
+
+        subroutine W2_arr(x1, x2, Imn)
+            import dp
+            real(dp), intent(in) :: x1, x2
+            complex(dp), intent(out) :: Imn(0:3, 0:3)
+        end subroutine W2_arr
+    end interface
+
+    real(dp), parameter :: tolerance = 5.0e-13_dp
+    real(dp), parameter :: x1 = 0.73_dp
+    real(dp), parameter :: x2 = -1.21_dp
+    complex(dp) :: actual(0:3, 0:3), expected(0:3, 0:3)
+    complex(dp) :: imn(0:3, 0:3), legacy(0:3, 0:3)
+    integer :: conservation_model
+
+    call W2_arr(x1, x2, imn)
+
+    do conservation_model = 0, 3
+        call expected_model(imn, conservation_model, expected)
+        call getIfunc_model(x1, x2, conservation_model, actual)
+        call assert_matrix_close(actual, expected, tolerance, conservation_model)
+    end do
+
+    boole_energy_conservation = .false.
+    call getIfunc(x1, x2, legacy)
+    call getIfunc_model(x1, x2, 0, actual)
+    call assert_matrix_close(actual, legacy, tolerance, 0)
+
+    boole_energy_conservation = .true.
+    call getIfunc(x1, x2, legacy)
+    call getIfunc_model(x1, x2, 1, actual)
+    call assert_matrix_close(actual, legacy, tolerance, 1)
+
+    print *, 'PASS: I-function conservation models match the KiLCA FPGEN formulas'
+
+contains
+
+    subroutine expected_model(bare, model, result)
+
+        complex(dp), intent(in) :: bare(0:3, 0:3)
+        integer, intent(in) :: model
+        complex(dp), intent(out) :: result(0:3, 0:3)
+
+        complex(dp) :: energy_denom, momentum_denom, coupling, determinant
+        integer :: m, n
+
+        energy_denom = 1.0_dp - bare(0, 0) + 2.0_dp * bare(2, 0) - bare(2, 2)
+        momentum_denom = 1.0_dp - bare(1, 1)
+        coupling = bare(1, 2) - bare(1, 0)
+        determinant = energy_denom * momentum_denom - coupling**2
+
+        select case (model)
+        case (0)
+            result = bare
+        case (1)
+            do m = 0, 3
+                do n = 0, 3
+                    result(m, n) = bare(m, n) &
+                        + (bare(m, 0) - bare(m, 2)) &
+                        * (bare(n, 0) - bare(n, 2)) / energy_denom
+                end do
+            end do
+        case (2)
+            do m = 0, 3
+                do n = 0, 3
+                    result(m, n) = bare(m, n) &
+                        + bare(m, 1) * bare(n, 1) / momentum_denom
+                end do
+            end do
+        case (3)
+            do m = 0, 3
+                do n = 0, 3
+                    result(m, n) = bare(m, n) + ( &
+                        coupling * bare(m, 1) * (bare(n, 2) - bare(n, 0)) &
+                        + energy_denom * bare(m, 1) * bare(n, 1) &
+                        + momentum_denom * (bare(m, 2) - bare(m, 0)) &
+                        * (bare(n, 2) - bare(n, 0)) &
+                        + coupling * (bare(m, 2) - bare(m, 0)) * bare(n, 1) &
+                        ) / determinant
+                end do
+            end do
+        case default
+            error stop 'invalid model in expected_model'
+        end select
+
+    end subroutine expected_model
+
+    subroutine assert_matrix_close(actual, expected, tol, model)
+
+        complex(dp), intent(in) :: actual(0:3, 0:3), expected(0:3, 0:3)
+        real(dp), intent(in) :: tol
+        integer, intent(in) :: model
+
+        real(dp) :: error
+
+        error = maxval(abs(actual - expected) &
+            / max(abs(expected), tiny(1.0_dp)))
+        if (error > tol) then
+            print *, 'FAIL: conservation model ', model, ' relative error = ', error
+            error stop
+        end if
+
+    end subroutine assert_matrix_close
+
+end program test_ifunc_conservation_models

--- a/KIM/tests/test_ifunc_model_config.f90
+++ b/KIM/tests/test_ifunc_model_config.f90
@@ -1,0 +1,56 @@
+program test_ifunc_model_config
+
+    use config_m, only: IFUNC_MODEL_INHERIT, ifunc_model_for_species, &
+                        ifunc_model_is_valid, resolve_ifunc_model, &
+                        resolved_electron_ifunc_conservation_model, &
+                        resolved_ion_ifunc_conservation_model
+
+    implicit none
+
+    integer :: model
+
+    call assert_equal(resolve_ifunc_model(IFUNC_MODEL_INHERIT, .false.), 0, &
+        'legacy energy-off fallback')
+    call assert_equal(resolve_ifunc_model(IFUNC_MODEL_INHERIT, .true.), 1, &
+        'legacy energy-on fallback')
+
+    do model = 0, 3
+        call assert_equal(resolve_ifunc_model(model, .false.), model, &
+            'explicit model with legacy energy off')
+        call assert_equal(resolve_ifunc_model(model, .true.), model, &
+            'explicit model with legacy energy on')
+        if (.not. ifunc_model_is_valid(model)) then
+            print *, 'FAIL: rejected valid model ', model
+            error stop
+        end if
+    end do
+
+    if (.not. ifunc_model_is_valid(IFUNC_MODEL_INHERIT)) then
+        error stop 'FAIL: rejected inherit sentinel'
+    end if
+    if (ifunc_model_is_valid(-2)) error stop 'FAIL: accepted model -2'
+    if (ifunc_model_is_valid(4)) error stop 'FAIL: accepted model 4'
+
+    resolved_electron_ifunc_conservation_model = 1
+    resolved_ion_ifunc_conservation_model = 3
+    call assert_equal(ifunc_model_for_species(0), 1, 'electron species routing')
+    call assert_equal(ifunc_model_for_species(1), 3, 'first ion species routing')
+    call assert_equal(ifunc_model_for_species(2), 3, 'second ion species routing')
+
+    print *, 'PASS: per-species I-function model configuration resolves correctly'
+
+contains
+
+    subroutine assert_equal(actual, expected, label)
+
+        integer, intent(in) :: actual, expected
+        character(*), intent(in) :: label
+
+        if (actual /= expected) then
+            print *, 'FAIL: ', trim(label), ': expected ', expected, ', got ', actual
+            error stop
+        end if
+
+    end subroutine assert_equal
+
+end program test_ifunc_model_config

--- a/KIM/tests/test_ion_temperature_gradient_model.f90
+++ b/KIM/tests/test_ion_temperature_gradient_model.f90
@@ -1,0 +1,65 @@
+program test_ion_temperature_gradient_model
+
+    use KIM_kinds_m, only: dp
+    use config_m, only: ion_temperature_gradient_model_is_valid, &
+                        temperature_gradient_force_terms
+
+    implicit none
+
+    real(dp), parameter :: gradient = 0.4_dp
+    real(dp) :: a1_temperature, a2
+
+    call assert_valid('full', .true.)
+    call assert_valid('zero_A2', .true.)
+    call assert_valid('zero_Tprime', .true.)
+    call assert_valid('unknown', .false.)
+
+    call temperature_gradient_force_terms(0, 'zero_Tprime', gradient, &
+        a1_temperature, a2)
+    call assert_close(a1_temperature, -0.6_dp, 'electron A1 is unchanged')
+    call assert_close(a2, 0.4_dp, 'electron A2 is unchanged')
+
+    call temperature_gradient_force_terms(1, 'full', gradient, &
+        a1_temperature, a2)
+    call assert_close(a1_temperature, -0.6_dp, 'full ion A1')
+    call assert_close(a2, 0.4_dp, 'full ion A2')
+
+    call temperature_gradient_force_terms(1, 'zero_A2', gradient, &
+        a1_temperature, a2)
+    call assert_close(a1_temperature, -0.6_dp, 'zero_A2 ion A1')
+    call assert_close(a2, 0.0_dp, 'zero_A2 ion A2')
+
+    call temperature_gradient_force_terms(1, 'zero_Tprime', gradient, &
+        a1_temperature, a2)
+    call assert_close(a1_temperature, 0.0_dp, 'zero_Tprime ion A1')
+    call assert_close(a2, 0.0_dp, 'zero_Tprime ion A2')
+
+    print *, 'PASS: ion temperature-gradient force models'
+
+contains
+
+    subroutine assert_valid(model, expected)
+
+        character(*), intent(in) :: model
+        logical, intent(in) :: expected
+
+        if (ion_temperature_gradient_model_is_valid(model) .neqv. expected) then
+            error stop 'ion temperature-gradient model validation mismatch'
+        end if
+
+    end subroutine assert_valid
+
+    subroutine assert_close(actual, expected, label)
+
+        real(dp), intent(in) :: actual, expected
+        character(*), intent(in) :: label
+
+        if (abs(actual - expected) > 10.0_dp * epsilon(1.0_dp) &
+                * max(1.0_dp, abs(expected))) then
+            print *, 'FAIL: ', trim(label), ': expected ', expected, ', got ', actual
+            error stop
+        end if
+
+    end subroutine assert_close
+
+end program test_ion_temperature_gradient_model

--- a/KIM/tests/test_kim_solver_periodic.f90
+++ b/KIM/tests/test_kim_solver_periodic.f90
@@ -24,6 +24,7 @@ program test_kim_solver_periodic
 
     implicit none
 
+    call test_legacy_conservation_default_reset()
     call test_run_type_end_to_end()
     call test_collisionless_ions_end_to_end()
     call test_multi_ion_order_independence()
@@ -36,8 +37,36 @@ program test_kim_solver_periodic
 
 contains
 
+    subroutine test_legacy_conservation_default_reset()
+        use config_m, only: profiles_in_memory, nml_config_path, &
+            resolved_electron_ifunc_conservation_model, &
+            resolved_ion_ifunc_conservation_model
+
+        call write_test_namelist('./KIM_config_legacy_no_energy_test.nml', &
+            legacy_energy_conservation=.false.)
+        nml_config_path = './KIM_config_legacy_no_energy_test.nml'
+        profiles_in_memory = .true.
+        call kim_init()
+        if (resolved_electron_ifunc_conservation_model /= 0 .or. &
+                resolved_ion_ifunc_conservation_model /= 0) then
+            error stop 'legacy energy-off setting did not resolve to model 0'
+        end if
+
+        call write_test_namelist('./KIM_config_default_energy_test.nml')
+        nml_config_path = './KIM_config_default_energy_test.nml'
+        call kim_init()
+        if (resolved_electron_ifunc_conservation_model /= 1 .or. &
+                resolved_ion_ifunc_conservation_model /= 1) then
+            error stop 'omitted conservation settings did not reset to model 1'
+        end if
+
+        print *, 'PASS: omitted conservation settings reset to the 1/1 default'
+    end subroutine test_legacy_conservation_default_reset
+
     subroutine test_species_resolved_currents(collisionless_ions)
-        use config_m, only: profiles_in_memory, nml_config_path
+        use config_m, only: profiles_in_memory, nml_config_path, &
+            resolved_electron_ifunc_conservation_model, &
+            resolved_ion_ifunc_conservation_model
         use fields_m, only: EBdat, EBdat_t
         use IO_collection_m, only: deinitialize_hdf5_output, h5id
         use KAMEL_hdf5_tools, only: h5_get, h5_obj_exists
@@ -55,18 +84,30 @@ contains
         complex(dp), allocatable :: jpar_i1(:), jpar_i2(:)
         class(kim_t), allocatable :: kim_instance
         real(dp) :: scale
-        integer :: N
+        integer :: N, h5_electron_ifunc_model, h5_ion_ifunc_model
         logical :: ex
 
         call make_test_profiles(npts, r_prof, n_prof, Te_prof, Ti_prof, &
                                 q_prof, Er_prof)
-        call write_test_namelist('./KIM_config_periodic_species_jpar_test.nml', &
-            ion_masses=ion_masses, collisionless_ions=collisionless_ions, &
-            hdf5_enabled=.true.)
+        if (collisionless_ions) then
+            call write_test_namelist('./KIM_config_periodic_species_jpar_test.nml', &
+                ion_masses=ion_masses, collisionless_ions=.true., &
+                hdf5_enabled=.true.)
+        else
+            call write_test_namelist('./KIM_config_periodic_species_jpar_test.nml', &
+                ion_masses=ion_masses, collisionless_ions=.false., &
+                hdf5_enabled=.true., electron_ifunc_model=1, ion_ifunc_model=3)
+        end if
         nml_config_path = './KIM_config_periodic_species_jpar_test.nml'
 
         profiles_in_memory = .true.
         call kim_init()
+        if (.not. collisionless_ions) then
+            if (resolved_electron_ifunc_conservation_model /= 1 .or. &
+                    resolved_ion_ifunc_conservation_model /= 3) then
+                error stop 'per-species I-function models were not resolved from KIM_CONFIG'
+            end if
+        end if
         call set_profiles_from_arrays(r_prof, n_prof, Te_prof, Ti_prof, &
                                       q_prof, Er_prof, npts)
         EBdat = EBdat_t()
@@ -93,6 +134,24 @@ contains
         if (.not. ex) error stop 'periodic first-ion jpar dataset missing'
         call h5_obj_exists(h5id, 'fields/jpar_i2', ex)
         if (.not. ex) error stop 'periodic second-ion jpar dataset missing'
+        call h5_obj_exists(h5id, 'config/electron_ifunc_conservation_model', ex)
+        if (.not. ex) error stop 'electron I-function model metadata missing'
+        call h5_obj_exists(h5id, 'config/ion_ifunc_conservation_model', ex)
+        if (.not. ex) error stop 'ion I-function model metadata missing'
+        call h5_get(h5id, 'config/electron_ifunc_conservation_model', &
+            h5_electron_ifunc_model)
+        call h5_get(h5id, 'config/ion_ifunc_conservation_model', &
+            h5_ion_ifunc_model)
+        if (h5_electron_ifunc_model /= 1) then
+            error stop 'incorrect electron I-function model metadata'
+        end if
+        if (collisionless_ions) then
+            if (h5_ion_ifunc_model /= 1) then
+                error stop 'incorrect collisionless-run ion I-function model metadata'
+            end if
+        else if (h5_ion_ifunc_model /= 3) then
+            error stop 'incorrect FP ion I-function model metadata'
+        end if
 
         N = size(EBdat%jpar)
         allocate(jpar(N), jpar_e(N), jpar_i(N), jpar_i1(N), jpar_i2(N))
@@ -567,15 +626,18 @@ contains
     end subroutine make_test_profiles
 
     subroutine write_test_namelist(path, ion_masses, match_global_approximations, &
-            collisionless_ions, ions_disabled, hdf5_enabled)
+            collisionless_ions, ions_disabled, hdf5_enabled, &
+            electron_ifunc_model, ion_ifunc_model, legacy_energy_conservation)
         ! Minimal electrostatic-periodic FokkerPlanck configuration; m_mode = -6,
         ! n_mode = 2 makes q resonant at q = 3, type_br_field = 12 (constant Br).
         ! Deliberately OMITS the &KIM_PERIODIC group to prove the periodic_*
         ! config defaults apply when the optional namelist is absent.
         character(len=*), intent(in) :: path
         integer, intent(in), optional :: ion_masses(:)
+        integer, intent(in), optional :: electron_ifunc_model, ion_ifunc_model
         logical, intent(in), optional :: match_global_approximations
         logical, intent(in), optional :: collisionless_ions, ions_disabled, hdf5_enabled
+        logical, intent(in), optional :: legacy_energy_conservation
         integer :: iunit, i, nions
         logical :: custom_species, use_collisionless, disable_ions, write_hdf5
 
@@ -608,6 +670,18 @@ contains
         write(iunit, '(A)') ' rescale_density = .false.'
         write(iunit, '(A)') ' number_density_rescale = 1.0'
         write(iunit, '(A)') ' ion_flr_scale_factor = 1.0'
+        if (present(electron_ifunc_model)) then
+            write(iunit, '(A,I0)') ' electron_ifunc_conservation_model = ', &
+                electron_ifunc_model
+        end if
+        if (present(ion_ifunc_model)) then
+            write(iunit, '(A,I0)') ' ion_ifunc_conservation_model = ', &
+                ion_ifunc_model
+        end if
+        if (present(legacy_energy_conservation)) then
+            write(iunit, '(A,L1)') ' boole_energy_conservation = ', &
+                legacy_energy_conservation
+        end if
         write(iunit, '(A)') '/'
         if (custom_species) then
             write(iunit, '(A)') '&KIM_species'

--- a/KIM/tests/test_periodic_assembly.f90
+++ b/KIM/tests/test_periodic_assembly.f90
@@ -58,6 +58,7 @@ contains
 
         complex(dp), allocatable :: Kphi(:,:), KB(:,:), Kjphi(:,:), KjB(:,:)
         complex(dp), allocatable :: Kjphi_species(:,:,:), KjB_species(:,:,:)
+        complex(dp), allocatable :: Kphi_species(:,:,:), KB_species(:,:,:)
         real(dp) :: rm, dx_asis, dx_tr, rho_L_rm, L
         integer :: n_rg, N, dim, im, imp
 
@@ -113,7 +114,7 @@ contains
         end if
 
         call assemble_periodic_matrices(plasma, L, M, Kphi, KB, Kjphi, KjB, &
-            Kjphi_species, KjB_species)
+            Kjphi_species, KjB_species, Kphi_species, KB_species)
 
         ! (shape) all four matrices are (2M+1) x (2M+1).
         dim = 2 * M + 1
@@ -142,6 +143,22 @@ contains
             error stop 'species-current matrices do not sum to aggregate matrices'
         end if
         print *, 'PASS: species-current matrices sum to aggregate matrices'
+
+        if (lbound(Kphi_species, 3) /= 0 .or. &
+                ubound(Kphi_species, 3) /= plasma%n_species - 1 .or. &
+                any(shape(Kphi_species) /= shape(KB_species))) then
+            error stop 'species-charge matrix shape or bounds are wrong'
+        end if
+        if (maxval(abs(Kphi - sum(Kphi_species, dim=3))) > &
+                2.0e-12_dp * max(1.0_dp, maxval(abs(Kphi))) .or. &
+                maxval(abs(KB - sum(KB_species, dim=3))) > &
+                2.0e-12_dp * max(1.0_dp, maxval(abs(KB)))) then
+            error stop 'species-charge matrices do not sum to aggregate matrices'
+        end if
+        if (maxval(abs(KB_species(:, :, 1))) <= tiny(1.0_dp)) then
+            error stop 'ion rho-B matrix is unexpectedly zero'
+        end if
+        print *, 'PASS: species-charge matrices sum to aggregate matrices'
 
         ! (characterization) recompute two elements by an inline brute-force sum
         ! with the SAME quadrature formula and compare to the stored elements.

--- a/KIM/tests/test_susceptibility_collisionless_limit.f90
+++ b/KIM/tests/test_susceptibility_collisionless_limit.f90
@@ -1,6 +1,5 @@
 program test_susceptibility_collisionless_limit
 
-    use getIfunc_config_m, only: boole_energy_conservation
     use KIM_kinds_m, only: dp
     use species_m, only: evaluate_susceptibility
     use use_libcerf_m, only: w_of_z_F
@@ -13,12 +12,11 @@ program test_susceptibility_collisionless_limit
         [1.0_dp, 10.0_dp, 100.0_dp, 1000.0_dp, 10000.0_dp]
     complex(dp) :: numerical(0:3, 0:3), exact(0:3, 0:3)
     real(dp) :: x1, x2, z, large_argument_error
-    integer :: i, conservation, iz
+    integer :: i, conservation_model, iz
 
-    do conservation = 1, 2
-        boole_energy_conservation = conservation == 1
+    do conservation_model = 0, 3
         large_argument_error = 0.0_dp
-        print '(A,L1)', 'energy conservation = ', boole_energy_conservation
+        print '(A,I0)', 'conservation model = ', conservation_model
         do iz = 1, size(z_values)
             z = z_values(iz)
             print '(A,F5.1)', 'z = ', z
@@ -26,7 +24,7 @@ program test_susceptibility_collisionless_limit
             do i = 1, size(scales)
                 x1 = scales(i)
                 x2 = sqrt(2.0_dp) * z * x1
-                call evaluate_susceptibility(x1, x2, numerical)
+                call evaluate_susceptibility(x1, x2, conservation_model, numerical)
                 call collisionless_limit(x1, x2, exact)
                 print '(F7.0,5(1X,ES10.3))', scales(i), &
                     relative_error(numerical(0, 0), exact(0, 0)), &
@@ -54,7 +52,7 @@ program test_susceptibility_collisionless_limit
     x1 = -10000.0_dp
     do iz = 1, size(z_values)
         x2 = sqrt(2.0_dp) * z_values(iz) * abs(x1)
-        call evaluate_susceptibility(x1, x2, numerical)
+        call evaluate_susceptibility(x1, x2, 1, numerical)
         call collisionless_limit(x1, x2, exact)
         large_argument_error = max( &
             relative_error(numerical(0, 0), exact(0, 0)), &

--- a/QL-Balance/src/base/getIfunc.f90
+++ b/QL-Balance/src/base/getIfunc.f90
@@ -1,53 +1,81 @@
 module getIfunc_config_m
-    ! Runtime flag for the energy-conservation correction in getIfunc.
-    ! Default .true. (energy-conserving). Standalone QL-Balance, KIM,
-    ! and other consumers can override via their own namelist parsing.
+    ! Compatibility flag for legacy callers of getIfunc. New callers can use
+    ! getIfunc_model to select the conservation model explicitly.
     implicit none
     logical :: boole_energy_conservation = .true.
 end module getIfunc_config_m
 
 subroutine getIfunc(x1, x2, symbI)
     use getIfunc_config_m, only: boole_energy_conservation
+    implicit none
     integer, parameter :: mnmax = 3
+    integer :: conservation_model
+    double precision, intent(in) :: x1, x2
+    double complex, dimension(0:mnmax, 0:mnmax), intent(out) :: symbI
+
+    conservation_model = merge(1, 0, boole_energy_conservation)
+    call getIfunc_model(x1, x2, conservation_model, symbI)
+
+end subroutine getIfunc
+
+subroutine getIfunc_model(x1, x2, conservation_model, symbI)
+    ! KiLCA FPGEN conservation corrections, including the coupled
+    ! energy/momentum form of Leitner et al., Eq. (24).
+    implicit none
+    integer, parameter :: mnmax = 3
+    integer, intent(in) :: conservation_model
     integer :: m, n
     double precision, intent(in) :: x1, x2
-    double precision :: z
-    double complex :: denom
+    double complex :: energy_denom, momentum_denom, coupling, determinant
     double complex, dimension(0:mnmax, 0:mnmax), intent(out) :: symbI
     double complex, dimension(0:mnmax, 0:mnmax) :: Imn
 
-    if (.false.) then
-        ! collisionless case:
-        symbI = (0.d0, 0.d0)
-        z = x2/(sqrt(2.d0)*x1)
+    call W2_arr(x1, x2, Imn)
 
-        symbI(0, 0) = sqrt(2.d0)*exp(-z**2)/abs(x1)
-        symbI(1, 0) = symbI(0, 0)*x2/x1
-        symbI(1, 1) = symbI(1, 0)*x2/x1
-
-        symbI(2, 0) = symbI(0, 0)*(x2/x1)**2
-        symbI(2, 1) = symbI(1, 0)*(x2/x1)**2
-        symbI(3, 0) = symbI(2, 1)
-        symbI(3, 1) = symbI(1, 1)*(x2/x1)**2
-
-        symbI(2, 2) = symbI(2, 0)*(x2/x1)**2
-        symbI(3, 2) = symbI(2, 1)*(x2/x1)**2
-        symbI(3, 3) = symbI(3, 1)*(x2/x1)**2
-    else
-        ! collisional case:
-        call W2_arr(x1, x2, Imn)
-
-        if (boole_energy_conservation) then
-            ! energy conservation:
-            denom = (1.d0, 0.d0) - Imn(0, 0) + (2.d0, 0.d0)*Imn(2, 0) - Imn(2, 2)
-            do m = 0, 3
-                do n = 0, 3
-                    symbI(m, n) = Imn(m, n) + (Imn(m, 0) - Imn(m, 2))*(Imn(n, 0) - Imn(n, 2))/denom
-                end do
+    select case (conservation_model)
+    case (0)
+        ! Particle-number conservation only.
+        symbI = Imn
+    case (1)
+        ! Particle-number and energy conservation.
+        energy_denom = (1.d0, 0.d0) - Imn(0, 0) &
+            + (2.d0, 0.d0)*Imn(2, 0) - Imn(2, 2)
+        do m = 0, mnmax
+            do n = 0, mnmax
+                symbI(m, n) = Imn(m, n) &
+                    + (Imn(m, 0) - Imn(m, 2)) &
+                    * (Imn(n, 0) - Imn(n, 2))/energy_denom
             end do
-        else
-            symbI = Imn
-        end if
-    end if
+        end do
+    case (2)
+        ! Particle-number and parallel-momentum conservation.
+        momentum_denom = (1.d0, 0.d0) - Imn(1, 1)
+        do m = 0, mnmax
+            do n = 0, mnmax
+                symbI(m, n) = Imn(m, n) &
+                    + Imn(m, 1)*Imn(n, 1)/momentum_denom
+            end do
+        end do
+    case (3)
+        ! Particle-number, energy, and parallel-momentum conservation.
+        energy_denom = (1.d0, 0.d0) - Imn(0, 0) &
+            + (2.d0, 0.d0)*Imn(2, 0) - Imn(2, 2)
+        momentum_denom = (1.d0, 0.d0) - Imn(1, 1)
+        coupling = Imn(1, 2) - Imn(1, 0)
+        determinant = energy_denom*momentum_denom - coupling*coupling
+        do m = 0, mnmax
+            do n = 0, mnmax
+                symbI(m, n) = Imn(m, n) + ( &
+                    coupling*Imn(m, 1)*(Imn(n, 2) - Imn(n, 0)) &
+                    + energy_denom*Imn(m, 1)*Imn(n, 1) &
+                    + momentum_denom*(Imn(m, 2) - Imn(m, 0)) &
+                    * (Imn(n, 2) - Imn(n, 0)) &
+                    + coupling*(Imn(m, 2) - Imn(m, 0))*Imn(n, 1) &
+                    )/determinant
+            end do
+        end do
+    case default
+        error stop 'getIfunc conservation model must be between 0 and 3'
+    end select
 
-end subroutine getIfunc
+end subroutine getIfunc_model

--- a/docs/plans/2026-07-24-kim-species-conservation-models.md
+++ b/docs/plans/2026-07-24-kim-species-conservation-models.md
@@ -1,0 +1,53 @@
+# Per-Species I-Function Conservation Models Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add KiLCA-compatible per-species particle, energy, and momentum conservation selection to KIM while preserving its default energy-conserving behavior.
+
+**Architecture:** Extend the shared QL-Balance I-function routine with an explicit conservation-model entry point and retain its legacy Boolean wrapper. KIM resolves separate electron and ion model settings, passes the selected model into each susceptibility evaluation, and records the resolved settings in its configuration output.
+
+**Tech Stack:** Fortran, CMake, CTest, HDF5.
+
+---
+
+### Task 1: Verify the susceptibility formulas
+
+**Files:**
+- Create: `KIM/tests/test_ifunc_conservation_models.f90`
+- Modify: `KIM/tests/CMakeLists.txt`
+- Modify: `QL-Balance/src/base/getIfunc.f90`
+
+1. Add a test that independently evaluates the KiLCA FPGEN formulas for models 0–3.
+2. Confirm the test initially fails because the explicit model entry point is absent.
+3. Implement the explicit entry point and keep `getIfunc` as a compatibility wrapper.
+4. Verify model 1 matches the existing energy-conserving result and model 0 matches the bare result.
+
+### Task 2: Add per-species KIM configuration
+
+**Files:**
+- Modify: `KIM/src/setup/config_mod.f90`
+- Modify: `KIM/src/general/read_config.f90`
+- Modify: `KIM/src/general/config_display.f90`
+- Modify: `KIM/src/background_equilibrium/species_mod.f90`
+
+1. Add electron and ion integer settings with KiLCA-compatible values: 0=N, 1=N+E, 2=N+P, 3=N+E+P.
+2. Use `-1` internally as “inherit the legacy Boolean” so old namelists remain valid.
+3. Validate and resolve both values after reading the namelist.
+4. Pass the resolved model explicitly for each species.
+
+### Task 3: Record and exercise the settings
+
+**Files:**
+- Modify: KIM example/test namelists and user documentation as appropriate.
+- Modify: `KIM/src/util/IO_collection.f90` if resolved settings are not already captured.
+
+1. Document the new settings and the deprecated Boolean fallback.
+2. Add an integration fixture for electron model 1 and ion model 3.
+3. Confirm the default 1/1 configuration reproduces the existing behavior.
+
+### Task 4: Verify
+
+1. Build the isolated worktree.
+2. Run the formula and integration tests.
+3. Run the full CTest suite and compare failures with the recorded baseline.
+4. Inspect the final diff for unintended changes.


### PR DESCRIPTION
## Summary

- add independent electron and ion I-function conservation-model selection, including number, energy, momentum, and combined energy-plus-momentum conservation
- retain the legacy energy-conservation flag as a compatibility fallback when a species model is left unset
- output species-resolved radial-magnetic-field charge kernels and profiles for the forced-periodicity solver
- add diagnostic ion temperature-gradient force modes (`full`, `zero_A2`, and `zero_Tprime`) without modifying the physical temperature profile
- write the resolved model selections to diagnostics/HDF5 output and document the configuration

## Motivation

The Er-scan study needs different conservation laws for electrons and ions: energy conservation without electron momentum conservation, with optional ion momentum conservation. Species-resolved magnetic charge output isolates the ion and electron forcing that does not depend on the integral solution. The ion temperature-gradient modes test which thermodynamic-force channel controls the ion-fluid-resonance response.

## Validation

- KAMEL builds successfully
- new conservation-model, configuration, ion temperature-gradient, species-charge assembly, and forced-periodicity tests pass
- full CTest: 46/47 pass
- the sole failure is the acknowledged baseline `test_rhs_balance` failure (`gamma_a_e mismatch`), unrelated to this change
