### PR TITLE
test(KiLCA): verify Lorentz torque convention

### DIFF
--- a/KiLCA/CMakeLists.txt
+++ b/KiLCA/CMakeLists.txt
@@ -310,6 +310,8 @@ set_target_properties(post_proc PROPERTIES
 add_dependencies(post_proc ${EXTERNAL_LIBS})
 target_link_libraries (post_proc kilca_lib ${EXTERNAL_LIBS})
 
+add_subdirectory(tests)
+
 # add a target to generate API documentation with Doxygen
 find_package (Doxygen)
 

--- a/KiLCA/flre/quants/calc_flre_quants.cpp
+++ b/KiLCA/flre/quants/calc_flre_quants.cpp
@@ -1047,11 +1047,11 @@ double h[3];
 eval_and_set_background_parameters_spec_independent_ (&(qp->r),qp->zone->sd->bs->flag_back);
 get_magnetic_field_parameters_ (h);
 
-complex<double> j_rsp[3], E_rsp[3], B_rsp[3];  //rsp sys
-complex<double> j_cyl[3], E_cyl[3], Bc_cyl[3];  //cyl sys
+complex<double> j_rsp[3], E_rsp[3], B_rsp[3]; //rsp sys
+complex<double> j_cyl[3], E_cyl[3], B_cyl[3]; //cyl sys
 
-complex<double> jxBc[3]; //j x B*
-complex<double> nd;      //density perturbation
+complex<double> nd; //density perturbation
+double force_density[3], torque_density[3];
 
 for (int spec=0; spec<2; spec++) //over species (i,e)
 {
@@ -1080,25 +1080,31 @@ for (int spec=0; spec<2; spec++) //over species (i,e)
     E_cyl[1] = h[2]*E_rsp[1] + h[1]*E_rsp[2];
     E_cyl[2] = h[2]*E_rsp[2] - h[1]*E_rsp[1];
 
-    //conjugate magnetic field:
-    Bc_cyl[0] = conj(B_rsp[0]);
-    Bc_cyl[1] = conj(h[2]*B_rsp[1] + h[1]*B_rsp[2]);
-    Bc_cyl[2] = conj(h[2]*B_rsp[2] - h[1]*B_rsp[1]);
-
-    vec_product_3D (j_cyl, Bc_cyl, jxBc);
+    //magnetic field:
+    B_cyl[0] = B_rsp[0];
+    B_cyl[1] = h[2]*B_rsp[1] + h[1]*B_rsp[2];
+    B_cyl[2] = h[2]*B_rsp[2] - h[1]*B_rsp[1];
 
     nd = ND[spec][0][qp->node] + ND[spec][1][qp->node]*I; //density perturbation
 
-    //force density:
+    calc_time_averaged_lorentz_force (
+        qp->zone->sd->bs->charge[spec],
+        nd,
+        E_cyl,
+        j_cyl,
+        B_cyl,
+        force_density);
+
+    calc_cylindrical_torque_density (
+        qp->r,
+        qp->zone->sd->bs->rtor,
+        force_density,
+        torque_density);
+
     for (int i=0; i<3; i++) //over components (r,th,z)
     {
-        LTD[spec][i][qp->node] = 0.5*real((qp->zone->sd->bs->charge[spec])*
-                                          nd*conj(E_cyl[i]) + E/c*jxBc[i]);
+        LTD[spec][i][qp->node] = torque_density[i];
     }
-
-    //torque density:
-    LTD[spec][1][qp->node] *= qp->r;                  //T_theta = F_theta*r
-    LTD[spec][2][qp->node] *= qp->zone->sd->bs->rtor; //T_z = F_z*R
 }
 
 //total torque t = i+e:
@@ -1181,11 +1187,57 @@ if (DEBUG_FLAG) fprintf (stdout, "\n%s is saved.", qp->name[qp->LOR_TORQUE_DENS]
 
 /*******************************************************************/
 
-void vec_product_3D (complex<double> *a, complex<double> *b, complex<double> *res)
+void vec_product_3D (
+    const complex<double> *a,
+    const complex<double> *b,
+    complex<double> *res)
 {
 res[0] =  (a[1]*b[2] - a[2]*b[1]);
 res[1] = -(a[0]*b[2] - a[2]*b[0]);
 res[2] =  (a[0]*b[1] - a[1]*b[0]);
+}
+
+/*******************************************************************/
+
+void calc_time_averaged_lorentz_force (
+    double charge,
+    complex<double> density,
+    const complex<double> *electric_field,
+    const complex<double> *current_density,
+    const complex<double> *magnetic_field,
+    double *force_density)
+{
+complex<double> conjugate_magnetic_field[3];
+complex<double> current_cross_magnetic_field[3];
+
+for (int i=0; i<3; i++)
+{
+    conjugate_magnetic_field[i] = conj(magnetic_field[i]);
+}
+
+vec_product_3D (
+    current_density,
+    conjugate_magnetic_field,
+    current_cross_magnetic_field);
+
+for (int i=0; i<3; i++)
+{
+    force_density[i] = 0.5*real(
+        charge*density*conj(electric_field[i]) + current_cross_magnetic_field[i]/c);
+}
+}
+
+/*******************************************************************/
+
+void calc_cylindrical_torque_density (
+    double radius,
+    double major_radius,
+    const double *force_density,
+    double *torque_density)
+{
+torque_density[0] = force_density[0];
+torque_density[1] = radius*force_density[1];
+torque_density[2] = major_radius*force_density[2];
 }
 
 /*******************************************************************/

--- a/KiLCA/flre/quants/calc_flre_quants.h
+++ b/KiLCA/flre/quants/calc_flre_quants.h
@@ -54,6 +54,20 @@ void save_total_flux (const flre_quants *qp);
 void calc_number_density (flre_quants *qp);
 void save_number_density (const flre_quants *qp);
 
+void calc_time_averaged_lorentz_force (
+    double charge,
+    complex<double> density,
+    const complex<double> *electric_field,
+    const complex<double> *current_density,
+    const complex<double> *magnetic_field,
+    double *force_density);
+
+void calc_cylindrical_torque_density (
+    double radius,
+    double major_radius,
+    const double *force_density,
+    double *torque_density);
+
 void calc_lorentz_torque_density (flre_quants *qp);
 void calc_lorentz_torque_on_cylinder (flre_quants *qp);
 void save_lorentz_torque (const flre_quants *qp);
@@ -62,7 +76,10 @@ void calculate_field_profiles_poy_test (flre_quants *qp);
 
 inline int binary_search (double x, const double *xa, int ilo, int ihi);
 
-void vec_product_3D (complex<double> *a, complex<double> *b, complex<double> *res);
+void vec_product_3D (
+    const complex<double> *a,
+    const complex<double> *b,
+    complex<double> *res);
 
 void integrate_over_cylinder (int dim, double *x, double *q, double vol_fac, double *qi);
 

--- a/KiLCA/tests/CMakeLists.txt
+++ b/KiLCA/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test_kilca_lorentz_torque test_lorentz_torque.cpp)
+target_link_libraries(test_kilca_lorentz_torque PRIVATE kilca_lib)
+
+add_test(
+    NAME kilca_lorentz_torque
+    COMMAND test_kilca_lorentz_torque
+)

--- a/KiLCA/tests/test_lorentz_torque.cpp
+++ b/KiLCA/tests/test_lorentz_torque.cpp
@@ -1,0 +1,64 @@
+#include "calc_flre_quants.h"
+
+#include <cmath>
+#include <complex>
+#include <cstdio>
+
+namespace {
+bool close(double actual, double expected, double tolerance = 1.0e-14) {
+    return std::abs(actual - expected) <= tolerance;
+}
+
+int check(const char* name, double actual, double expected, double tolerance = 1.0e-14) {
+    if (close(actual, expected, tolerance)) {
+        return 0;
+    }
+
+    std::fprintf(stderr, "%s: expected %.17e, got %.17e (difference %.17e)\n", name, expected,
+        actual, actual - expected);
+    return 1;
+}
+} // namespace
+
+int main() {
+    int failures = 0;
+
+    const std::complex<double> density(1.0, 2.0);
+    const std::complex<double> electric_field[3] = {std::complex<double>(3.0, 4.0),
+        std::complex<double>(0.0, 0.0), std::complex<double>(0.0, 0.0)};
+    const std::complex<double> current_density[3] = {std::complex<double>(1.0, 1.0),
+        std::complex<double>(0.0, 0.0), std::complex<double>(0.0, 0.0)};
+    const std::complex<double> magnetic_field[3] = {std::complex<double>(0.0, 0.0),
+        std::complex<double>(0.0, 0.0), std::complex<double>(2.0, 3.0)};
+    double force[3];
+
+    calc_time_averaged_lorentz_force(
+        2.0, density, electric_field, current_density, magnetic_field, force);
+
+    failures += check("electrostatic force", force[0], 11.0);
+    failures += check("magnetic cross-product sign", force[1], -2.5 / c);
+    failures += check("zero force component", force[2], 0.0);
+
+    double torque[3];
+    calc_cylindrical_torque_density(5.0, 7.0, force, torque);
+
+    failures += check("poloidal torque moment arm", torque[1], -12.5 / c);
+    failures += check("toroidal torque moment arm", torque[2], 0.0);
+
+    double radius[3] = {1.0, 2.0, 4.0};
+    double density_profile[3] = {1.0, -2.0, 3.0};
+    double integrated[3];
+
+    integrate_over_cylinder(3, radius, density_profile, 10.0, integrated);
+
+    failures += check("integral origin", integrated[0], 0.0);
+    failures += check("integral first interval", integrated[1], -15.0);
+    failures += check("integral signed total", integrated[2], 65.0);
+
+    if (failures != 0) {
+        return 1;
+    }
+
+    std::puts("KiLCA Lorentz torque identities passed");
+    return 0;
+}

--- a/docs/plans/2026-07-27-kilca-lorentz-torque-verification.md
+++ b/docs/plans/2026-07-27-kilca-lorentz-torque-verification.md
@@ -1,0 +1,110 @@
+# KiLCA Lorentz Torque Verification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan
+> task-by-task.
+
+**Goal:** Add an independent, source-linked CTest for KiLCA's complex-phasor Lorentz-force
+torque density and cylindrical radial integration.
+
+**Architecture:** Extract the scalar/vector mathematics embedded in
+`calc_lorentz_torque_density` into small pure C++ functions. Keep the existing production data
+plumbing intact, call the pure functions from production, and test them without constructing a
+`flre_quants` object.
+
+**Tech Stack:** C++11, CMake/CTest, KiLCA's existing complex-number conventions.
+
+---
+
+### Task 1: Register a focused KiLCA torque test
+
+**Files:**
+- Create: `KiLCA/tests/CMakeLists.txt`
+- Create: `KiLCA/tests/test_lorentz_torque.cpp`
+- Modify: `KiLCA/CMakeLists.txt`
+
+**Step 1: Write the failing test**
+
+Add cases for the time-averaged phasor force
+`0.5 Re(q n E* + (j x B*) / c)`, cylindrical moment arms, species summation, and trapezoidal
+integration with the cylindrical volume factor.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+`cmake -S . -B build -G Ninja && cmake --build build --target test_kilca_lorentz_torque`
+
+Expected: FAIL because the pure torque functions are not declared.
+
+### Task 2: Extract and route the production formula
+
+**Files:**
+- Modify: `KiLCA/flre/quants/calc_flre_quants.h`
+- Modify: `KiLCA/flre/quants/calc_flre_quants.cpp`
+
+**Step 1: Implement the minimal pure functions**
+
+Add functions that compute the averaged Lorentz force, apply `(0, r, R0)` moment arms, and
+integrate a radial density with the existing trapezoidal cylinder rule.
+
+**Step 2: Route production through them**
+
+Replace the inline force and moment-arm arithmetic in `calc_lorentz_torque_density` with calls to
+the tested helpers, preserving inputs and output layout.
+
+**Step 3: Run the focused test**
+
+Run:
+`cmake --build build --target test_kilca_lorentz_torque`
+
+Then:
+`ctest --test-dir build -R kilca_lorentz_torque --output-on-failure`
+
+Expected: PASS.
+
+### Task 3: Document conventions and remaining scope
+
+**Files:**
+- Create: `docs/verification/kilca-flr.md`
+
+**Step 1: Record the verified mapping**
+
+Link dissertation equations 6.17-6.18 to the production symbols. State CGS units, the
+`exp(-i omega t)` phasor convention, complex conjugation, the factor `1/2`, torque moment arms,
+and the straight-cylinder integration assumptions.
+
+**Step 2: Record unverified work explicitly**
+
+List the generated FLR1/FLR3/FLR5 coefficient identities and constant-psi/layer-width reductions
+as pending rather than implying that the whole issue is verified.
+
+### Task 4: Verify and commit
+
+**Files:**
+- Verify all changed files.
+
+**Step 1: Run formatting and static checks**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+**Step 2: Run focused and full CTest suites**
+
+Run:
+`cmake --build build`
+
+Then:
+`ctest --test-dir build -R kilca_lorentz_torque --output-on-failure`
+
+Then:
+`ctest --test-dir build --output-on-failure`
+
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+Run:
+Stage the KiLCA CMake/test changes, the two `calc_flre_quants` files, and the plan and
+verification documents.
+
+Run: `git commit -m "test(KiLCA): verify Lorentz torque convention"`

--- a/docs/verification/kilca-flr.md
+++ b/docs/verification/kilca-flr.md
@@ -1,0 +1,110 @@
+# KiLCA FLR mathematics verification
+
+This document tracks executable checks of the differential KiLCA plasma-response model. A
+passing golden record is useful for detecting change, but is not evidence that an equation is
+correct.
+
+Primary reference: Markus Markl, *Kinetic investigation of the bifurcation of resonant magnetic
+perturbations in magnetically confined plasmas and development of an integral response model*
+(2024), [doi:10.3217/efp2p-0x485](https://doi.org/10.3217/efp2p-0x485).
+
+## Compiled model
+
+The default CMake configuration selects:
+
+- `MAGNETIC_DRIFT=MDNO`, so the compiled conductivity sources have no `_drift` suffix;
+- `COLLISION_MODEL=FPGEN`, so the compiled collision source is
+  `calc_W2_array_gen.f90`;
+- `flre_order` values 1, 3, and 5, dispatched explicitly by
+  `KiLCA/flre/conductivity/calc_D_array.f90`.
+
+The corresponding generated coefficient sources are `calc_D_array_1_fac.f90`,
+`calc_D_array_3_fac.f90`, and `calc_D_array_5_fac.f90`. Other similarly named source files are
+not part of the default target and are not evidence for the compiled model.
+
+## Verification status
+
+### Verified
+
+- Time/phase convention: thesis (4.1), with real fields represented by
+  `Re(F exp(-i omega t))`. The complex amplitudes in `KiLCA/flre/quants/` are covered by the
+  Lorentz-force CTest.
+- Lorentz-force density: the full phasor average
+  `1/2 Re(q n E* + j x B*/c)`. Thesis (6.17) gives the magnetic-force torque reduction. The
+  production symbols are `calc_time_averaged_lorentz_force` and
+  `calc_lorentz_torque_density`.
+- Cylindrical torque arms: `T_theta = r F_theta` and `T_z = R0 F_z`, implemented by
+  `calc_cylindrical_torque_density`.
+- Radial integration: the signed numerical weighting for the straight-cylinder volume element
+  `4 pi^2 R0 r dr`, implemented by `flre_quants::vol_fac`,
+  `integrate_over_cylinder`, and `calc_lorentz_torque_on_cylinder`.
+
+### Pending
+
+- FLR expansion: thesis (5.5)-(5.7), a Taylor expansion in radial Larmor displacement through
+  order `N`. The small parameter is locally `rho/L`, or `k_perp rho` for a Fourier scale.
+  Coefficient identities and quantitative remainder/domain bounds remain to be checked in
+  `calc_D_array_{1,3,5}_fac.f90`, `kmatrices.f90`, and `conductivity.f90`.
+- Constant-psi reduction: thesis (6.18) adds assumptions beyond numerical radial integration.
+- Resonant-layer width: `flre_zone::D` is read from zone settings and controls conductivity-grid
+  refinement. No derivation is attached to this input, so it is not a computed physical layer
+  width.
+- Island width: no direct consuming KiLCA symbol was identified in this audit. Response-field
+  output does not by itself verify an island-width formula.
+
+Here `rho = v_T/omega_c`. The statement `rho/L << 1` is the asymptotic condition for the
+Taylor expansion, not a repository-enforced validity threshold. No numerical bound for the
+neglected `O((rho/L)^(N+1))` contribution has yet been established for the generated
+coefficient files.
+
+## Lorentz torque convention
+
+For complex amplitudes with the thesis convention `exp(-i omega t)`, the period average of two
+real harmonics is
+
+`<Re(a exp(-i omega t)) Re(b exp(-i omega t))> = 1/2 Re(a b*)`.
+
+KiLCA therefore computes, in CGS units,
+
+`f = 1/2 Re(q n E* + j x B*/c)`.
+
+The CTest uses deliberately complex amplitudes so that removing either conjugation changes the
+answer. It also chooses basis-aligned `j` and `B` vectors so that a cross-product sign mutation
+fails independently of the electric term.
+
+After transforming `(r,s,p)` components to cylinder components `(r,theta,z)`, the local output
+slots contain:
+
+- radial force density `f_r` (retained for historical output compatibility);
+- poloidal torque density `r f_theta`;
+- toroidal torque density `R0 f_z`.
+
+The radial slot is not integrated: `calc_lorentz_torque_on_cylinder` passes a zero volume factor
+for that component. Tangential components use
+
+`Integral T dV = 4 pi^2 R0 Integral r T(r) dr`
+
+with a signed trapezoidal rule. Ion and electron torque densities are calculated separately and
+then summed.
+
+The focused test is registered as `kilca_lorentz_torque` in CTest.
+
+## Constant-psi boundary
+
+Thesis equation (6.18) is not merely the numerical radial integration above. It assumes one
+perturbation mode and replaces all radially varying quantities except the parallel current by
+their values at the resonant surface. Equation (6.19) additionally assumes strong,
+electron-only shielding and neglects the perpendicular electric field; the thesis explicitly
+states that this limit is invalid close to the gyrocenter resonance.
+
+No production helper currently exposes that analytic reduction as an independently testable
+function. Until such a consumer is identified or introduced, the constant-psi part of issue
+#195 remains unverified.
+
+## Reproduction
+
+```bash
+cmake -S . -B build -G Ninja
+cmake --build build --target test_kilca_lorentz_torque
+ctest --test-dir build -R kilca_lorentz_torque --output-on-failure
+```


### PR DESCRIPTION
## Purpose

Advance #195 with a focused, executable verification of KiLCA's Lorentz-torque sign convention.

## Changes

- extract the phasor Lorentz-force and cylindrical-torque calculations into testable helpers without changing production behavior
- add a focused CTest covering complex conjugation, cross-product sign, cylindrical moment arms, and signed radial integration
- document the compiled FLR variants and clearly separate the still-pending constant-psi/FLR coefficient work

This advances #195 but does not close it.

## Validation

- fresh CMake/Ninja build after rebasing onto current `main`
- full CTest suite: 50/50 passed
- `git diff --check origin/main...HEAD`