### PR TITLE
test(QL-Balance): verify linearized QL heat product

### DIFF
--- a/QL-Balance/src/base/rhs_balance_m.f90
+++ b/QL-Balance/src/base/rhs_balance_m.f90
@@ -89,6 +89,7 @@ module rhs_balance_m
     public :: compute_thermodynamic_forces
     public :: compute_particle_fluxes
     public :: compute_total_heat_fluxes
+    public :: compute_linearized_product
     public :: compute_diffusive_parts
     public :: compute_convective_parts
     public :: compute_source_terms_at_point
@@ -666,12 +667,26 @@ contains
 
         ! Eq. 3: Electron temperature
         ! Complete linearization: δ(E0r·Γ_ql) = E0r·δΓ_ql + δE0r·Γ_ql_frozen
-        qlheat_e = +e_charge * (E0r * Gamma_ql_e + E0r_lin * Gamma_ql_e_froz)
+        qlheat_e = +e_charge * compute_linearized_product(E0r, Gamma_ql_e, E0r_lin, &
+                                                          Gamma_ql_e_froz)
 
         ! Eq. 4: Ion temperature
         ! Complete linearization: δ(E0r·Γ_ql) = E0r·δΓ_ql + δE0r·Γ_ql_frozen
-        qlheat_i = -Z * e_charge * (E0r * Gamma_ql_i + E0r_lin * Gamma_ql_i_froz)
+        qlheat_i = -Z * e_charge * compute_linearized_product(E0r, Gamma_ql_i, E0r_lin, &
+                                                              Gamma_ql_i_froz)
     end subroutine compute_rmp_induced_sources
+
+    pure function compute_linearized_product(base, response_delta, base_delta, response_frozen) &
+        result(product_delta)
+        ! First variation of a product:
+        !   delta(base * response) = base * delta(response) + delta(base) * response.
+        implicit none
+
+        real(dp), intent(in) :: base, response_delta, base_delta, response_frozen
+        real(dp) :: product_delta
+
+        product_delta = base * response_delta + base_delta * response_frozen
+    end function compute_linearized_product
 
     pure subroutine compute_dot_params_at_point(ipoi, npoi, nbaleqs, fluxes_dif, fluxes_con, &
                                                 fluxes_con_nl, params, params_lin, params_b_lin, &

--- a/QL-Balance/src/test/test_rhs_balance.f90
+++ b/QL-Balance/src/test/test_rhs_balance.f90
@@ -12,6 +12,7 @@ program test_rhs_balance
                              compute_thermodynamic_forces, &
                              compute_particle_fluxes, &
                              compute_total_heat_fluxes, &
+                             compute_linearized_product, &
                              compute_source_terms_at_point, &
                              species_fluxes_t, &
                              transport_fluxes_t
@@ -32,6 +33,7 @@ program test_rhs_balance
     call test_thermodynamic_forces()
     call test_particle_fluxes()
     call test_heat_fluxes()
+    call test_linearized_product()
     call test_source_terms_at_point()
 
     print *, ""
@@ -171,9 +173,9 @@ contains
 
         ! Thermodynamic forces (arbitrary test values)
         forces%e%A1_noE = -0.05_dp
-        forces%e%A2 = 0.1_dp
+        forces%e%A2 = 0.08_dp
         forces%i%A1_noE = -0.04_dp
-        forces%i%A2 = 0.1_dp
+        forces%i%A2 = 0.09_dp
         forces%e%A1 = -0.03_dp
         forces%i%A1 = -0.06_dp
 
@@ -276,6 +278,27 @@ contains
         print *, "  PASSED: ", test_name
 
     end subroutine test_heat_fluxes
+
+
+    subroutine test_linearized_product()
+        ! Verify the complete first variation of a product:
+        !   delta(E * Gamma) = E * delta(Gamma) + delta(E) * Gamma.
+        real(dp) :: actual, expected
+        character(len=*), parameter :: test_name = "test_linearized_product"
+
+        print *, "Running: ", test_name
+
+        expected = 5.0_dp * 2.0_dp + 7.0_dp * 3.0_dp
+        actual = compute_linearized_product(5.0_dp, 2.0_dp, 7.0_dp, 3.0_dp)
+        call assert_equal(actual, expected, "linearized E*Gamma")
+
+        expected = 5.0_dp * 2.0_dp + 7.0_dp * 4.0_dp
+        actual = compute_linearized_product(5.0_dp, 2.0_dp, 7.0_dp, 4.0_dp)
+        call assert_equal(actual, expected, "point-local frozen Gamma")
+
+        print *, "  PASSED: ", test_name
+
+    end subroutine test_linearized_product
 
 
     subroutine test_source_terms_at_point()


### PR DESCRIPTION
## Summary

- extract the first variation of a product into a pure, directly testable helper
- route electron and ion QL heat-source linearization through that helper
- add regression coverage for both terms and avoid an exact-cancellation test fixture

This advances #199 without closing it. The stale point-local `forces_nl` defect described earlier was already fixed by #111; the remaining issue scope is broader.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` — 49/49 passed
