### PR TITLE
fix(KIM): correct finite-Krook rho-B coefficient

### DIFF
--- a/KIM/src/kernels/Krook_kernel_plasma_prefacs.f90
+++ b/KIM/src/kernels/Krook_kernel_plasma_prefacs.f90
@@ -291,7 +291,7 @@ module Krook_kernel_plasma_prefacs_m
         logical, intent(in), optional :: collisionless
         real(dp), intent(in), optional :: epsilon
         complex(dp) :: val
-        real(dp) :: A1, A1_factor, A2
+        real(dp) :: A1, A2
         complex(dp) :: plasma_Z, z0
         logical :: use_collisionless
 
@@ -299,16 +299,14 @@ module Krook_kernel_plasma_prefacs_m
         A2 = 0.5d0 * (spec%A2(j) + spec%A2(j+1))
         use_collisionless = .false.
         if (present(collisionless)) use_collisionless = collisionless
-        A1_factor = 0.5_dp
         if (use_collisionless) then
             if (.not. present(epsilon)) error stop 'Collisionless G1_rho_B requires epsilon'
             z0 = Krook_z0_cc(j, spec, .true., epsilon)
-            A1_factor = 1.0_dp
         else
             z0 = Krook_z0_cc(j, spec, .false.)
         end if
 
-        val = A1_factor * A1 * (z0 * plasma_Z(z0) + 1.0d0) + A2 * &
+        val = A1 * (z0 * plasma_Z(z0) + 1.0d0) + A2 * &
             (&
                 0.5d0 + (z0 * plasma_Z(z0) + 1.0d0) * (1.0d0 + z0**2.0d0) &
             )

--- a/KIM/tests/test_collisionless_ion_kernel.f90
+++ b/KIM/tests/test_collisionless_ion_kernel.f90
@@ -12,7 +12,7 @@ program test_collisionless_ion_kernel
     implicit none
 
     complex(dp) :: actual, expected, explicit_c0, collisional
-    complex(dp) :: pole_wide, pole_narrow, pole_cc, z0_cc, plasma_Z
+    complex(dp) :: pole_wide, pole_narrow, pole_cc, z0_cc, z0_finite, plasma_Z
     real(dp) :: magnitude_wide, magnitude_narrow, pole_magnitude
     type(species_t) :: spec
 
@@ -123,6 +123,11 @@ program test_collisionless_ion_kernel
     call assert_prefactor('G3_rho_phi', collisional, explicit_c0, expected)
 
     collisional = Krook_G1_rho_B(1, spec)
+    z0_finite = Krook_z0_cc(1, spec, collisionless=.false.)
+    expected = 0.45_dp * (z0_finite * plasma_Z(z0_finite) + 1.0_dp) - 0.15_dp * (&
+        0.5_dp + (z0_finite * plasma_Z(z0_finite) + 1.0_dp) * (1.0_dp + z0_finite**2))
+    call assert_close('finite Krook G1_rho_B', collisional, expected)
+
     explicit_c0 = Krook_G1_rho_B(1, spec, collisionless=.true., epsilon=0.25_dp)
     expected = 0.45_dp * (z0_cc * plasma_Z(z0_cc) + 1.0_dp) - 0.15_dp * (&
         0.5_dp + (z0_cc * plasma_Z(z0_cc) + 1.0_dp) * (1.0_dp + z0_cc**2))
@@ -146,6 +151,20 @@ program test_collisionless_ion_kernel
     print *, 'PASS: collisionless magnitude terms and causal signed poles remain distinct'
 
 contains
+
+    subroutine assert_close(name, actual_value, reference_value)
+        character(len=*), intent(in) :: name
+        complex(dp), intent(in) :: actual_value, reference_value
+        real(dp) :: tolerance
+
+        tolerance = 1.0e-13_dp * (1.0_dp + abs(reference_value))
+        if (abs(actual_value - reference_value) > tolerance) then
+            print *, 'FAIL: prefactor mismatch for ', name
+            print *, '  actual   = ', actual_value
+            print *, '  expected = ', reference_value
+            error stop
+        end if
+    end subroutine assert_close
 
     subroutine assert_prefactor(name, fp_value, c0_value, reference_value)
         character(len=*), intent(in) :: name


### PR DESCRIPTION
## Summary

- use the derived unit coefficient for the finite-Krook `A1 [z0 Z(z0) + 1]` contribution to `K^{rho B}`
- preserve the existing finite-collision and explicit collisionless `z0` selection
- add a regression assertion for the complete finite-Krook prefactor

## Verification

- red: the new finite-Krook assertion failed against the former `0.5` coefficient
- green: `ctest --test-dir build -R '^(test_collisionless_ion_kernel|test_collisionless_fourier_kernel|test_collisionless_ion_assembly|test_susceptibility_collisionless_limit|test_collision_scale_z0)$' --output-on-failure`
- result: 5/5 tests passed
- independent code review: no findings

Closes #253