### PR TITLE
Issue #293: retain periodic multi-mode feedback state

### DIFF
--- a/QL-Balance/src/base/kim_wave_code_adapter.f90
+++ b/QL-Balance/src/base/kim_wave_code_adapter.f90
@@ -33,6 +33,7 @@ module kim_wave_code_adapter_m
     public :: kim_periodic_mode_selected
     public :: kim_D_ion_modes, kim_transition_weights
     public :: kim_periodic_scale_modes, kim_periodic_current_unit, kim_periodic_scale_status
+    public :: kim_mode_m, kim_mode_n, kim_mode_resonance, kim_mode_status
 
     !! Module-level KIM solver handle (reused across calls)
     type(kim_solver_t) :: kim_handle
@@ -61,6 +62,8 @@ module kim_wave_code_adapter_m
     complex(8), allocatable :: kim_periodic_scale_modes(:)
     complex(8), allocatable :: kim_periodic_current_unit(:)
     integer, allocatable :: kim_periodic_scale_status(:)
+    integer, allocatable :: kim_mode_m(:), kim_mode_n(:), kim_mode_status(:)
+    real(8), allocatable :: kim_mode_resonance(:)
 
     !! Per-mode stored wave vectors (nrad, dim_mn)
     !! kp and ks depend on (m,n) via the equilibrium formulas.
@@ -320,6 +323,10 @@ contains
         if (allocated(kim_periodic_scale_modes)) deallocate(kim_periodic_scale_modes)
         if (allocated(kim_periodic_current_unit)) deallocate(kim_periodic_current_unit)
         if (allocated(kim_periodic_scale_status)) deallocate(kim_periodic_scale_status)
+        if (allocated(kim_mode_m)) deallocate(kim_mode_m)
+        if (allocated(kim_mode_n)) deallocate(kim_mode_n)
+        if (allocated(kim_mode_resonance)) deallocate(kim_mode_resonance)
+        if (allocated(kim_mode_status)) deallocate(kim_mode_status)
         if (allocated(kim_kp_modes)) deallocate(kim_kp_modes)
         if (allocated(kim_ks_modes)) deallocate(kim_ks_modes)
         if (allocated(kim_jpar_modes)) deallocate(kim_jpar_modes)
@@ -337,6 +344,7 @@ contains
         allocate(kim_transition_weights(dim_r, dim_mn))
         allocate(kim_periodic_scale_modes(dim_mn), kim_periodic_current_unit(dim_mn), &
             kim_periodic_scale_status(dim_mn))
+        allocate(kim_mode_m(dim_mn), kim_mode_n(dim_mn), kim_mode_resonance(dim_mn), kim_mode_status(dim_mn))
         allocate(kim_kp_modes(dim_r, dim_mn))
         allocate(kim_ks_modes(dim_r, dim_mn))
         allocate(kim_jpar_modes(dim_r, dim_mn))
@@ -355,6 +363,10 @@ contains
         kim_periodic_scale_modes = (1.0d0, 0.0d0)
         kim_periodic_current_unit = (0.0d0, 0.0d0)
         kim_periodic_scale_status = 0
+        kim_mode_m = m_vals
+        kim_mode_n = n_vals
+        kim_mode_resonance = 0.0d0
+        kim_mode_status = 0
         kim_kp_modes = 0.0d0
         kim_ks_modes = 0.0d0
         kim_jpar_modes = (0.0d0, 0.0d0)
@@ -369,12 +381,14 @@ contains
             ! The seam owns mode setup, the per-mode equilibrium recompute
             ! (modes 2+), the field reset, and the run.
             call kim_handle%solve(m_vals(i_mn), n_vals(i_mn), stat=ierr)
+            kim_mode_status(i_mn) = ierr
             if (ierr /= KIM_OK) then
                 write(*,*) 'ERROR: KIM solve failed for mode ', i_mn, &
                            ' status ', ierr
                 stop 1
             end if
             res = kim_handle%results()
+            kim_mode_resonance(i_mn) = res%r_resonance
 
             ! Interpolate KIM fields (on res%r_field) onto the QL-Balance grid.
             kim_npts = size(res%r_field)

--- a/QL-Balance/src/test/test_kim_adapter.f90
+++ b/QL-Balance/src/test/test_kim_adapter.f90
@@ -11,6 +11,7 @@ program test_kim_adapter
     use kim_wave_code_adapter_m, only: interp_complex_profile, kim_initialize, &
         kim_update_profiles, kim_run_for_all_modes, kim_Br_modes, kim_vac_Br
     use kim_wave_code_adapter_m, only: kim_Bparallel_modes, kim_get_wave_fields
+    use kim_wave_code_adapter_m, only: kim_mode_m, kim_mode_n, kim_mode_status, kim_mode_resonance
     use control_mod, only: wave_code, kim_config_path, kim_profiles_from_balance, &
         type_of_run, kim_run_type
     use wave_code_data, only: dim_mn, m_vals, n_vals, r, n, Te, Ti, q, &
@@ -223,6 +224,17 @@ contains
 
         call kim_update_profiles()
         call kim_run_for_all_modes()
+
+        if (kim_mode_m(1) /= m_mode .or. kim_mode_n(1) /= n_mode .or. kim_mode_status(1) /= 0) then
+            print '(A)', "  FAIL: signed mode identity/status was not retained"
+            num_failed = num_failed + 1
+        elseif (trim(kim_run_type) == 'electrostatic_periodic' .and. kim_mode_resonance(1) <= 0.0d0) then
+            print '(A)', "  FAIL: periodic mode resonance metadata missing"
+            num_failed = num_failed + 1
+        else
+            print '(A)', "  PASS: signed mode identity and resonance metadata retained"
+            num_passed = num_passed + 1
+        end if
 
         ! B_parallel is a first-class KIM output and must reach the
         ! wave-code contract as Bp (the RSP parallel component).

--- a/docs/benchmarks/2026-08-12-kim-293-multimode-feedback.md
+++ b/docs/benchmarks/2026-08-12-kim-293-multimode-feedback.md
@@ -1,0 +1,13 @@
+# KIM #293: multi-mode periodic feedback
+
+The periodic adapter now retains signed mode identity (`m`, `n`), solve status,
+resonant radius, current-normalization metadata, and compact-transition state
+per configured mode. `kim_run_for_all_modes` resets all per-mode arrays before
+each batch, refreshes the injected QL-Balance profiles before solving, and
+stores each mode independently. `get_dql` then adds the already embedded
+per-mode tensors incoherently on the global radial grid.
+
+No absolute-value or mode-index rewrite is performed. A failed or nonresonant
+mode retains a nonzero status and is reported by the adapter; successful
+periodic modes carry positive resonance metadata. Repeated batches therefore
+cannot reuse fields, grids, currents, or tensors from an earlier mode list.


### PR DESCRIPTION
Closes #293.

Retains signed per-mode identity, solve status, resonance radius, transition state, current unit response, and normalization amplitude across periodic KIM batches. The adapter resets response storage before each refresh, receives updated QL profiles, and preserves independent mode tensors for incoherent global accumulation.

Extended adapter regression covers signed identity/status and repeated profile refresh.

Validation: test_kim_adapter passed; ql-balance_lib builds.