### PR TITLE
Issue #288: carry Bparallel through KiLCA/KIM

### DIFF
--- a/KIM/src/CMakeLists.txt
+++ b/KIM/src/CMakeLists.txt
@@ -58,7 +58,11 @@ if("${SUPERLU_FOUND}")
     message(" ====== SuperLU was found! =====")
     target_link_libraries(KIM_lib PUBLIC "${SUPERLU_LIBRARIES}")
     message("SuperLu libraries: ${SUPERLU_LIBRARIES}")
-    target_include_directories(KIM_lib PUBLIC "${SUPERLU_INCLUDES}")
+    # SuperLU headers are needed only while compiling KIM.  Keeping this
+    # include directory PRIVATE prevents FindSuperLU's Darwin SDK
+    # `usr/include` result from leaking into downstream C++ targets, where it
+    # breaks libc++'s include_next-based C headers.
+    target_include_directories(KIM_lib PRIVATE "${SUPERLU_INCLUDES}")
     message("${SUPERLU_INCLUDES}")
 endif()
 

--- a/QL-Balance/src/base/kim_wave_code_adapter.f90
+++ b/QL-Balance/src/base/kim_wave_code_adapter.f90
@@ -49,6 +49,9 @@ module kim_wave_code_adapter_m
     complex(8), allocatable :: kim_Et_modes(:,:)
     complex(8), allocatable :: kim_Ez_modes(:,:)
     complex(8), allocatable, public :: kim_Br_modes(:,:)
+    !! Parallel magnetic perturbation in RSP coordinates.  This is
+    !! exposed through wave_code_data%Bp, matching the KiLCA interface.
+    complex(8), allocatable, public :: kim_Bparallel_modes(:,:)
 
     !! Per-mode stored wave vectors (nrad, dim_mn)
     !! kp and ks depend on (m,n) via the equilibrium formulas.
@@ -294,6 +297,7 @@ contains
         if (allocated(kim_Et_modes)) deallocate(kim_Et_modes)
         if (allocated(kim_Ez_modes)) deallocate(kim_Ez_modes)
         if (allocated(kim_Br_modes)) deallocate(kim_Br_modes)
+        if (allocated(kim_Bparallel_modes)) deallocate(kim_Bparallel_modes)
         if (allocated(kim_kp_modes)) deallocate(kim_kp_modes)
         if (allocated(kim_ks_modes)) deallocate(kim_ks_modes)
         if (allocated(kim_jpar_modes)) deallocate(kim_jpar_modes)
@@ -306,6 +310,7 @@ contains
         allocate(kim_Et_modes(dim_r, dim_mn))
         allocate(kim_Ez_modes(dim_r, dim_mn))
         allocate(kim_Br_modes(dim_r, dim_mn))
+        allocate(kim_Bparallel_modes(dim_r, dim_mn))
         allocate(kim_kp_modes(dim_r, dim_mn))
         allocate(kim_ks_modes(dim_r, dim_mn))
         allocate(kim_jpar_modes(dim_r, dim_mn))
@@ -318,6 +323,7 @@ contains
         kim_Et_modes = (0.0d0, 0.0d0)
         kim_Ez_modes = (0.0d0, 0.0d0)
         kim_Br_modes = (0.0d0, 0.0d0)
+        kim_Bparallel_modes = (0.0d0, 0.0d0)
         kim_kp_modes = 0.0d0
         kim_ks_modes = 0.0d0
         kim_jpar_modes = (0.0d0, 0.0d0)
@@ -374,6 +380,14 @@ contains
             ! Br (radial magnetic field perturbation)
             call interp_complex_profile(kim_npts, kim_r, res%Br, &
                 dim_r, bal_r, kim_Br_modes(:, i_mn))
