### PR TITLE
build: pin final fortio subset

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,7 +17,7 @@ if(NOT TARGET fortio)
     FetchContent_Declare(
         fortio
         GIT_REPOSITORY https://github.com/lazy-fortran/fortio.git
-        GIT_TAG 88ce8de1fa42832b48df779f6d748e5873ee0bde
+        GIT_TAG e540614970bc63289339a7c8e120cc1ce608b23c
     )
     FetchContent_MakeAvailable(fortio)
     set(BUILD_TESTING ${_KAMEL_BUILD_TESTING_SAVED})


### PR DESCRIPTION
Pins KAMEL's direct Fortio FetchContent dependency to the finalized, dependency-test-isolated native subset revision.

Verified locally with bare `fo`: static analysis, build, tests, and lint all pass.