### PR TITLE
fix(KIM): restore collisionless finite-FLR remainder

### DIFF
--- a/KIM/src/asymptotics/collisionless_fourier_kernel.f90
+++ b/KIM/src/asymptotics/collisionless_fourier_kernel.f90
@@ -199,6 +199,7 @@ contains
         complex(dp), intent(out) :: rho_phi, rho_B, j_phi, j_B
 
         real(dp) :: grad_A1, grad_A2, bplus, bcross, ks, k_abs
+        real(dp) :: radial_gaussian
         real(dp) :: lambda_D, omega_c, sI0, sIm1, vT
         real(dp) :: coeff0, coeff1, coeff2
         complex(dp) :: k_pole, zeta0, response_Z
@@ -219,6 +220,8 @@ contains
 
         call flr_arg_pair_sp(plasma_in, sp, kr, krp, j, bplus, bcross)
         call scaled_bessel_pair(bplus, bcross, sI0, sIm1)
+        radial_gaussian = exp(&
+            -0.5_dp * plasma_in%spec(sp)%rho_L(j)**2 * (kr - krp)**2)
 
         k_abs = Krook_collisionless_kpar_magnitude(plasma_in%kp(j), epsilon)
         k_pole = Krook_collisionless_kpar(plasma_in%kp(j), epsilon)
@@ -253,6 +256,16 @@ contains
         ! written with the same explicit 1/(8*pi^2) normalization.
         rho_phi = omega_c / (sqrt(2.0_dp) * lambda_D**2 * vT * k_abs) &
             * rho_phi_moment / (8.0_dp * pi**2)
+
+        ! The moment above is the m_phi=0 contribution. The analytically
+        ! summed nonzero cyclotron harmonics add the finite-FLR remainder
+        ! [exp(-b_plus) I_0(b_cross) - exp(-rho_L^2 (kr-krp)^2/2)]/lambda_D^2;
+        ! see thesis (13.125)--(13.127). In a homogeneous static plasma this
+        ! cancels the -sI0 zeroth harmonic and restores the complete radial
+        ! Gaussian Debye response. The common Fourier normalization is the
+        ! same as for the zeroth-harmonic moment.
+        rho_phi = rho_phi + (sI0 - radial_gaussian) &
+            / (lambda_D**2 * 8.0_dp * pi**2)
         j_phi = omega_c / (lambda_D**2 * k_pole) &
             * j_phi_moment / (8.0_dp * pi**2)
 

--- a/KIM/tests/test_collisionless_fourier_kernel.f90
+++ b/KIM/tests/test_collisionless_fourier_kernel.f90
@@ -4,6 +4,7 @@ program test_collisionless_fourier_kernel
     use config_m, only: artificial_debye_case
     use constants_m, only: pi
     use flr2_fourier_kernel_m, only: set_global_kernel_approximations
+    use fortnum_special, only: bessel_in
     use setup_m, only: omega
     use species_m, only: plasma_t
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
@@ -13,6 +14,7 @@ program test_collisionless_fourier_kernel
     type(plasma_t) :: test_plasma
     complex(dp) :: rho_phi, rho_B, j_phi, j_B
     complex(dp) :: rho_phi_ref, rho_B_ref, j_phi_ref, j_B_ref
+    real(dp) :: bplus_ref, bcross_ref, radial_gaussian_ref, remainder_ref
     real(dp), parameter :: epsilon = 0.05_dp
     real(dp), parameter :: kr = 0.73_dp, krp = -0.41_dp
 
@@ -21,14 +23,34 @@ program test_collisionless_fourier_kernel
     artificial_debye_case = 0
     omega = 0.17_dp
 
+    ! Run the static-limit checks first. They are independent of the
+    ! manufactured oracle below and must catch an incomplete FLR response
+    ! before any hard-coded non-static reference values are considered.
+    call test_homogeneous_static_limit(test_plasma)
+
     call collisionless_ion_cores(test_plasma, 1, kr, krp, 1, epsilon, &
         rho_phi, rho_B, j_phi, j_B)
 
     ! Independent Fourier-space evaluation of the global collisionless
-    ! G1+G2+G3 decomposition.  In particular, G2 supplies the -b_plus term,
+    ! G1+G2+G3 decomposition. In particular, G2 supplies the -b_plus term,
     ! and the velocity moments retain their Z(zeta) and 1+zeta*Z(zeta)
