### PR TITLE
Issue #292: normalize periodic KIM response to target current

### DIFF
--- a/QL-Balance/CMakeLists.txt
+++ b/QL-Balance/CMakeLists.txt
@@ -62,6 +62,7 @@ set(balance_lib_base_fortran_sources
     ${base_balance_src}/grid_mod.f90
     ${base_balance_src}/h5mod.f90
     ${base_balance_src}/integrate_parallel_current.f90
+    ${base_balance_src}/periodic_current_normalization_m.f90
     ${base_balance_src}/kim_wave_code_adapter.f90
     ${base_balance_src}/magnetic_island_width.f90
     ${base_balance_src}/matrix_mod.f90

--- a/QL-Balance/src/base/kim_wave_code_adapter.f90
+++ b/QL-Balance/src/base/kim_wave_code_adapter.f90
@@ -32,6 +32,7 @@ module kim_wave_code_adapter_m
     public :: interp_complex_profile  ! exposed for testing
     public :: kim_periodic_mode_selected
     public :: kim_D_ion_modes, kim_transition_weights
+    public :: kim_periodic_scale_modes, kim_periodic_current_unit, kim_periodic_scale_status
 
     !! Module-level KIM solver handle (reused across calls)
     type(kim_solver_t) :: kim_handle
@@ -57,6 +58,9 @@ module kim_wave_code_adapter_m
     complex(8), allocatable, public :: kim_Bparallel_modes(:,:)
     real(8), allocatable :: kim_D_ion_modes(:,:,:,:)
     real(8), allocatable :: kim_transition_weights(:,:)
+    complex(8), allocatable :: kim_periodic_scale_modes(:)
+    complex(8), allocatable :: kim_periodic_current_unit(:)
+    integer, allocatable :: kim_periodic_scale_status(:)
 
     !! Per-mode stored wave vectors (nrad, dim_mn)
     !! kp and ks depend on (m,n) via the equilibrium formulas.
@@ -284,8 +288,10 @@ contains
             dim_r, bal_r => r, &
             wcd_kp => kp, wcd_ks => ks, wcd_om_E => om_E, &
             wcd_B0 => B0, wcd_nue => nue, wcd_nui => nui, &
-            wcd_B0t => B0t, wcd_B0z => B0z, wcd_Vth => Vth, wcd_Vz => Vz
+            wcd_B0t => B0t, wcd_B0z => B0z, wcd_Vth => Vth, wcd_Vz => Vz, &
+            I_par_toroidal
         use control_mod, only: kim_profiles_from_balance
+        use periodic_current_normalization_m, only: integrate_trusted_current, periodic_drive_scale
 
         implicit none
 
@@ -293,6 +299,8 @@ contains
         integer :: i_mn, ierr, kim_npts, kim_plasma_npts, nrad_inside, i
         real(8), allocatable :: kim_r(:), kim_plasma_r(:), weights(:)
         real(8) :: core_lo, core_hi, width
+        complex(8) :: current_unit, drive_scale
+        integer :: scale_status
         logical :: periodic
 
         periodic = kim_periodic_mode_selected()
@@ -309,6 +317,9 @@ contains
         if (allocated(kim_Bparallel_modes)) deallocate(kim_Bparallel_modes)
         if (allocated(kim_D_ion_modes)) deallocate(kim_D_ion_modes)
         if (allocated(kim_transition_weights)) deallocate(kim_transition_weights)
+        if (allocated(kim_periodic_scale_modes)) deallocate(kim_periodic_scale_modes)
+        if (allocated(kim_periodic_current_unit)) deallocate(kim_periodic_current_unit)
+        if (allocated(kim_periodic_scale_status)) deallocate(kim_periodic_scale_status)
         if (allocated(kim_kp_modes)) deallocate(kim_kp_modes)
         if (allocated(kim_ks_modes)) deallocate(kim_ks_modes)
         if (allocated(kim_jpar_modes)) deallocate(kim_jpar_modes)
@@ -324,6 +335,8 @@ contains
         allocate(kim_Bparallel_modes(dim_r, dim_mn))
         allocate(kim_D_ion_modes(2, 2, dim_r, dim_mn))
         allocate(kim_transition_weights(dim_r, dim_mn))
+        allocate(kim_periodic_scale_modes(dim_mn), kim_periodic_current_unit(dim_mn), &
+            kim_periodic_scale_status(dim_mn))
         allocate(kim_kp_modes(dim_r, dim_mn))
         allocate(kim_ks_modes(dim_r, dim_mn))
         allocate(kim_jpar_modes(dim_r, dim_mn))
@@ -339,6 +352,9 @@ contains
         kim_Bparallel_modes = (0.0d0, 0.0d0)
         kim_D_ion_modes = 0.0d0
         kim_transition_weights = 1.0d0
+        kim_periodic_scale_modes = (1.0d0, 0.0d0)
+        kim_periodic_current_unit = (0.0d0, 0.0d0)
+        kim_periodic_scale_status = 0
         kim_kp_modes = 0.0d0
         kim_ks_modes = 0.0d0
         kim_jpar_modes = (0.0d0, 0.0d0)
@@ -373,6 +389,31 @@ contains
                     error stop 'periodic KIM result lacks compact embedding metadata'
                 end if
                 allocate(weights(dim_r))
+                current_unit = integrate_trusted_current(kim_r, res%jpar, core_lo, core_hi)
+                call periodic_drive_scale(I_par_toroidal, current_unit, 2.99792458d10, &
+                    1.0d-30, 1.0d12, 1.0d0, drive_scale, scale_status)
+                kim_periodic_current_unit(i_mn) = current_unit
+                kim_periodic_scale_modes(i_mn) = drive_scale
+                kim_periodic_scale_status(i_mn) = scale_status
+                write(*,*) '  periodic KIM current normalization: mode ', i_mn, &
+                    ' unit=', current_unit, ' scale=', drive_scale, ' status=', scale_status
+                if (I_par_toroidal > 0.0d0 .and. scale_status /= 0) then
+                    write(*,*) 'WARNING: periodic current normalization guard status ', scale_status, &
+                        ' for mode ', i_mn
+                end if
+                if (I_par_toroidal > 0.0d0 .and. scale_status == 0) then
+                    res%Es = drive_scale*res%Es
+                    res%Ep = drive_scale*res%Ep
+                    res%Er = drive_scale*res%Er
+                    res%Etheta = drive_scale*res%Etheta
+                    res%Ez = drive_scale*res%Ez
+                    res%Br = drive_scale*res%Br
+                    if (allocated(res%Bparallel)) res%Bparallel = drive_scale*res%Bparallel
+                    if (allocated(res%jpar)) res%jpar = drive_scale*res%jpar
+                    if (allocated(res%jpar_e)) res%jpar_e = drive_scale*res%jpar_e
+                    if (allocated(res%jpar_i)) res%jpar_i = drive_scale*res%jpar_i
+                    if (allocated(res%D_ion)) res%D_ion = abs(drive_scale)**2*res%D_ion
+                end if
             end if
 
             if (i_mn == 1) then

--- a/QL-Balance/src/base/periodic_current_normalization_m.f90
+++ b/QL-Balance/src/base/periodic_current_normalization_m.f90
@@ -1,0 +1,55 @@
+module periodic_current_normalization_m
+    !! Target-current normalization for one linear periodic response.
+    !! integrate_trusted_current returns int(J_parallel*r dr); the scale
+    !! routine applies the documented 2*pi cylindrical-current convention.
+    use QLBalance_kinds, only: dp
+    implicit none
+    private
+    public :: integrate_trusted_current, periodic_drive_scale
+
+contains
+
+    complex(dp) function integrate_trusted_current(r, jpar, core_lo, core_hi) result(current)
+        real(dp), intent(in) :: r(:), core_lo, core_hi
+        complex(dp), intent(in) :: jpar(:)
+        integer :: i
+        real(dp) :: left, right, midpoint
+        if (size(r) /= size(jpar) .or. size(r) < 2) error stop 'current integration grid mismatch'
+        current = (0.0_dp, 0.0_dp)
+        do i = 1, size(r)-1
+            midpoint = 0.5_dp*(r(i)+r(i+1))
+            if (midpoint < core_lo .or. midpoint > core_hi) cycle
+            left = max(r(i), core_lo)
+            right = min(r(i+1), core_hi)
+            if (right > left) current = current + 0.5_dp*(r(i+1)*jpar(i+1)+r(i)*jpar(i))*(right-left)
+        end do
+    end function integrate_trusted_current
+
+    subroutine periodic_drive_scale(target_current, unit_current, c_light, current_floor, &
+                                    max_scale_ratio, relaxation, scale, status)
+        real(dp), intent(in) :: target_current, c_light, current_floor, max_scale_ratio, relaxation
+        complex(dp), intent(in) :: unit_current
+        complex(dp), intent(out) :: scale
+        integer, intent(out) :: status
+        real(dp) :: ratio
+        status = 0
+        scale = (1.0_dp, 0.0_dp)
+        if (target_current <= 0.0_dp .or. c_light <= 0.0_dp .or. current_floor <= 0.0_dp &
+            .or. max_scale_ratio <= 0.0_dp .or. relaxation <= 0.0_dp .or. relaxation > 1.0_dp) then
+            status = 1
+            return
+        end if
+        if (abs(unit_current) <= current_floor) then
+            status = 2
+            return
+        end if
+        scale = relaxation * (target_current*c_light/(unit_current)) / (2.0_dp*acos(-1.0_dp)) &
+            + (1.0_dp-relaxation)*(1.0_dp,0.0_dp)
+        ratio = abs(scale)
+        if (.not. (ratio == ratio) .or. ratio > max_scale_ratio) then
+            status = 3
+            scale = (1.0_dp, 0.0_dp)
+        end if
+    end subroutine periodic_drive_scale
+
+end module periodic_current_normalization_m

--- a/QL-Balance/src/base/transp_coeffs_mod.f90
+++ b/QL-Balance/src/base/transp_coeffs_mod.f90
@@ -41,6 +41,7 @@ module transp_coeffs_mod
         !   So: antenna_factor = (I_par_toroidal * c / (2*pi * |Ipar|))^2
         !
         use wave_code_data, only: antenna_factor, I_par_toroidal
+        use control_mod, only: wave_code, kim_run_type
         use grid_mod, only: Ipar
 
         implicit none
@@ -48,6 +49,15 @@ module transp_coeffs_mod
         double precision, parameter :: c_light = 2.99792458d10   ! speed of light [cm/s]
         double precision, parameter :: twopi = 6.283185307179586d0
         double precision :: I_tor_cgs, I_cyl_cgs
+
+        ! Periodic KIM responses are normalized at their linear source before
+        ! diffusion assembly.  Do not apply the legacy antenna factor a
+        ! second time to fields/tensors that already carry |s| and |s|^2.
+        if (trim(wave_code) == 'KIM' .and. trim(kim_run_type) == 'electrostatic_periodic') then
+            antenna_factor = 1.0d0
+            write(*,*) 'Periodic KIM response already target-current normalized; antenna_factor = 1'
+            return
+        end if
 
         if (I_par_toroidal <= 0.0d0) return  ! legacy mode: use namelist antenna_factor
 

--- a/QL-Balance/src/test/CMakeLists.txt
+++ b/QL-Balance/src/test/CMakeLists.txt
@@ -52,3 +52,7 @@ add_fortran_test(test_periodic_response_contract)
 add_executable(test_periodic_kim_selector.x test_periodic_kim_selector.f90)
 target_link_libraries(test_periodic_kim_selector.x PUBLIC ql-balance_lib)
 add_fortran_test(test_periodic_kim_selector)
+
+add_executable(test_periodic_current_normalization.x test_periodic_current_normalization.f90)
+target_link_libraries(test_periodic_current_normalization.x PUBLIC ql-balance_lib)
+add_fortran_test(test_periodic_current_normalization)

--- a/QL-Balance/src/test/test_periodic_current_normalization.f90
+++ b/QL-Balance/src/test/test_periodic_current_normalization.f90
@@ -1,0 +1,22 @@
+program test_periodic_current_normalization
+    use QLBalance_kinds, only: dp
+    use periodic_current_normalization_m, only: integrate_trusted_current, periodic_drive_scale
+    implicit none
+    real(dp), parameter :: r(5) = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp]
+    complex(dp), parameter :: j(5) = [(1.0_dp,0.0_dp), (1.0_dp,0.0_dp), &
+                                      (1.0_dp,0.0_dp), (1.0_dp,0.0_dp), (1.0_dp,0.0_dp)]
+    complex(dp) :: unit_current, scale
+    integer :: status
+    unit_current = integrate_trusted_current(r, j, 1.0_dp, 3.0_dp)
+    if (abs(unit_current - 4.0_dp) > 1.0e-12_dp) &
+        error stop 'trusted current integral geometry'
+    call periodic_drive_scale(8.0_dp, unit_current, 1.0_dp, 1.0e-20_dp, 1.0e6_dp, 1.0_dp, scale, status)
+    if (status /= 0 .or. abs(scale - cmplx(1.0_dp/acos(-1.0_dp),0.0_dp,dp)) > 1.0e-12_dp) &
+        error stop 'target current scale'
+    call periodic_drive_scale(16.0_dp, unit_current, 1.0_dp, 1.0e-20_dp, 1.0e6_dp, 1.0_dp, scale, status)
+    if (status /= 0 .or. abs(scale - 2.0_dp*cmplx(1.0_dp/acos(-1.0_dp),0.0_dp,dp)) > 1.0e-12_dp) &
+        error stop 'target current doubling'
+    call periodic_drive_scale(8.0_dp, (0.0_dp,0.0_dp), 1.0_dp, 1.0e-20_dp, 1.0e6_dp, 1.0_dp, scale, status)
+    if (status /= 2) error stop 'current floor guard'
+    print *, 'periodic current normalization tests passed'
+end program test_periodic_current_normalization

