### PR TITLE
build: pin thread-safe fortio revision

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,7 +17,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG a1e15804afa22d4721446e7885cd58f74f38a59d
+        GIT_TAG 30ad45c2a6e73a14b6a68c2b8286f89792e67318
     )
     FetchContent_MakeAvailable(fortio)
     set(BUILD_TESTING ${_KAMEL_BUILD_TESTING_SAVED})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,7 +17,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG d33fe5f3bea2a7d48f6362e93b584758f1077a22
+        GIT_TAG 88ce8de1fa42832b48df779f6d748e5873ee0bde
     )
     FetchContent_MakeAvailable(fortio)
     set(BUILD_TESTING ${_KAMEL_BUILD_TESTING_SAVED})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,7 +17,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG 30ad45c2a6e73a14b6a68c2b8286f89792e67318
+        GIT_TAG d33fe5f3bea2a7d48f6362e93b584758f1077a22
     )
     FetchContent_MakeAvailable(fortio)
     set(BUILD_TESTING ${_KAMEL_BUILD_TESTING_SAVED})


### PR DESCRIPTION
## Summary
- update the immutable Fortio dependency pin to the revision with race-checked NetCDF diagnostics
- retain the already validated ITP-only compatibility surface

## Verification
- bare fo: build, tests, and lint all pass
- the dependency revision passes Fortio ThreadSanitizer, OpenMP, native-performance, fpm, CMake, Linux, and Windows CI