-    ! dependence.  The global solver is the normalization/sign baseline.
-    rho_phi_ref = cmplx(-2.1566076735926778e-2_dp, -7.8627199009209740e-3_dp, dp)
+    ! dependence. The hard-coded rho-Phi value is the independently checked
+    ! m_phi=0 moment. Add the analytically summed m_phi /= 0 remainder using
+    ! primitive definitions rather than the production FLR helpers, so a
+    ! shared error in b_plus, b_cross, or the radial Gaussian cannot self-pass.
+    bplus_ref = 0.5_dp * test_plasma%spec(1)%rho_L(1)**2 * (&
+        2.0_dp * test_plasma%ks(1)**2 + kr**2 + krp**2)
+    bcross_ref = test_plasma%spec(1)%rho_L(1)**2 &
+        * sqrt(test_plasma%ks(1)**2 + kr**2) &
+        * sqrt(test_plasma%ks(1)**2 + krp**2)
+    radial_gaussian_ref = exp(&
+        -0.5_dp * test_plasma%spec(1)%rho_L(1)**2 * (kr - krp)**2)
+    remainder_ref = (&
+        exp(-bplus_ref) * bessel_in(0, bcross_ref) - radial_gaussian_ref) &
+        / (test_plasma%spec(1)%lambda_D(1)**2 * 8.0_dp * pi**2)
+    rho_phi_ref = cmplx(&
+        -2.1566076735926778e-2_dp + remainder_ref, &
+        -7.8627199009209740e-3_dp, dp)
     rho_B_ref = cmplx(-5.9925789298467730e-14_dp, 1.5662372153310280e-14_dp, dp)
     j_phi_ref = cmplx(7.8025611966209100e-3_dp, -6.5083683321303820e-3_dp, dp)
     j_B_ref = cmplx(6.1104067713266680e-14_dp, -1.5970330300359097e-14_dp, dp)
@@ -41,7 +63,6 @@ program test_collisionless_fourier_kernel
     call assert_close('j-B global-kernel oracle', j_B, j_B_ref, 5.0e-8_dp)
 
     call test_magnetic_recurrence(test_plasma)
-    call test_homogeneous_static_limit(test_plasma)
     call test_resonance_regularization(test_plasma)
     call test_collision_frequency_independence(test_plasma)
 
@@ -87,6 +108,7 @@ contains
     subroutine test_homogeneous_static_limit(plasma)
         type(plasma_t), intent(inout) :: plasma
         complex(dp) :: rp, rb, jp, jb, expected
+        real(dp) :: gaussian
         real(dp) :: saved_omega, saved_om_E, saved_ks, saved_rho_L
         real(dp) :: saved_A1, saved_A2
 
@@ -99,17 +121,61 @@ contains
 
         omega = 0.0_dp
         plasma%om_E(1) = 0.0_dp
-        plasma%ks(1) = 0.0_dp
-        plasma%spec(1)%rho_L(1) = 0.0_dp
         plasma%spec(1)%A1(1) = 0.0_dp
         plasma%spec(1)%A2(1) = 0.0_dp
 
