### PR TITLE
fix(KIM): restore collisionless j-B parity

### DIFF
--- a/KIM/src/asymptotics/collisionless_fourier_kernel.f90
+++ b/KIM/src/asymptotics/collisionless_fourier_kernel.f90
@@ -277,8 +277,11 @@ contains
 
         rho_B = com_unit * vT**2 / (sol * lambda_D**2 * omega_c * k_pole) &
             * magnetic_bracket / (8.0_dp * pi**2)
+        ! zeta0 is evaluated with k_abs to keep the retarded response in the
+        ! stable half-plane.  The derived current contains signed
+        ! zeta/k_parallel, whose regularized combination is zeta0/k_abs.
         j_B = com_unit * sqrt(2.0_dp) * vT**3 * zeta0 &
-            / (sol * lambda_D**2 * omega_c * k_pole) &
+            / (sol * lambda_D**2 * omega_c * k_abs) &
             * magnetic_bracket / (8.0_dp * pi**2)
     end subroutine collisionless_ion_cores
 

--- a/KIM/tests/test_collisionless_fourier_kernel.f90
+++ b/KIM/tests/test_collisionless_fourier_kernel.f90
@@ -53,7 +53,7 @@ program test_collisionless_fourier_kernel
         -7.8627199009209740e-3_dp, dp)
     rho_B_ref = cmplx(-5.9925789298467730e-14_dp, 1.5662372153310280e-14_dp, dp)
     j_phi_ref = cmplx(7.8025611966209100e-3_dp, -6.5083683321303820e-3_dp, dp)
-    j_B_ref = cmplx(6.1104067713266680e-14_dp, -1.5970330300359097e-14_dp, dp)
+    j_B_ref = cmplx(-5.631687763559327e-14_dp, 2.858614390986371e-14_dp, dp)
 
     call assert_close('rho-Phi global-kernel oracle', rho_phi, rho_phi_ref, 2.0e-13_dp)
     ! fortnum's integer-order Bessel approximation is accurate to about 1e-8
@@ -62,6 +62,7 @@ program test_collisionless_fourier_kernel
     call assert_close('j-Phi global-kernel oracle', j_phi, j_phi_ref, 2.0e-13_dp)
     call assert_close('j-B global-kernel oracle', j_B, j_B_ref, 5.0e-8_dp)
 
+    call test_kpar_parity(test_plasma)
     call test_magnetic_recurrence(test_plasma)
     call test_resonance_regularization(test_plasma)
     call test_collision_frequency_independence(test_plasma)
@@ -93,16 +94,38 @@ contains
         plasma%spec(1)%nu(1) = 9.0e7_dp
     end subroutine make_manufactured_plasma
 
+    subroutine test_kpar_parity(plasma)
+        type(plasma_t), intent(inout) :: plasma
+        complex(dp) :: rp_positive, rb_positive, jp_positive, jb_positive
+        complex(dp) :: rp_negative, rb_negative, jp_negative, jb_negative
+        real(dp) :: saved_kp
+
+        saved_kp = plasma%kp(1)
+        plasma%kp(1) = abs(saved_kp)
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, &
+            rp_positive, rb_positive, jp_positive, jb_positive)
+        plasma%kp(1) = -abs(saved_kp)
+        call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, &
+            rp_negative, rb_negative, jp_negative, jb_negative)
+        plasma%kp(1) = saved_kp
+
+        call assert_close('j-B is even in k_parallel', jb_negative, jb_positive, 2.0e-13_dp)
+    end subroutine test_kpar_parity
+
     subroutine test_magnetic_recurrence(plasma)
-        use Krook_kernel_plasma_prefacs_m, only: Krook_collisionless_z0
+        use Krook_kernel_plasma_prefacs_m, only: Krook_collisionless_kpar, &
+            Krook_collisionless_kpar_magnitude, Krook_collisionless_z0
         type(plasma_t), intent(in) :: plasma
-        complex(dp) :: rp, rb, jp, jb, z0
+        complex(dp) :: k_pole, rp, rb, jp, jb, z0
+        real(dp) :: k_abs
 
         call collisionless_ion_cores(plasma, 1, kr, krp, 1, epsilon, rp, rb, jp, jb)
+        k_abs = Krook_collisionless_kpar_magnitude(plasma%kp(1), epsilon)
+        k_pole = Krook_collisionless_kpar(plasma%kp(1), epsilon)
         z0 = Krook_collisionless_z0(plasma%om_E(1), omega, plasma%kp(1), &
             plasma%spec(1)%vT(1), epsilon)
         call assert_close('j-B/rho-B recurrence', jb, &
-            sqrt(2.0_dp) * plasma%spec(1)%vT(1) * z0 * rb, 2.0e-13_dp)
+            sqrt(2.0_dp) * plasma%spec(1)%vT(1) * z0 * k_pole / k_abs * rb, 2.0e-13_dp)
     end subroutine test_magnetic_recurrence
 
     subroutine test_homogeneous_static_limit(plasma)


### PR DESCRIPTION
## Summary

- evaluate the collisionless periodic magnetic-current factor with the derived regularized combination `z0/kAbs`
- preserve the magnitude-based stable response argument and the causal pole used by the magnetic-charge block
- add a direct positive/negative-`k_parallel` parity regression and update the corrected manufactured current reference

## Verification

- red: the new parity assertion failed against the former `z0/kPole` implementation
- green: `ctest --test-dir build -R '^(test_collisionless_fourier_kernel|test_collisionless_ion_assembly|test_periodic_assembly|test_periodic_solve|test_kim_solver_periodic)$' --output-on-failure`
- result: 5/5 tests passed
- independent review: no critical findings; the bounded numerical correction is consistent with the signed derivation

## Documentation follow-up

The external consolidated derivation and Mathematica source still encode the old recurrence and therefore do not regenerate this corrected oracle. That out-of-repository follow-up is recorded explicitly in #263; this PR does not modify external documentation.

Closes #254
Related: #263