+
+            ! Bparallel is already represented in RSP coordinates by KIM;
+            ! store it separately so the wave-code adapter can expose it as
+            ! Bp without confusing it with the radial Br component.
+            if (allocated(res%Bparallel)) then
+                call interp_complex_profile(kim_npts, kim_r, res%Bparallel, &
+                    dim_r, bal_r, kim_Bparallel_modes(:, i_mn))
+            end if
 
             ! jpar (parallel current density: total, electron, ion)
             if (allocated(res%jpar)) then
@@ -550,15 +564,15 @@ contains
 
         Es = kim_Es_modes(:, i_mn)
         Br = kim_Br_modes(:, i_mn)
+        Bp = kim_Bparallel_modes(:, i_mn)
         Er = kim_Er_modes(:, i_mn)
         Ep = kim_Ep_modes(:, i_mn)
         Et = kim_Et_modes(:, i_mn)
         Ez = kim_Ez_modes(:, i_mn)
 
-        ! KIM does not compute magnetic field perturbation components
-        ! other than Br. Set remaining B components to zero.
+        ! KIM does not compute the cylindrical magnetic perturbations or the
+        ! perpendicular RSP component.  Bparallel is carried above as Bp.
         Bs = (0.0d0, 0.0d0)
-        Bp = (0.0d0, 0.0d0)
         Bt = (0.0d0, 0.0d0)
         Bz = (0.0d0, 0.0d0)
 
@@ -802,6 +816,7 @@ contains
             kim_Ez_modes(i, i_mn) = (0.0d0, 0.0d0)
             ! Total Br = vacuum Br beyond plasma
             kim_Br_modes(i, i_mn) = kim_vac_Br(i, i_mn)
+            kim_Bparallel_modes(i, i_mn) = (0.0d0, 0.0d0)
             ! Wave vectors not physical in vacuum
             kim_kp_modes(i, i_mn) = 0.0d0
             kim_ks_modes(i, i_mn) = 0.0d0

--- a/QL-Balance/src/test/test_kim_adapter.f90
+++ b/QL-Balance/src/test/test_kim_adapter.f90
@@ -10,10 +10,11 @@ program test_kim_adapter
     !
     use kim_wave_code_adapter_m, only: interp_complex_profile, kim_initialize, &
         kim_update_profiles, kim_run_for_all_modes, kim_Br_modes, kim_vac_Br
+    use kim_wave_code_adapter_m, only: kim_Bparallel_modes, kim_get_wave_fields
     use control_mod, only: wave_code, kim_config_path, kim_profiles_from_balance, &
         type_of_run
     use wave_code_data, only: dim_mn, m_vals, n_vals, r, n, Te, Ti, q, &
-        Vth, Vz, dPhi0
+        Vth, Vz, dPhi0, Bp
     use plasma_parameters, only: params_b
     use grid_mod, only: Ercov
     use baseparam_mod, only: ev
@@ -221,6 +222,17 @@ contains
 
         call kim_update_profiles()
         call kim_run_for_all_modes()
+
+        ! B_parallel is a first-class KIM output and must reach the
+        ! wave-code contract as Bp (the RSP parallel component).
+        call kim_get_wave_fields(1)
+        if (maxval(abs(Bp - kim_Bparallel_modes(:, 1))) <= 1.0d-12) then
+            print '(A)', "  PASS: KIM Bparallel reaches wave_code_data Bp"
+            num_passed = num_passed + 1
+        else
+            print '(A)', "  FAIL: KIM Bparallel was not copied to Bp"
+            num_failed = num_failed + 1
+        end if
 
         allocate(br_rescaled(npts))
         br_rescaled = kim_Br_modes(:, 1)


### PR DESCRIPTION
Closes #288

Carries KIM's Bparallel result through the periodic adapter into the shared wave-code contract as Bp, matching KiLCA's RSP parallel magnetic component. Adds adapter regression coverage and keeps non-parallel KIM magnetic components explicit zeros.

Also prevents SuperLU's Darwin SDK include path from propagating into downstream C++ targets, addressing the observed libc++ <cmath>/<cstdio> failure.