### PR TITLE
KIM: complete Phi/Br ion transport tensor

### DIFF
--- a/KIM/src/diagnostics/kim_qldiff_mod.f90
+++ b/KIM/src/diagnostics/kim_qldiff_mod.f90
@@ -5,7 +5,7 @@ module kim_qldiff_m
     implicit none
 
     private
-    public :: calc_dqle22, calc_dqli11_phi
+    public :: calc_dqle22, calc_dqli11_phi, calc_dqli_tensor
 
 contains
 
@@ -32,6 +32,52 @@ contains
         comfac = 0.5_dp/(nui*B0**2)
         dqli11 = comfac*sol**2*abs(Es)**2*real(symbI(0,0),dp)
     end function calc_dqli11_phi
+
+    subroutine calc_dqli_tensor(vTi, nui, om_E, B0, kpar, Es, Br, D11, D12, D21, D22)
+        ! Complete ion Phi/Br Onsager tensor in the integral formalism.
+        ! This is the scalar, local counterpart of QL-Balance's
+        ! calc_transport_coeffs_ornuhl; electrons intentionally retain their
+        ! existing drift-kinetic path.
+        use constants_m, only: sol
+        use config_m, only: resolved_ion_ifunc_conservation_model
+        real(dp), intent(in) :: vTi, nui, om_E, B0, kpar
+        complex(dp), intent(in) :: Es, Br
+        real(dp), intent(out) :: D11, D12, D21, D22
+        real(dp) :: x1, x2, comfac, epm2, brm2, epbr_re, epbr_im, d12a
+        complex(dp) :: symbI(0:3,0:3)
+        interface
+            subroutine getIfunc_model(x1, x2, conservation_model, symbI)
+                double precision, intent(in) :: x1, x2
+                integer, intent(in) :: conservation_model
+                double complex, dimension(0:3,0:3), intent(out) :: symbI
+            end subroutine getIfunc_model
+        end interface
+
+        x1 = kpar*vTi/nui
+        x2 = -om_E/nui
+        call getIfunc_model(x1, x2, resolved_ion_ifunc_conservation_model, symbI)
+
+        comfac = 0.5_dp/(nui*B0**2)
+        epm2 = sol**2*abs(Es)**2
+        brm2 = vTi**2*abs(Br)**2
+        epbr_re = 2.0_dp*sol*vTi*real(conjg(Es)*Br,dp)
+        epbr_im = 2.0_dp*sol*vTi*aimag(conjg(Es)*Br)
+
+        D11 = comfac*(epm2*real(symbI(0,0),dp) + epbr_re*real(symbI(1,0),dp) &
+             + brm2*real(symbI(1,1),dp))
+        D12 = comfac*(epm2*real(symbI(0,0)+0.5_dp*symbI(2,0),dp) &
+             + epbr_re*real(symbI(1,0)+0.25_dp*(symbI(3,0)+symbI(2,1)),dp) &
+             + brm2*real(symbI(1,1)+0.5_dp*symbI(3,1),dp))
+        D21 = D12
+        D22 = comfac*(epm2*real(2.0_dp*symbI(0,0)+symbI(2,0)+0.25_dp*symbI(2,2),dp) &
+             + epbr_re*real(2.0_dp*symbI(1,0)+0.5_dp*(symbI(3,0)+symbI(2,1)) &
+                              +0.25_dp*symbI(3,2),dp) &
+             + brm2*real(2.0_dp*symbI(1,1)+symbI(3,1)+0.25_dp*symbI(3,3),dp))
+
+        d12a = comfac*epbr_im*0.25_dp*aimag(symbI(2,1)-symbI(3,0))
+        D12 = D12 + d12a
+        D21 = D21 - d12a
+    end subroutine calc_dqli_tensor
 
     function calc_dqle22(vTe, nue, om_E, B0, kpar, Es, Br) result(dqle22)
         ! Quasilinear electron heat diffusion coefficient D_ql,e22, the

--- a/KIM/tests/test_kim_diagnostics.f90
+++ b/KIM/tests/test_kim_diagnostics.f90
@@ -2,7 +2,7 @@ program test_kim_diagnostics
 
     use KIM_kinds_m, only: dp
     use kim_diagnostics_m, only: integrate_Ipar, interp_local_complex
-    use kim_qldiff_m, only: calc_dqle22
+    use kim_qldiff_m, only: calc_dqle22, calc_dqli11_phi, calc_dqli_tensor
 
     implicit none
 
@@ -14,6 +14,7 @@ program test_kim_diagnostics
     call test_interp_local_complex()
     call test_dqle22_resonant('Dqle22 at resonance, omE/nue = 0.5', 0.5_dp)
     call test_dqle22_resonant('Dqle22 at resonance, omE/nue = 2.0', 2.0_dp)
+    call test_dqli_tensor_contract()
     call test_em_solve_writes_diagnostics_file()
     call test_em_solve_no_resonance_skips_file()
 
@@ -117,6 +118,27 @@ contains
 
         call assert_close(label, cmplx(dqle22, 0.0_dp, dp), &
                           cmplx(dqle22_exact, 0.0_dp, dp), 1.0e-2_dp)
+    end subroutine
+
+    subroutine test_dqli_tensor_contract()
+        real(dp), parameter :: vTi = 3.0e7_dp, nui = 2.0e5_dp
+        real(dp), parameter :: omE = 0.75_dp*nui, B0 = 1.8e4_dp, kpar = 1.0e-8_dp
+        complex(dp), parameter :: Es = cmplx(2.0e-3_dp, -1.0e-3_dp, dp)
+        complex(dp), parameter :: Br = cmplx(0.7_dp, 0.4_dp, dp)
+        real(dp) :: D11, D12, D21, D22, D11phi, D11zero, D12phi, D21phi, D22phi
+
+        call calc_dqli_tensor(vTi, nui, omE, B0, kpar, Es, Br, D11, D12, D21, D22)
+        D11phi = calc_dqli11_phi(vTi, nui, omE, B0, kpar, Es)
+        call calc_dqli_tensor(vTi, nui, omE, B0, kpar, Es, (0.0_dp,0.0_dp), &
+                              D11zero, D12phi, D21phi, D22phi)
+        call assert_close('ion tensor Phi-only D11 limit', cmplx(D11zero,0.0_dp,dp), &
+                          cmplx(D11phi,0.0_dp,dp), 1.0e-10_dp)
+        call calc_dqli_tensor(vTi, nui, omE, B0, kpar, Es, Br, D11, D12, D21, D22)
+        if (.not. (D11 > 0.0_dp .and. D22 > 0.0_dp)) error stop 'ion tensor diagonal is not positive'
+        if (abs(D11-D11zero) <= 1.0e-14_dp*max(1.0_dp,abs(D11))) &
+            error stop 'ion Br channel did not contribute to D11'
+        if (abs(D12) > huge(1.0_dp) .or. abs(D21) > huge(1.0_dp)) &
+            error stop 'ion tensor cross channel is non-finite'
     end subroutine
 
     subroutine test_em_solve_writes_diagnostics_file()


### PR DESCRIPTION
Closes #287. Adds the complete integral-formalism ion Phi/Br tensor D11, D12, D21, D22, including the complex cross-field channel and exact Phi-only reduction. Adds regression coverage to the KIM diagnostics test.