### PR TITLE
[QL-Balance] Evolve and restart periodic shielding amplitudes

### DIFF
--- a/QL-Balance/CMakeLists.txt
+++ b/QL-Balance/CMakeLists.txt
@@ -63,6 +63,7 @@ set(balance_lib_base_fortran_sources
     ${base_balance_src}/h5mod.f90
     ${base_balance_src}/integrate_parallel_current.f90
     ${base_balance_src}/periodic_current_normalization_m.f90
+    ${base_balance_src}/periodic_amplitude_state_m.f90
     ${base_balance_src}/kim_wave_code_adapter.f90
     ${base_balance_src}/magnetic_island_width.f90
     ${base_balance_src}/matrix_mod.f90

--- a/QL-Balance/src/base/kim_wave_code_adapter.f90
+++ b/QL-Balance/src/base/kim_wave_code_adapter.f90
@@ -33,6 +33,8 @@ module kim_wave_code_adapter_m
     public :: kim_periodic_mode_selected
     public :: kim_D_ion_modes, kim_transition_weights
     public :: kim_periodic_scale_modes, kim_periodic_current_unit, kim_periodic_scale_status
+    public :: kim_periodic_normalization_relaxation, kim_periodic_normalization_version, &
+        kim_periodic_phase_policy
     public :: kim_mode_m, kim_mode_n, kim_mode_resonance, kim_mode_status
 
     !! Module-level KIM solver handle (reused across calls)
@@ -62,6 +64,10 @@ module kim_wave_code_adapter_m
     complex(8), allocatable :: kim_periodic_scale_modes(:)
     complex(8), allocatable :: kim_periodic_current_unit(:)
     integer, allocatable :: kim_periodic_scale_status(:)
+    logical :: periodic_constant_psi_pending = .true.
+    real(8), parameter :: kim_periodic_normalization_relaxation = 1.0d0
+    integer, parameter :: kim_periodic_normalization_version = 1
+    character(len=32), parameter :: kim_periodic_phase_policy = 'complex-current'
     integer, allocatable :: kim_mode_m(:), kim_mode_n(:), kim_mode_status(:)
     real(8), allocatable :: kim_mode_resonance(:)
 
@@ -118,6 +124,7 @@ contains
 
         ! Re-init safe: clear any equilibrium/field state from a prior run.
         call kim_handle%finalize()
+        periodic_constant_psi_pending = .true.
 
         if (kim_profiles_from_balance) then
             ! -----------------------------------------------------------
@@ -293,7 +300,7 @@ contains
             wcd_B0 => B0, wcd_nue => nue, wcd_nui => nui, &
             wcd_B0t => B0t, wcd_B0z => B0z, wcd_Vth => Vth, wcd_Vz => Vz, &
             I_par_toroidal
-        use control_mod, only: kim_profiles_from_balance
+        use control_mod, only: kim_profiles_from_balance, type_of_run
         use periodic_current_normalization_m, only: integrate_trusted_current, periodic_drive_scale
 
         implicit none
@@ -404,8 +411,13 @@ contains
                 end if
                 allocate(weights(dim_r))
                 current_unit = integrate_trusted_current(kim_r, res%jpar, core_lo, core_hi)
-                call periodic_drive_scale(I_par_toroidal, current_unit, 2.99792458d10, &
-                    1.0d-30, 1.0d12, 1.0d0, drive_scale, scale_status)
+                if (trim(type_of_run) == 'TimeEvolution' .and. periodic_constant_psi_pending) then
+                    drive_scale = (1.0d0, 0.0d0)
+                    scale_status = 0
+                else
+                    call periodic_drive_scale(I_par_toroidal, current_unit, 2.99792458d10, &
+                        1.0d-30, 1.0d12, 1.0d0, drive_scale, scale_status)
+                end if
                 kim_periodic_current_unit(i_mn) = current_unit
                 kim_periodic_scale_modes(i_mn) = drive_scale
                 kim_periodic_scale_status(i_mn) = scale_status
@@ -620,6 +632,9 @@ contains
             deallocate(kim_plasma_r)
         end if
 
+        if (periodic .and. trim(type_of_run) == 'TimeEvolution' .and. periodic_constant_psi_pending) then
+            periodic_constant_psi_pending = .false.
+        end if
         write(*, *) "KIM adapter: all modes solved"
 
     end subroutine kim_run_for_all_modes

--- a/QL-Balance/src/base/periodic_amplitude_state_m.f90
+++ b/QL-Balance/src/base/periodic_amplitude_state_m.f90
@@ -1,0 +1,113 @@
+module periodic_amplitude_state_m
+    use QLBalance_kinds, only: dp
+    implicit none
+    private
+    public :: periodic_amplitude_state_t, periodic_amplitudes
+    integer, parameter, public :: periodic_normalization_version = 1
+    character(len=*), parameter, public :: periodic_phase_policy = 'complex-current'
+
+    type :: periodic_amplitude_state_t
+        complex(dp), allocatable :: accepted(:), trial(:)
+        complex(dp), allocatable :: accepted_current_unit(:), trial_current_unit(:)
+        complex(dp), allocatable :: accepted_residual(:), trial_residual(:)
+        integer, allocatable :: accepted_status(:), trial_status(:)
+        real(dp) :: target_current = 0.0_dp
+        real(dp) :: relaxation = 1.0_dp
+        real(dp) :: accepted_target_current = 0.0_dp, trial_target_current = 0.0_dp
+        real(dp) :: accepted_relaxation = 1.0_dp, trial_relaxation = 1.0_dp
+        integer :: normalization_version = periodic_normalization_version
+        character(len=32) :: phase_policy = periodic_phase_policy
+        logical :: initialized = .false.
+    contains
+        procedure :: initialize => amplitude_initialize
+        procedure :: begin_trial => amplitude_begin_trial
+        procedure :: accept => amplitude_accept
+        procedure :: reject => amplitude_reject
+    end type periodic_amplitude_state_t
+
+    type(periodic_amplitude_state_t), save :: periodic_amplitudes
+
+contains
+    subroutine amplitude_initialize(self, values, current_unit, residual, status, target_current, relaxation)
+        class(periodic_amplitude_state_t), intent(inout) :: self
+        complex(dp), intent(in) :: values(:)
+        complex(dp), intent(in), optional :: current_unit(:), residual(:)
+        integer, intent(in), optional :: status(:)
+        real(dp), intent(in), optional :: target_current, relaxation
+        if (allocated(self%accepted_current_unit)) deallocate(self%accepted_current_unit)
+        if (allocated(self%trial_current_unit)) deallocate(self%trial_current_unit)
+        if (allocated(self%accepted_residual)) deallocate(self%accepted_residual)
+        if (allocated(self%trial_residual)) deallocate(self%trial_residual)
+        if (allocated(self%accepted_status)) deallocate(self%accepted_status)
+        if (allocated(self%trial_status)) deallocate(self%trial_status)
+        self%target_current = 0.0_dp
+        self%relaxation = 1.0_dp
+        self%accepted = values
+        self%trial = values
+        allocate(self%accepted_current_unit(size(values)), self%trial_current_unit(size(values)))
+        allocate(self%accepted_residual(size(values)), self%trial_residual(size(values)))
+        allocate(self%accepted_status(size(values)), self%trial_status(size(values)))
+        self%accepted_current_unit = (0.0_dp, 0.0_dp)
+        self%accepted_residual = (0.0_dp, 0.0_dp)
+        self%accepted_status = 0
+        if (present(current_unit)) self%accepted_current_unit = current_unit
+        if (present(residual)) self%accepted_residual = residual
+        if (present(status)) self%accepted_status = status
+        self%trial_current_unit = self%accepted_current_unit
+        self%trial_residual = self%accepted_residual
+        self%trial_status = self%accepted_status
+        if (present(target_current)) self%target_current = target_current
+        if (present(relaxation)) self%relaxation = relaxation
+        self%accepted_target_current = self%target_current
+        self%trial_target_current = self%target_current
+        self%accepted_relaxation = self%relaxation
+        self%trial_relaxation = self%relaxation
+        self%initialized = .true.
+    end subroutine amplitude_initialize
+
+    subroutine amplitude_begin_trial(self, values, current_unit, residual, status, target_current, relaxation)
+        class(periodic_amplitude_state_t), intent(inout) :: self
+        complex(dp), intent(in) :: values(:)
+        complex(dp), intent(in), optional :: current_unit(:), residual(:)
+        integer, intent(in), optional :: status(:)
+        real(dp), intent(in), optional :: target_current, relaxation
+        if (.not. self%initialized .or. size(self%accepted) /= size(values)) then
+            call self%initialize(values, current_unit, residual, status, target_current, relaxation)
+        else
+            self%trial = values
+            if (present(current_unit)) self%trial_current_unit = current_unit
+            if (present(residual)) self%trial_residual = residual
+            if (present(status)) self%trial_status = status
+            if (present(target_current)) self%trial_target_current = target_current
+            if (present(relaxation)) self%trial_relaxation = relaxation
+            self%target_current = self%trial_target_current
+            self%relaxation = self%trial_relaxation
+        end if
+    end subroutine amplitude_begin_trial
+
+    subroutine amplitude_accept(self)
+        class(periodic_amplitude_state_t), intent(inout) :: self
+        if (.not. self%initialized) error stop 'cannot accept uninitialized amplitude state'
+        self%accepted = self%trial
+        self%accepted_current_unit = self%trial_current_unit
+        self%accepted_residual = self%trial_residual
+        self%accepted_status = self%trial_status
+        self%accepted_target_current = self%trial_target_current
+        self%accepted_relaxation = self%trial_relaxation
+        self%target_current = self%accepted_target_current
+        self%relaxation = self%accepted_relaxation
+    end subroutine amplitude_accept
+
+    subroutine amplitude_reject(self)
+        class(periodic_amplitude_state_t), intent(inout) :: self
+        if (.not. self%initialized) error stop 'cannot reject uninitialized amplitude state'
+        self%trial = self%accepted
+        self%trial_current_unit = self%accepted_current_unit
+        self%trial_residual = self%accepted_residual
+        self%trial_status = self%accepted_status
+        self%trial_target_current = self%accepted_target_current
+        self%trial_relaxation = self%accepted_relaxation
+        self%target_current = self%accepted_target_current
+        self%relaxation = self%accepted_relaxation
+    end subroutine amplitude_reject
+end module periodic_amplitude_state_m

--- a/QL-Balance/src/base/time_evolution.f90
+++ b/QL-Balance/src/base/time_evolution.f90
@@ -5,6 +5,7 @@ module time_evolution
     use balance_base, only: balance_t
     use QLBalance_kinds, only: dp
     use logger_m, only: log_debug, log_info
+    use periodic_amplitude_state_m, only: periodic_amplitudes
 
     implicit none
 
@@ -155,6 +156,8 @@ module time_evolution
 
         call alloc_Br_Dqle_for_timeevol
         call get_dql
+        call sync_periodic_amplitude_trial()
+        if (periodic_amplitudes%initialized) call periodic_amplitudes%accept()
         call compute_antenna_factor_from_Ipar
         call rescale_transp_coeffs_by_ant_fac
         call hold_prev_transp_coeffs
@@ -191,6 +194,7 @@ module time_evolution
         redostep = .false.
 
         call get_dql
+        call sync_periodic_amplitude_trial()
         call compute_antenna_factor_from_Ipar
         call rescale_transp_coeffs_by_ant_fac
         call interp_Br_Dql_at_resonance_timeevol
@@ -232,6 +236,7 @@ module time_evolution
 
             timstep_arr = timstep_arr * factolred
             params = params_beg
+            call periodic_amplitudes%reject()
 
             call log_debug("Redoing step: Maxval(timscal) > tol * factolmax")
             if (iredo > 100) then
@@ -251,6 +256,7 @@ module time_evolution
         call evolvestep(timstep, eps)
         timstep_arr = timstep
         time = time + timstep
+        if (periodic_amplitudes%initialized) call periodic_amplitudes%accept()
 
         call log_debug("msg_time_info")
         if (.not. suppression_mode) call write_kin_profile_at_time_index
@@ -262,6 +268,29 @@ module time_evolution
 
         call ramp_coil
     end subroutine doStep
+
+    subroutine sync_periodic_amplitude_trial()
+        use kim_wave_code_adapter_m, only: kim_periodic_mode_selected, kim_periodic_scale_modes, &
+            kim_periodic_current_unit, kim_periodic_scale_status, kim_periodic_normalization_relaxation
+        use wave_code_data, only: I_par_toroidal
+        complex(dp), allocatable :: residual(:)
+        integer :: i
+
+        if (kim_periodic_mode_selected() .and. allocated(kim_periodic_scale_modes)) then
+            allocate(residual(size(kim_periodic_scale_modes)))
+            residual = (0.0_dp, 0.0_dp)
+            do i = 1, size(residual)
+                if (allocated(kim_periodic_current_unit)) then
+                    residual(i) = I_par_toroidal * 2.99792458d10 / (2.0_dp*acos(-1.0_dp)) &
+                        - kim_periodic_scale_modes(i) * kim_periodic_current_unit(i)
+                end if
+            end do
+            call periodic_amplitudes%begin_trial(kim_periodic_scale_modes, &
+                kim_periodic_current_unit, residual, kim_periodic_scale_status, &
+                I_par_toroidal, kim_periodic_normalization_relaxation)
+            deallocate(residual)
+        end if
+    end subroutine sync_periodic_amplitude_trial
 
     subroutine allocate_prev_variables
 
@@ -524,8 +553,11 @@ module time_evolution
         use h5mod
         use KAMEL_hdf5_tools
         use wave_code_data, only: Vth
+        use periodic_amplitude_state_m, only: periodic_amplitudes, periodic_normalization_version, &
+            periodic_phase_policy
 
         implicit none
+        real(dp), allocatable :: amp_status(:)
         integer :: ipoi
 
         if (ihdf5IO .eq. 1) then
@@ -578,6 +610,39 @@ module time_evolution
 
             CALL h5_add_float_1(h5_id, trim(h5_currentgrp)//"Vth", &
                                 real(Vth), lbound(Vth), ubound(Vth))
+
+            ! Checkpoint the accepted/trial periodic KIM state alongside the
+            ! profile snapshot.  Real/imaginary parts are used because the
+            ! HDF5 helper has no corresponding complex read interface.
+            if (periodic_amplitudes%initialized) then
+                allocate(amp_status(size(periodic_amplitudes%accepted_status)))
+                amp_status = real(periodic_amplitudes%accepted_status, dp)
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_amplitude_accepted_real", &
+                    real(periodic_amplitudes%accepted), (/1/), (/size(periodic_amplitudes%accepted)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_amplitude_accepted_imag", &
+                    aimag(periodic_amplitudes%accepted), (/1/), (/size(periodic_amplitudes%accepted)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_amplitude_trial_real", &
+                    real(periodic_amplitudes%trial), (/1/), (/size(periodic_amplitudes%trial)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_amplitude_trial_imag", &
+                    aimag(periodic_amplitudes%trial), (/1/), (/size(periodic_amplitudes%trial)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_current_unit_real", &
+                    real(periodic_amplitudes%accepted_current_unit), (/1/), (/size(periodic_amplitudes%accepted_current_unit)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_current_unit_imag", &
+                    aimag(periodic_amplitudes%accepted_current_unit), (/1/), (/size(periodic_amplitudes%accepted_current_unit)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_current_residual_real", &
+                    real(periodic_amplitudes%accepted_residual), (/1/), (/size(periodic_amplitudes%accepted_residual)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_current_residual_imag", &
+                    aimag(periodic_amplitudes%accepted_residual), (/1/), (/size(periodic_amplitudes%accepted_residual)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_scale_status", amp_status, (/1/), (/size(amp_status)/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_target_current", &
+                    [periodic_amplitudes%accepted_target_current], (/1/), (/1/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_normalization_relaxation", &
+                    [periodic_amplitudes%accepted_relaxation], (/1/), (/1/))
+                CALL h5_add_double_1(h5_id, trim(h5_currentgrp)//"periodic_normalization_version", &
+                    [real(periodic_normalization_version, dp)], (/1/), (/1/))
+                CALL h5_add_string(h5_id, trim(h5_currentgrp)//"periodic_phase_policy", periodic_phase_policy)
+                deallocate(amp_status)
+            end if
 
             CALL h5_close(h5_id)
             CALL h5_deinit()

--- a/QL-Balance/src/base/wave_code_data_64bit.f90
+++ b/QL-Balance/src/base/wave_code_data_64bit.f90
@@ -603,17 +603,24 @@ subroutine read_background_profiles_h5_timeevol(tstep)
     use control_mod, only: paramscan
     use baseparam_mod, only: rtor
     use logger_m, only: log_debug, log_info, log_warning
+    use periodic_amplitude_state_m, only: periodic_amplitudes
 
     implicit none;
     integer, intent(in) :: tstep
     double precision, dimension(:), allocatable :: Er_dummy, Vth_dummy
     character(len=1024) :: groupname
-    integer :: lb, ub;
+    integer :: lb, ub, amp_lb, amp_ub, i
+    logical :: amp_exists
+    real(8), allocatable :: amp_acc_real(:), amp_acc_imag(:), amp_trial_real(:), amp_trial_imag(:)
+    real(8), allocatable :: amp_unit_real(:), amp_unit_imag(:), amp_res_real(:), amp_res_imag(:)
+    real(8), allocatable :: amp_status(:), amp_target(:), amp_relax(:)
+    complex(8), allocatable :: amp_acc(:), amp_trial(:), amp_unit(:), amp_res(:)
+    integer, allocatable :: amp_status_int(:)
 
 
     call log_info('Read time evolved background profiles from hdf5 file')
 
-    write (groupname, '(A,I1,A,I1,A,I0,"/")') 'f_', m_vals(1), '_', n_vals(1), '/fort.1000/', &
+    write (groupname, '(A,I1,A,I1,A,I0,"/")') 'f_', m_vals(1), '_', n_vals(1), '/KinProfiles/', &
                                               1000 + tstep
 
     CALL h5_init()
@@ -622,6 +629,13 @@ subroutine read_background_profiles_h5_timeevol(tstep)
     CALL h5_open_rw(path2time, h5_id)
 
     CALL h5_obj_exists(h5_id, trim(groupname), h5_exists_log)
+    if (.not. h5_exists_log) then
+        ! Preserve compatibility with pre-KinProfiles output, while using the
+        ! current writer's group so periodic amplitude checkpoints are found.
+        write (groupname, '(A,I1,A,I1,A,I0,"/")') 'f_', m_vals(1), '_', n_vals(1), '/fort.1000/', &
+                                                  1000 + tstep
+        CALL h5_obj_exists(h5_id, trim(groupname), h5_exists_log)
+    end if
     if (.not. h5_exists_log) then
         call log_warning("group " // trim(groupname) // " does not exist.")
     else
@@ -671,6 +685,41 @@ subroutine read_background_profiles_h5_timeevol(tstep)
     rVth = rn
     rVz = rn
     rep = rn
+
+    ! Restore the periodic KIM response state when it is present in the
+    ! profile checkpoint.  Older files simply take the documented unit-drive
+    ! constant-psi initial state.
+    CALL h5_obj_exists(group_id_1, "periodic_amplitude_accepted_real", amp_exists)
+    if (amp_exists) then
+        CALL h5_get_bounds_1(group_id_1, "periodic_amplitude_accepted_real", amp_lb, amp_ub)
+        allocate(amp_acc_real(amp_ub), amp_acc_imag(amp_ub), amp_trial_real(amp_ub), amp_trial_imag(amp_ub))
+        allocate(amp_unit_real(amp_ub), amp_unit_imag(amp_ub), amp_res_real(amp_ub), amp_res_imag(amp_ub))
+        allocate(amp_status(amp_ub), amp_status_int(amp_ub), amp_target(1), amp_relax(1))
+        CALL h5_get_double_1(group_id_1, "periodic_amplitude_accepted_real", amp_acc_real)
+        CALL h5_get_double_1(group_id_1, "periodic_amplitude_accepted_imag", amp_acc_imag)
+        CALL h5_get_double_1(group_id_1, "periodic_amplitude_trial_real", amp_trial_real)
+        CALL h5_get_double_1(group_id_1, "periodic_amplitude_trial_imag", amp_trial_imag)
+        CALL h5_get_double_1(group_id_1, "periodic_current_unit_real", amp_unit_real)
+        CALL h5_get_double_1(group_id_1, "periodic_current_unit_imag", amp_unit_imag)
+        CALL h5_get_double_1(group_id_1, "periodic_current_residual_real", amp_res_real)
+        CALL h5_get_double_1(group_id_1, "periodic_current_residual_imag", amp_res_imag)
+        CALL h5_get_double_1(group_id_1, "periodic_scale_status", amp_status)
+        CALL h5_get_double_1(group_id_1, "periodic_target_current", amp_target)
+        CALL h5_get_double_1(group_id_1, "periodic_normalization_relaxation", amp_relax)
+        amp_acc = cmplx(amp_acc_real, amp_acc_imag, 8)
+        amp_trial = cmplx(amp_trial_real, amp_trial_imag, 8)
+        amp_unit = cmplx(amp_unit_real, amp_unit_imag, 8)
+        amp_res = cmplx(amp_res_real, amp_res_imag, 8)
+        do i = 1, amp_ub
+            amp_status_int(i) = nint(amp_status(i))
+        end do
+        call periodic_amplitudes%initialize(amp_acc, amp_unit, amp_res, amp_status_int, amp_target(1), amp_relax(1))
+        call periodic_amplitudes%begin_trial(amp_trial, amp_unit, amp_res, amp_status_int, amp_target(1), amp_relax(1))
+        deallocate(amp_acc_real, amp_acc_imag, amp_trial_real, amp_trial_imag, amp_unit_real, amp_unit_imag)
+        deallocate(amp_res_real, amp_res_imag, amp_status, amp_status_int, amp_target, amp_relax)
+        deallocate(amp_acc, amp_trial, amp_unit, amp_res)
+        call log_info('restored periodic KIM amplitudes from time-evolution checkpoint')
+    end if
 
     CALL h5_close_group(group_id_1)
     CALL h5_close(h5_id)

--- a/QL-Balance/src/test/CMakeLists.txt
+++ b/QL-Balance/src/test/CMakeLists.txt
@@ -56,3 +56,7 @@ add_fortran_test(test_periodic_kim_selector)
 add_executable(test_periodic_current_normalization.x test_periodic_current_normalization.f90)
 target_link_libraries(test_periodic_current_normalization.x PUBLIC ql-balance_lib)
 add_fortran_test(test_periodic_current_normalization)
+
+add_executable(test_periodic_amplitude_state.x test_periodic_amplitude_state.f90)
+target_link_libraries(test_periodic_amplitude_state.x PUBLIC ql-balance_lib)
+add_fortran_test(test_periodic_amplitude_state)

--- a/QL-Balance/src/test/test_periodic_amplitude_state.f90
+++ b/QL-Balance/src/test/test_periodic_amplitude_state.f90
@@ -1,0 +1,29 @@
+program test_periodic_amplitude_state
+    use QLBalance_kinds, only: dp
+    use periodic_amplitude_state_m, only: periodic_amplitude_state_t
+    implicit none
+    type(periodic_amplitude_state_t) :: state
+    complex(dp) :: initial(2), trial(2), unit_initial(2), unit_trial(2)
+    complex(dp) :: residual_initial(2), residual_trial(2)
+    integer :: status_initial(2), status_trial(2)
+    initial = [cmplx(1.0_dp,0.0_dp,dp), cmplx(2.0_dp,0.0_dp,dp)]
+    trial = [cmplx(3.0_dp,1.0_dp,dp), cmplx(4.0_dp,-1.0_dp,dp)]
+    unit_initial = [cmplx(5.0_dp,0.0_dp,dp), cmplx(6.0_dp,0.0_dp,dp)]
+    unit_trial = [cmplx(7.0_dp,1.0_dp,dp), cmplx(8.0_dp,-1.0_dp,dp)]
+    residual_initial = [cmplx(0.1_dp,0.2_dp,dp), cmplx(0.3_dp,0.4_dp,dp)]
+    residual_trial = [cmplx(0.5_dp,0.6_dp,dp), cmplx(0.7_dp,0.8_dp,dp)]
+    status_initial = [0, 2]
+    status_trial = [1, 3]
+    call state%initialize(initial, unit_initial, residual_initial, status_initial, 9.0_dp, 0.75_dp)
+    call state%begin_trial(trial, unit_trial, residual_trial, status_trial, 10.0_dp, 0.5_dp)
+    call state%reject()
+    if (maxval(abs(state%trial-initial)) > 1.0e-14_dp) error stop 'amplitude rollback'
+    if (maxval(abs(state%trial_current_unit-unit_initial)) > 1.0e-14_dp) error stop 'current rollback'
+    if (any(state%trial_status /= status_initial)) error stop 'status rollback'
+    if (abs(state%target_current-9.0_dp) > 1.0e-14_dp) error stop 'target metadata'
+    call state%begin_trial(trial)
+    call state%accept()
+    if (maxval(abs(state%accepted-trial)) > 1.0e-14_dp) error stop 'amplitude commit'
+    if (maxval(abs(state%accepted_current_unit-unit_initial)) > 1.0e-14_dp) error stop 'optional metadata'
+    print *, 'periodic amplitude state tests passed'
+end program test_periodic_amplitude_state

--- a/docs/benchmarks/2026-08-12-kim-294-periodic-amplitude-restart.md
+++ b/docs/benchmarks/2026-08-12-kim-294-periodic-amplitude-restart.md
@@ -1,0 +1,51 @@
+# KIM #294 — periodic amplitude evolution and restart
+
+## Contract
+
+Periodic KIM responses are now represented by an accepted/trial state shared by
+QL-Balance's time-evolution driver. The state is per mode and contains:
+
+- the complex shielding amplitude;
+- the complex unit-response current and target-current residual;
+- the normalization guard status;
+- target current, relaxation, phase policy, and normalization-version metadata.
+
+At initialization, the periodic adapter supplies a unit amplitude. This is the
+constant-ψ first-step drive. After each profile state is accepted,
+`get_dql` refreshes KIM with the accepted profiles, integrates the unit local
+parallel current on the trusted core, and evaluates the target-current scale.
+The scale is applied once to the linear fields and currents and as
+`abs(scale)**2` to the ion diffusion tensor before the profile advance.
+
+The trial scale is recorded before the profile update. A successful update
+commits the scale and diagnostics; an error-controlled redo restores the trial
+state from the last accepted state. The next response refresh then uses the
+restored profiles and recomputes the unit response, so no stale shielding
+current is reused.
+
+## Checkpoint and continuation
+
+Each `KinProfiles/<1000+timestep>/` HDF5 profile checkpoint now stores the
+accepted and trial complex amplitudes as real/imaginary datasets, together with
+the unit current, current residual, guard status, target current, relaxation,
+normalization version, and phase policy. The time-evolution reader restores
+these datasets when continuing from a checkpoint; files written by the older
+`fort.1000` layout remain readable (without amplitude state, and therefore use
+the unit-drive default).
+
+The accepted/trial split is deliberately explicit: a failed step cannot alter
+the accepted amplitude or its diagnostics. On restart, the restored accepted
+state is used as the trial baseline and the next KIM solve refreshes the unit
+response against the restarted profiles.
+
+## Validation
+
+The focused test `test_periodic_amplitude_state` covers initialization,
+rollback, and commit of complex mode amplitudes. The implementation was
+compiled with the QL-Balance library and exercised with:
+
+```text
+test_kim_adapter ...................... Passed
+test_periodic_current_normalization ... Passed
+test_periodic_amplitude_state ......... Passed
+```


### PR DESCRIPTION
Closes #294

## What changed
- add per-mode accepted/trial complex periodic shielding state with current, residual, guard-status, target, relaxation, phase-policy, and normalization-version diagnostics
- enforce the documented constant-psi unit drive on the first TimeEvolution response; subsequent refreshes recalculate target-current shielding from the latest accepted profiles
- commit amplitude state only after an accepted profile step and restore trial state on rejected error-controlled steps
- checkpoint accepted/trial amplitudes and normalization diagnostics in KinProfiles HDF5 snapshots and restore them on continuation, with fallback compatibility for the legacy fort.1000 layout
- add focused rollback/commit regression coverage and implementation notes

## Validation
- complete rebuild of configured targets
- `ctest --test-dir build-ql290 --output-on-failure`: 60/60 passed

Stacked on #303.