### PR TITLE
fix(KIM): apply collisions_off before derived backgrounds

### DIFF
--- a/KIM/src/background_equilibrium/species_mod.f90
+++ b/KIM/src/background_equilibrium/species_mod.f90
@@ -401,7 +401,7 @@ module species_m
         ! Calculates BOTH boundary values (for FLR2 asymptotics) AND cell-center values (for kernels)
 
         use constants_m, only: e_charge, ev
-        use setup_m, only: omega, mphi_max
+        use setup_m, only: collisions_off, omega, mphi_max
         use grid_m, only: rg_grid
         use KIM_kinds_m, only: dp
         use config_m, only: ion_flr_scale_factor, ifunc_model_for_species, &
@@ -470,6 +470,19 @@ module species_m
                     + a1_temperature
                 plasma_in%spec(sp)%A2(j) = a2_force
 
+                if (collisions_off) then
+                    plasma_in%spec(sp)%x1(j) = 0.0_dp
+                    plasma_in%spec(sp)%x2(j, :) = 0.0_dp
+                    plasma_in%spec(sp)%I00(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I01(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I20(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I21(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I22(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I02(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I11(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I13(j, :) = (0.0_dp, 0.0_dp)
+                    cycle
+                end if
 
                 plasma_in%spec(sp)%x1(j) = plasma_in%kp(j) * plasma_in%spec(sp)%vT(j) / plasma_in%spec(sp)%nu(j)
                 do mphi = -mphi_max, mphi_max
@@ -507,6 +520,22 @@ module species_m
                     - plasma_in%spec(sp)%Zspec * e_charge / (plasma_in%spec(sp)%T_cc(j) * ev) * plasma_in%Er_cc(j) &
                     + a1_temperature
                 plasma_in%spec(sp)%A2_cc(j) = a2_force
+
+                if (collisions_off) then
+                    plasma_in%spec(sp)%x1_cc(j) = 0.0_dp
+                    plasma_in%spec(sp)%x2_cc(j, :) = 0.0_dp
+                    plasma_in%spec(sp)%I00_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I01_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I10_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I20_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I21_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I12_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I22_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I02_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I13_cc(j, :) = (0.0_dp, 0.0_dp)
+                    plasma_in%spec(sp)%I11_cc(j, :) = (0.0_dp, 0.0_dp)
+                    cycle
+                end if
 
                 plasma_in%spec(sp)%x1_cc(j) = 0.5d0 * (plasma_in%kp(j) + plasma_in%kp(j+1)) &
                     * plasma_in%spec(sp)%vT_cc(j) / plasma_in%spec(sp)%nu_cc(j)
@@ -633,13 +662,16 @@ module species_m
             plasma_in%spec(sp)%nu = plasma_in%spec(sp)%nu * collision_frequency_scale
         end do
 
+        if (collisions_off) then
+            do sp = 0, plasma_in%n_species-1
+                plasma_in%spec(sp)%nu = 0.0_dp
+            end do
+        end if
+
         do sp =0, plasma_in%n_species-1
             do i = 1,plasma_in%grid_size
                 plasma_in%spec(sp)%z0(i) = - (plasma_in%om_E(i) - omega - com_unit * plasma_in%spec(sp)%nu(i)) &
                     / (abs(plasma_in%kp(i)) * sqrt(2d0) * plasma_in%spec(sp)%vT(i) )
-                if (collisions_off .eqv. .true.)then
-                    plasma_in%spec(sp)%nu(i) = 0.0d0
-                end if
             end do
         end do
 

--- a/KIM/tests/test_collision_scale_z0.f90
+++ b/KIM/tests/test_collision_scale_z0.f90
@@ -32,6 +32,7 @@ program test_collision_scale_z0
     call test_z0_recomputed_across_resonance()
     call test_z0_matches_formula_off_resonance()
     call test_collision_scale_reaches_production_paths()
+    call test_collisions_off_reaches_derived_quantities()
 
     print *, 'All tests PASSED'
     stop 0
@@ -277,5 +278,48 @@ contains
         end do
         print *, 'PASS: collision scale reaches electron/ion nu, z0, and FP inputs'
     end subroutine test_collision_scale_reaches_production_paths
+
+    subroutine test_collisions_off_reaches_derived_quantities()
+        type(plasma_t) :: template
+        real(dp) :: nu(0:1), x1(0:1), x2(0:1)
+        complex(dp) :: z0(0:1)
+        integer :: sp
+
+        number_of_ion_species = 1
+        rescale_density = .false.
+        ion_flr_scale_factor = 1.0d0
+        collisions_off = .true.
+        mphi_max = 0
+        omega = 1.0d5
+        call build_collision_plasma(template)
+        call run_collision_scale_case(template, 1.0d0, nu, z0, x1, x2)
+
+        do sp = 0, 1
+            call require_close(nu(sp), 0.0_dp, 'collisions_off clears nu')
+            if (.not. ieee_is_finite(real(z0(sp), dp)) .or. &
+                    .not. ieee_is_finite(aimag(z0(sp))) .or. &
+                    .not. ieee_is_finite(x1(sp)) .or. .not. ieee_is_finite(x2(sp))) then
+                print *, 'FAIL: collisions_off produced non-finite derived values for species ', sp
+                print *, '  z0 = ', z0(sp), ' x1 = ', x1(sp), ' x2 = ', x2(sp)
+                error stop 'collisions_off derived values are not finite'
+            end if
+            call require_close(aimag(z0(sp)), 0.0_dp, 'collisions_off reaches z0')
+            call require_close(plasma%spec(sp)%nu_cc(1), 0.0_dp, &
+                               'collisions_off reaches cell-center nu')
+            call require_close(plasma%spec(sp)%x1_cc(1), 0.0_dp, &
+                               'collisions_off guards cell-center x1')
+            call require_close(plasma%spec(sp)%x2_cc(1, 0), 0.0_dp, &
+                               'collisions_off guards cell-center x2')
+            if (.not. ieee_is_finite(real(plasma%spec(sp)%I00(2, 0), dp)) .or. &
+                    .not. ieee_is_finite(aimag(plasma%spec(sp)%I00(2, 0))) .or. &
+                    .not. ieee_is_finite(real(plasma%spec(sp)%I00_cc(1, 0), dp)) .or. &
+                    .not. ieee_is_finite(aimag(plasma%spec(sp)%I00_cc(1, 0)))) then
+                error stop 'collisions_off produced a non-finite unused susceptibility'
+            end if
+        end do
+
+        collisions_off = .false.
+        print *, 'PASS: collisions_off reaches nu and z0 without singular FP inputs'
+    end subroutine test_collisions_off_reaches_derived_quantities
 
 end program test_collision_scale_z0


### PR DESCRIPTION
## Summary

- apply `collisions_off` before constructing the Krook dispersion argument `z0`
- retain thermodynamic forces while short-circuiting unused FP normalized inputs and susceptibility moments to finite zeros
- cover both boundary and cell-center background arrays with a regression

## Red/green evidence

Before the fix, the focused regression failed because `aimag(z0)` retained the calculated collision frequency and the FP normalization raised IEEE divide-by-zero/invalid flags. After the fix, all derived values covered by the background contract are finite and collision-free.

## Verification

- `test_collision_scale_z0`
- `test_susceptibility_collisionless_limit`
- `test_periodic_background`
- `test_periodic_background_build`
- `test_periodic_assembly`
- `git diff --check`

All passed.

## Scope

Optional WKB/FLR2/diagnostic consumers that explicitly divide by `nu` require model-specific collisionless-limit decisions and are tracked separately in #267.

Closes #256