--- a/docs/benchmarks/2026-08-12-kim-292-target-current-normalization.md
+++ b/docs/benchmarks/2026-08-12-kim-292-target-current-normalization.md
@@ -1,0 +1,22 @@
+# KIM #292: target-current normalization
+
+For periodic KIM, each mode is first solved with the unit constant-\(\psi\)
+drive. On the trusted current layer, the adapter evaluates
+
+\[
+I_{\rm unit}=\int J_\parallel r\,dr,
+\qquad
+s=\frac{c I_{\parallel,\rm tor}}{2\pi I_{\rm unit}}.
+\]
+
+The linear response fields \((B_r,B_\parallel,E,J_\parallel)\) are multiplied
+by the complex amplitude \(s\); the ion tensor is multiplied once by
+\(|s|^2\). The legacy antenna-factor rescaling is disabled for this path, so
+it cannot apply a second \(|s|^2\) factor. A zero target keeps the explicit
+unit-response benchmark behavior.
+
+`periodic_current_normalization_m` owns the trusted-layer quadrature, the
+2-\(\pi\) convention, relaxation, current-floor, non-finite, and maximum
+scale-ratio guards. The adapter records per-mode unit current, complex scale,
+and guard status. `test_periodic_current_normalization` covers geometry,
+target doubling, and the current-floor guard.


### PR DESCRIPTION
Closes #292.

Adds explicit complex target-current normalization for periodic KIM responses. Unit constant-psi fields are integrated on the trusted current layer; linear fields/currents scale by s and ion tensors by |s|^2 exactly once. The legacy antenna factor is disabled for this path to prevent double scaling.

Includes current geometry/2-pi convention, relaxation and safety guards, per-mode unit-current/scale/status diagnostics, documentation, and regression tests for target doubling and current-floor behavior.

Validation: periodic adapter/embedding/selector suite 5/5 passed; ql-balance_lib builds.