+        ! At finite FLR the sum over all cyclotron harmonics restores the
+        ! complete static Debye response. On the Fourier diagonal the
+        ! canonical radial Gaussian is exactly unity, irrespective of ks.
+        call collisionless_ion_cores(plasma, 1, kr, kr, 1, epsilon, rp, rb, jp, jb)
+        expected = cmplx(-1.0_dp / (8.0_dp * pi**2 * plasma%spec(1)%lambda_D(1)**2), &
+            0.0_dp, dp)
+        call assert_close('homogeneous finite-FLR diagonal Debye limit', rp, expected, 2.0e-13_dp)
+        call assert_close('homogeneous finite-FLR diagonal rho-B vanishes', rb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous finite-FLR diagonal j-Phi vanishes', jp, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous finite-FLR diagonal j-B vanishes', jb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+
+        ! Off the Fourier diagonal, the same static response is broadened
+        ! only by the radial guiding-centre Gaussian. It must not depend on
+        ! the individual perpendicular wavenumbers through Gamma_0(b).
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
+        gaussian = exp(-0.5_dp * plasma%spec(1)%rho_L(1)**2 * (kr - krp)**2)
+        expected = cmplx(-gaussian / &
+            (8.0_dp * pi**2 * plasma%spec(1)%lambda_D(1)**2), 0.0_dp, dp)
+        call assert_close('homogeneous finite-FLR off-diagonal Debye limit', &
+            rp, expected, 2.0e-13_dp)
+        call assert_close('homogeneous finite-FLR off-diagonal rho-B vanishes', rb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous finite-FLR off-diagonal j-Phi vanishes', jp, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous finite-FLR off-diagonal j-B vanishes', jb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+
+        ! The optional global-comparison approximation omits ks from b_plus
+        ! and b_cross. Its m_phi=0 term changes, but the analytic remainder
+        ! must still cancel it and leave the same canonical radial Gaussian.
+        call set_global_kernel_approximations(.true.)
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
+        call assert_close('homogeneous simplified-FLR off-diagonal Debye limit', &
+            rp, expected, 2.0e-13_dp)
+        call set_global_kernel_approximations(.false.)
+
+        ! Retain the zero-FLR case as a separate limiting check. This case
+        ! alone is insufficient because both competing formulas reduce to 1.
+        plasma%ks(1) = 0.0_dp
+        plasma%spec(1)%rho_L(1) = 0.0_dp
         call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
         expected = cmplx(-1.0_dp / (8.0_dp * pi**2 * plasma%spec(1)%lambda_D(1)**2), 0.0_dp, dp)
-        call assert_close('homogeneous static Debye limit', rp, expected, 2.0e-13_dp)
-        call assert_close('homogeneous rho-B vanishes', rb, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
-        call assert_close('homogeneous j-Phi vanishes', jp, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
-        call assert_close('homogeneous j-B vanishes', jb, cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous zero-FLR Debye limit', rp, expected, 2.0e-13_dp)
+        call assert_close('homogeneous zero-FLR rho-B vanishes', rb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous zero-FLR j-Phi vanishes', jp, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
+        call assert_close('homogeneous zero-FLR j-B vanishes', jb, &
+            cmplx(0.0_dp, 0.0_dp, dp), 1.0e-30_dp)
 
         omega = saved_omega
         plasma%om_E(1) = saved_om_E

--- a/docs/plans/2026-07-28-kim-collisionless-flr-remainder-design.md
+++ b/docs/plans/2026-07-28-kim-collisionless-flr-remainder-design.md
@@ -1,0 +1,43 @@
+# Collisionless Finite-FLR Remainder Design
+
+## Problem
+
+The periodic collisionless ion `rho-Phi` core evaluates only the
+`m_phi = 0` contribution from Markl, Eq. (13.58). At finite Larmor radius,
+that contribution contains `-exp(-b_plus) I_0(b_cross) / lambda_D^2` in the
+homogeneous static limit. The nonzero cyclotron harmonics supply the analytic
+remainder derived in Eqs. (13.125)--(13.127):
+
+```text
+[exp(-b_plus) I_0(b_cross)
+ - exp(-rho_L^2 (kr-krp)^2 / 2)] / lambda_D^2.
+```
+
+Without it, the collisionless kernel disagrees with both the global kernel and
+the periodic Fokker--Planck convention even before gradients or resonances are
+introduced. Existing tests set `rho_L = 0`, where the missing term vanishes.
+
+## Design
+
+Add the closed-form nonzero-harmonic remainder directly to `rho_phi` after the
+zeroth-harmonic moment is evaluated. Reuse the already computed scaled Bessel
+factor and compute the Gaussian from `rho_L`, `kr`, and `krp`. Keep the common
+`1/(8*pi^2)` normalization explicit. Do not alter `rho_B`, `j_phi`, or `j_B`:
+the same derivation shows the higher-harmonic charge response driven by `B_r`
+reduces to the zeroth harmonic, and this issue concerns only `rho-Phi`.
+
+## Regression Strategy
+
+Replace the degenerate zero-FLR-only static check with independent finite-FLR
+tests covering:
+
+1. diagonal `kr = krp`, where the complete static response must be exactly
+   `-1/lambda_D^2` for arbitrary nonzero `ks*rho_L`;
+2. off-diagonal `kr != krp`, where the response must be the canonical Gaussian;
+3. zero FLR, retained as a limiting-case guard;
+4. non-static manufactured-oracle values, updated from an independent formula
+   that includes the analytic remainder;
+5. magnetic and current outputs unchanged by the correction.
+
+The finite-FLR diagonal case is the essential mutation test: removing the
+remainder changes the result by `1-exp(-b)I_0(b)` and must fail decisively.

--- a/docs/plans/2026-07-28-kim-collisionless-flr-remainder.md
+++ b/docs/plans/2026-07-28-kim-collisionless-flr-remainder.md
@@ -1,0 +1,48 @@
+# Collisionless Finite-FLR Remainder Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore the analytically summed nonzero-cyclotron-harmonic remainder in the periodic collisionless ion `rho-Phi` kernel and prevent zero-FLR tests from masking regressions.
+
+**Architecture:** Keep the existing zeroth-harmonic collisionless moments. Add the closed-form remainder from Markl Eq. (13.127) only to `rho_phi`, using the existing scaled Bessel factor and the canonical radial Gaussian. Validate complete observable kernel values rather than internal helper arithmetic.
+
+**Tech Stack:** Fortran 2008, CMake/Ninja, CTest.
+
+---
+
+### Task 1: Add finite-FLR static regression tests
+
+**Files:**
+- Modify: `KIM/tests/test_collisionless_fourier_kernel.f90`
+
+1. Add a homogeneous finite-FLR diagonal test with nonzero `ks`, `rho_L`, and `kr`.
+2. Add a homogeneous finite-FLR off-diagonal test with `kr != krp`.
+3. Retain the zero-FLR limit as a separate test.
+4. Build and run `test_collisionless_fourier_kernel`; verify the two new tests fail because the current core returns the zeroth-harmonic Bessel factor.
+
+### Task 2: Implement the analytic remainder
+
+**Files:**
+- Modify: `KIM/src/asymptotics/collisionless_fourier_kernel.f90`
+
+1. Compute `exp(-rho_L^2*(kr-krp)^2/2)`.
+2. Add `(sI0 - gaussian)/lambda_D^2/(8*pi^2)` to `rho_phi`.
+3. Explain the decomposition and cite Eqs. (13.125)--(13.127) in comments.
+4. Rebuild and verify the new static tests pass.
+
+### Task 3: Strengthen the manufactured oracle
+
+**Files:**
+- Modify: `KIM/tests/test_collisionless_fourier_kernel.f90`
+
+1. Update the independent finite-FLR oracle to include the analytic remainder.
+2. Check `rho_phi`, `rho_B`, `j_phi`, and `j_B` independently.
+3. Run the focused kernel and assembly suites.
+4. Temporarily remove or negate the remainder and verify the finite-FLR tests fail, then restore it.
+
+### Task 4: Full verification
+
+1. Format changed Fortran with the repository formatter if available.
+2. Build KIM and all tests.
+3. Run full local CTest and record any acknowledged baseline failure separately.
+4. Review the final diff for scope and derivation consistency.


### PR DESCRIPTION
## Summary

- restore the analytically summed nonzero-cyclotron-harmonic remainder in the periodic collisionless ion `rho-Phi` kernel
- recover the canonical finite-FLR radial Gaussian from Markl Eqs. (13.125)--(13.127)
- add finite-FLR diagonal, off-diagonal, simplified-kernel, zero-FLR, and independent manufactured-oracle regression coverage

## Root cause

The collisionless periodic core evaluated only the `m_phi = 0` moment. In the homogeneous static limit this leaves `-exp(-b_plus) I_0(b_cross) / lambda_D^2`. The omitted `m_phi != 0` sum contributes

```text
[exp(-b_plus) I_0(b_cross)
 - exp(-rho_L^2 (kr-krp)^2 / 2)] / lambda_D^2,
```

which restores the canonical Gaussian response. The previous static test set `rho_L = 0`, where both formulas reduce to the same value and the defect was invisible.

## Impact

For the existing `(m,n)=(7,2)`, `lambda=+1` collisionless input, the corrected solution agrees with the FP result to 0.68% in `Phi`, 0.51% in `j_parallel`, and 1.67% in integrated `I_parallel`; the old differences were 108%, 97%, and 177%.

## Validation

- full CMake build
- CTest: 50/50 passed
- changed-file pre-commit hooks passed
- red/green test confirmed the old implementation fails by 21.4% in a representative finite-FLR diagonal case
- sign-mutation check confirmed the regression test detects an inverted correction
- end-to-end corrected `(7,2)`, `lambda=+1` collisionless run completed successfully